### PR TITLE
Fix flaky test in generic on() event handler

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -750,24 +750,21 @@ final private[openfeature] class FeatureFlagsLive(
       .map(fiber => fiber.interrupt.unit)
 
   override def on(eventType: ProviderEventType, handler: ProviderEvent => UIO[Unit]): UIO[UIO[Unit]] =
-    for
-      // Check current status for immediate execution (spec 5.3.3)
-      status <- providerStatus
-      metadata = ProviderMetadata(providerName)
-      _ <- eventType match
-        case ProviderEventType.Ready if status == ProviderStatus.Ready =>
-          handler(ProviderEvent.Ready(metadata))
-        case ProviderEventType.Error if status == ProviderStatus.Error || status == ProviderStatus.Fatal =>
-          handler(ProviderEvent.Error(new RuntimeException("Provider in error state"), metadata))
-        case ProviderEventType.Stale if status == ProviderStatus.Stale =>
-          handler(ProviderEvent.Stale("Provider in stale state", metadata))
-        case _ => ZIO.unit
-      // Subscribe to future events
-      fiber <- events
-        .filter(_.eventType == eventType)
-        .foreach(handler)
-        .forkDaemon
-    yield fiber.interrupt.unit
+    eventType match
+      case ProviderEventType.Ready =>
+        onProviderReady(m => handler(ProviderEvent.Ready(m)))
+      case ProviderEventType.Error =>
+        onProviderError((e, m) => handler(ProviderEvent.Error(e, m)))
+      case ProviderEventType.Stale =>
+        onProviderStale((reason, m) => handler(ProviderEvent.Stale(reason, m)))
+      case ProviderEventType.ConfigurationChanged =>
+        onConfigurationChanged((flags, m) => handler(ProviderEvent.ConfigurationChanged(flags, m)))
+      case ProviderEventType.Reconnecting =>
+        events
+          .filter(_.eventType == ProviderEventType.Reconnecting)
+          .foreach(handler)
+          .forkDaemon
+          .map(fiber => fiber.interrupt.unit)
 
   override def addHook(hook: FeatureHook): UIO[Unit] =
     hooksRef.update(_ :+ hook)


### PR DESCRIPTION
## Summary
- Refactor `on()` in `FeatureFlagsLive` to delegate to specific handler methods (`onProviderReady`, `onProviderError`, `onProviderStale`, `onConfigurationChanged`) instead of duplicating immediate-handler logic with a pattern match guard
- Fixes flaky "generic on method registers handler for event type" test that failed intermittently in CI

## Details
The `on()` method duplicated the status-check-and-immediate-call logic from each specific handler using a pattern match with guards. The specific methods (e.g. `onProviderReady`) use `ZIO.when` and never fail. By delegating to them, `on()` now uses the exact same proven code path, eliminating the subtle timing difference that caused the flaky test.