### PR TITLE
Add invocation-level hooks support

### DIFF
--- a/core/src/main/scala/zio/openfeature/EvaluationOptions.scala
+++ b/core/src/main/scala/zio/openfeature/EvaluationOptions.scala
@@ -1,0 +1,28 @@
+package zio.openfeature
+
+/** Options for flag evaluation, including invocation-level hooks.
+  *
+  * Per the OpenFeature spec, hooks can be registered at multiple levels: API, Client, Invocation, and Provider. This
+  * class provides invocation-level hooks that apply to a single evaluation call.
+  */
+final case class EvaluationOptions(
+  hooks: List[FeatureHook] = Nil,
+  hookHints: HookHints = HookHints.empty
+):
+  def withHook(hook: FeatureHook): EvaluationOptions =
+    copy(hooks = hooks :+ hook)
+
+  def withHooks(newHooks: List[FeatureHook]): EvaluationOptions =
+    copy(hooks = hooks ++ newHooks)
+
+  def withHint(key: String, value: Any): EvaluationOptions =
+    copy(hookHints = hookHints + (key -> value))
+
+object EvaluationOptions:
+  val empty: EvaluationOptions = EvaluationOptions()
+
+  def apply(hook: FeatureHook): EvaluationOptions =
+    EvaluationOptions(hooks = List(hook))
+
+  def apply(hooks: FeatureHook*): EvaluationOptions =
+    EvaluationOptions(hooks = hooks.toList)

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -25,6 +25,38 @@ trait FeatureFlags:
   def doubleDetails(key: String, default: Double): IO[FeatureFlagError, FlagResolution[Double]]
   def valueDetails[A: FlagType](key: String, default: A): IO[FeatureFlagError, FlagResolution[A]]
 
+  // Evaluation with options (invocation-level hooks)
+  def booleanDetails(
+    key: String,
+    default: Boolean,
+    ctx: EvaluationContext,
+    options: EvaluationOptions
+  ): IO[FeatureFlagError, FlagResolution[Boolean]]
+  def stringDetails(
+    key: String,
+    default: String,
+    ctx: EvaluationContext,
+    options: EvaluationOptions
+  ): IO[FeatureFlagError, FlagResolution[String]]
+  def intDetails(
+    key: String,
+    default: Int,
+    ctx: EvaluationContext,
+    options: EvaluationOptions
+  ): IO[FeatureFlagError, FlagResolution[Int]]
+  def doubleDetails(
+    key: String,
+    default: Double,
+    ctx: EvaluationContext,
+    options: EvaluationOptions
+  ): IO[FeatureFlagError, FlagResolution[Double]]
+  def valueDetails[A: FlagType](
+    key: String,
+    default: A,
+    ctx: EvaluationContext,
+    options: EvaluationOptions
+  ): IO[FeatureFlagError, FlagResolution[A]]
+
   def setGlobalContext(ctx: EvaluationContext): UIO[Unit]
   def globalContext: UIO[EvaluationContext]
   def withContext[R, E, A](ctx: EvaluationContext)(zio: ZIO[R, E, A]): ZIO[R, E, A]
@@ -106,6 +138,48 @@ object FeatureFlags:
 
   def valueDetails[A: FlagType](key: String, default: A): ZIO[FeatureFlags, FeatureFlagError, FlagResolution[A]] =
     ZIO.serviceWithZIO(_.valueDetails(key, default))
+
+  // Evaluation with options (invocation-level hooks)
+
+  def booleanDetails(
+    key: String,
+    default: Boolean,
+    ctx: EvaluationContext,
+    options: EvaluationOptions
+  ): ZIO[FeatureFlags, FeatureFlagError, FlagResolution[Boolean]] =
+    ZIO.serviceWithZIO(_.booleanDetails(key, default, ctx, options))
+
+  def stringDetails(
+    key: String,
+    default: String,
+    ctx: EvaluationContext,
+    options: EvaluationOptions
+  ): ZIO[FeatureFlags, FeatureFlagError, FlagResolution[String]] =
+    ZIO.serviceWithZIO(_.stringDetails(key, default, ctx, options))
+
+  def intDetails(
+    key: String,
+    default: Int,
+    ctx: EvaluationContext,
+    options: EvaluationOptions
+  ): ZIO[FeatureFlags, FeatureFlagError, FlagResolution[Int]] =
+    ZIO.serviceWithZIO(_.intDetails(key, default, ctx, options))
+
+  def doubleDetails(
+    key: String,
+    default: Double,
+    ctx: EvaluationContext,
+    options: EvaluationOptions
+  ): ZIO[FeatureFlags, FeatureFlagError, FlagResolution[Double]] =
+    ZIO.serviceWithZIO(_.doubleDetails(key, default, ctx, options))
+
+  def valueDetails[A: FlagType](
+    key: String,
+    default: A,
+    ctx: EvaluationContext,
+    options: EvaluationOptions
+  ): ZIO[FeatureFlags, FeatureFlagError, FlagResolution[A]] =
+    ZIO.serviceWithZIO(_.valueDetails(key, default, ctx, options))
 
   def setGlobalContext(ctx: EvaluationContext): ZIO[FeatureFlags, Nothing, Unit] =
     ZIO.serviceWithZIO(_.setGlobalContext(ctx))


### PR DESCRIPTION
- Add EvaluationOptions case class for per-evaluation hooks and hints
- Add evaluation methods that accept options (booleanDetails, stringDetails, etc)
- Client hooks run before invocation hooks per OpenFeature spec
- Hook hints can be passed to control hook behavior
- Add tests for invocation-level hooks