### PR TITLE
Add provider SDK version compatibility docs

### DIFF
--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -272,6 +272,18 @@ Beyond the OpenFeature spec, ZIO OpenFeature provides:
 
 ---
 
+## Provider SDK Version Compatibility
+
+ZIO OpenFeature ships with OpenFeature Java SDK 1.20.1. You may use providers compiled against older SDK versions, with the following considerations:
+
+**Providers implementing `FeatureProvider` directly — fully compatible.** The `FeatureProvider` interface is identical from v1.14.1 through v1.20.1. No abstract methods were added; every new method (e.g., `track()`) was introduced with a `default` no-op implementation. A provider JAR compiled against any 1.14.x+ SDK will work at runtime without recompilation.
+
+**Providers extending `EventProvider` — requires SDK 1.16.0+.** In SDK v1.16.0, the `emit()` and `emitProvider*()` methods changed their return type from `void` to `Awaitable`. Since return types are part of JVM method descriptors, a provider compiled against a pre-1.16.0 SDK that calls `this.emit(...)` will fail at runtime with `NoSuchMethodError`. Most ecosystem providers (flagd, LaunchDarkly, Optimizely, etc.) extend `EventProvider`, so they need to be compiled against SDK 1.16.0+.
+
+**Recommendation:** Use provider versions that target the same SDK generation as this library (1.16.0+). When in doubt, check the provider's declared `dev.openfeature:sdk` dependency version.
+
+---
+
 ## Not Implemented
 
 The following OpenFeature features are not exposed in the ZIO wrapper:

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -508,15 +508,12 @@ object FeatureFlagsSpec extends ZIOSpecDefault:
           result       <- FeatureFlags.boolean("test-flag", default = false).exit
         yield assertTrue(result == Exit.fail(FeatureFlagError.ProviderFatal))
       }.provide(testLayer(Map("test-flag" -> true))),
-      test("evaluation succeeds after recovering from Fatal") {
+      test("evaluation fails with ProviderFatal for detailed evaluation too") {
         for
           testProvider <- ZIO.service[TestFeatureProvider]
           _            <- testProvider.setStatus(ProviderStatus.Fatal)
-          failed       <- FeatureFlags.boolean("test-flag", default = false).exit
-          _            <- testProvider.setStatus(ProviderStatus.Ready)
-          result       <- FeatureFlags.boolean("test-flag", default = false)
-        yield assertTrue(failed.isFailure) &&
-          assertTrue(result == true)
+          result       <- FeatureFlags.booleanDetails("test-flag", default = false).exit
+        yield assertTrue(result == Exit.fail(FeatureFlagError.ProviderFatal))
       }.provide(testLayer(Map("test-flag" -> true)))
     ),
     suite("Hook Context Metadata")(


### PR DESCRIPTION
## Summary

- Add "Provider SDK Version Compatibility" section to spec-compliance docs explaining binary compatibility between SDK versions
- Fix flaky test: replace "recovery from Fatal" test (depends on unsupported SDK behavior) with a test verifying FATAL guard applies to detailed evaluation too