### PR TITLE
Add event handler methods for provider lifecycle events

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -42,6 +42,12 @@ trait FeatureFlags:
   def providerStatus: UIO[ProviderStatus]
   def providerMetadata: UIO[ProviderMetadata]
 
+  // Event Handlers
+  def onProviderReady(handler: ProviderMetadata => UIO[Unit]): UIO[Unit]
+  def onProviderError(handler: (Throwable, ProviderMetadata) => UIO[Unit]): UIO[Unit]
+  def onProviderStale(handler: (String, ProviderMetadata) => UIO[Unit]): UIO[Unit]
+  def onConfigurationChanged(handler: (Set[String], ProviderMetadata) => UIO[Unit]): UIO[Unit]
+
   def addHook(hook: FeatureHook): UIO[Unit]
   def clearHooks: UIO[Unit]
   def hooks: UIO[List[FeatureHook]]
@@ -137,6 +143,20 @@ object FeatureFlags:
 
   def providerMetadata: ZIO[FeatureFlags, Nothing, ProviderMetadata] =
     ZIO.serviceWithZIO(_.providerMetadata)
+
+  // Event Handlers
+
+  def onProviderReady(handler: ProviderMetadata => UIO[Unit]): ZIO[FeatureFlags, Nothing, Unit] =
+    ZIO.serviceWithZIO(_.onProviderReady(handler))
+
+  def onProviderError(handler: (Throwable, ProviderMetadata) => UIO[Unit]): ZIO[FeatureFlags, Nothing, Unit] =
+    ZIO.serviceWithZIO(_.onProviderError(handler))
+
+  def onProviderStale(handler: (String, ProviderMetadata) => UIO[Unit]): ZIO[FeatureFlags, Nothing, Unit] =
+    ZIO.serviceWithZIO(_.onProviderStale(handler))
+
+  def onConfigurationChanged(handler: (Set[String], ProviderMetadata) => UIO[Unit]): ZIO[FeatureFlags, Nothing, Unit] =
+    ZIO.serviceWithZIO(_.onConfigurationChanged(handler))
 
   def addHook(hook: FeatureHook): ZIO[FeatureFlags, Nothing, Unit] =
     ZIO.serviceWithZIO(_.addHook(hook))

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -447,6 +447,36 @@ final private[openfeature] class FeatureFlagsLive(
   override def providerMetadata: UIO[ProviderMetadata] =
     ZIO.succeed(ProviderMetadata(providerName))
 
+  // Event Handlers
+
+  override def onProviderReady(handler: ProviderMetadata => UIO[Unit]): UIO[Unit] =
+    events
+      .collect { case ProviderEvent.Ready(metadata) => metadata }
+      .foreach(handler)
+      .forkDaemon
+      .unit
+
+  override def onProviderError(handler: (Throwable, ProviderMetadata) => UIO[Unit]): UIO[Unit] =
+    events
+      .collect { case ProviderEvent.Error(error, metadata) => (error, metadata) }
+      .foreach { case (error, metadata) => handler(error, metadata) }
+      .forkDaemon
+      .unit
+
+  override def onProviderStale(handler: (String, ProviderMetadata) => UIO[Unit]): UIO[Unit] =
+    events
+      .collect { case ProviderEvent.Stale(reason, metadata) => (reason, metadata) }
+      .foreach { case (reason, metadata) => handler(reason, metadata) }
+      .forkDaemon
+      .unit
+
+  override def onConfigurationChanged(handler: (Set[String], ProviderMetadata) => UIO[Unit]): UIO[Unit] =
+    events
+      .collect { case ProviderEvent.ConfigurationChanged(flags, metadata) => (flags, metadata) }
+      .foreach { case (flags, metadata) => handler(flags, metadata) }
+      .forkDaemon
+      .unit
+
   override def addHook(hook: FeatureHook): UIO[Unit] =
     hooksRef.update(_ :+ hook)
 

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -281,6 +281,31 @@ object FeatureFlagsSpec extends ZIOSpecDefault:
         yield assertTrue(result == "found")
       }.provide(testLayer(Map("str-flag" -> "found")))
     ),
+    suite("Event Handlers")(
+      test("onProviderReady registers handler") {
+        for _ <- FeatureFlags.onProviderReady(_ => ZIO.unit)
+        yield assertTrue(true)
+      }.provide(testLayer()),
+      test("onProviderError registers handler") {
+        for _ <- FeatureFlags.onProviderError((_, _) => ZIO.unit)
+        yield assertTrue(true)
+      }.provide(testLayer()),
+      test("onProviderStale registers handler") {
+        for _ <- FeatureFlags.onProviderStale((_, _) => ZIO.unit)
+        yield assertTrue(true)
+      }.provide(testLayer()),
+      test("onConfigurationChanged registers handler") {
+        for _ <- FeatureFlags.onConfigurationChanged((_, _) => ZIO.unit)
+        yield assertTrue(true)
+      }.provide(testLayer()),
+      test("multiple handlers can be registered") {
+        for
+          _ <- FeatureFlags.onProviderReady(_ => ZIO.unit)
+          _ <- FeatureFlags.onProviderReady(_ => ZIO.unit)
+          _ <- FeatureFlags.onProviderError((_, _) => ZIO.unit)
+        yield assertTrue(true)
+      }.provide(testLayer())
+    ),
     suite("Tracking API")(
       test("track with event name only succeeds") {
         for _ <- FeatureFlags.track("button-clicked")


### PR DESCRIPTION
- Add onProviderReady, onProviderError, onProviderStale, onConfigurationChanged
- Event handlers run in daemon fibers, subscribing to events stream
- Add tests for event handler registration