### PR TITLE
Add evaluation details to finallyAfter hook (#19)

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -76,12 +76,16 @@ final private[openfeature] class FeatureFlagsLive(
     for {
       beforeResult <- composedHook.before(hookCtx, HookHints.empty)
       (effectiveCtx, hints) = beforeResult.getOrElse((context, HookHints.empty))
+      resultRef <- Ref.make[Option[FlagResolution[_]]](None)
       result <- evaluate(effectiveCtx)
+        .tap(res => resultRef.set(Some(res)))
         .tapBoth(
           err => composedHook.error(hookCtx, err, hints),
           res => composedHook.after(hookCtx, res, hints)
         )
-        .ensuring(composedHook.finallyAfter(hookCtx, hints).ignore)
+        .ensuring(
+          resultRef.get.flatMap(details => composedHook.finallyAfter(hookCtx, details, hints)).ignore
+        )
     } yield result
   }
 
@@ -567,12 +571,16 @@ final private[openfeature] class FeatureFlagsLive(
     for {
       beforeResult <- composedHook.before(hookCtx, initialHints)
       (effectiveCtx, hints) = beforeResult.getOrElse((context, initialHints))
+      resultRef <- Ref.make[Option[FlagResolution[_]]](None)
       result <- evaluate(effectiveCtx)
+        .tap(res => resultRef.set(Some(res)))
         .tapBoth(
           err => composedHook.error(hookCtx, err, hints),
           res => composedHook.after(hookCtx, res, hints)
         )
-        .ensuring(composedHook.finallyAfter(hookCtx, hints).ignore)
+        .ensuring(
+          resultRef.get.flatMap(details => composedHook.finallyAfter(hookCtx, details, hints)).ignore
+        )
     } yield result
   }
 

--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -69,7 +69,7 @@ trait FeatureHook {
   def error(ctx: HookContext, error: FeatureFlagError, hints: HookHints): UIO[Unit] =
     ZIO.unit
 
-  def finallyAfter(ctx: HookContext, hints: HookHints): UIO[Unit] =
+  def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
     ZIO.unit
 }
 
@@ -103,8 +103,8 @@ object FeatureHook {
     override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
       ZIO.foreachDiscard(hooks)(hook => hook.error(ctxForHook(ctx, hook), err, hints))
 
-    override def finallyAfter(ctx: HookContext, hints: HookHints): UIO[Unit] =
-      ZIO.foreachDiscard(hooks)(hook => hook.finallyAfter(ctxForHook(ctx, hook), hints))
+    override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
+      ZIO.foreachDiscard(hooks)(hook => hook.finallyAfter(ctxForHook(ctx, hook), details, hints))
   }
 
   def logging(

--- a/core/src/test/scala/zio/openfeature/HookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookSpec.scala
@@ -104,7 +104,7 @@ object HookSpec extends ZIOSpecDefault {
       },
       test("finallyAfter completes successfully") {
         for {
-          _ <- FeatureHook.noop.finallyAfter(makeHookContext(), HookHints.empty)
+          _ <- FeatureHook.noop.finallyAfter(makeHookContext(), None, HookHints.empty)
         } yield assertTrue(true)
       }
     ),
@@ -258,19 +258,19 @@ object HookSpec extends ZIOSpecDefault {
         val callCount = new java.util.concurrent.atomic.AtomicInteger(0)
 
         val hook1 = new FeatureHook {
-          override def finallyAfter(ctx: HookContext, hints: HookHints): UIO[Unit] =
+          override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
             ZIO.succeed(callCount.incrementAndGet())
         }
 
         val hook2 = new FeatureHook {
-          override def finallyAfter(ctx: HookContext, hints: HookHints): UIO[Unit] =
+          override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
             ZIO.succeed(callCount.incrementAndGet())
         }
 
         val composed = FeatureHook.compose(List(hook1, hook2))
 
         for {
-          _ <- composed.finallyAfter(makeHookContext(), HookHints.empty)
+          _ <- composed.finallyAfter(makeHookContext(), None, HookHints.empty)
         } yield assertTrue(callCount.get() == 2)
       },
       test("compose before without modifications returns None") {

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -556,6 +556,55 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         } yield assertTrue(result == Exit.fail(FeatureFlagError.ProviderFatal))
       }.provide(testLayer(Map("test-flag" -> true)))
     ),
+    suite("finallyAfter receives evaluation details (spec 4.3.8)")(
+      test("finallyAfter receives details on success") {
+        val capturedDetails = Unsafe.unsafe { implicit u =>
+          Runtime.default.unsafe.run(Ref.make(Option.empty[FlagResolution[_]])).getOrThrow()
+        }
+
+        val hook = new FeatureHook {
+          override def finallyAfter(
+            ctx: HookContext,
+            details: Option[FlagResolution[_]],
+            hints: HookHints
+          ): UIO[Unit] =
+            capturedDetails.set(details)
+        }
+
+        for {
+          _       <- FeatureFlags.addHook(hook)
+          _       <- FeatureFlags.boolean("test-flag", default = false)
+          details <- capturedDetails.get
+        } yield {
+          val d = details.get
+          assertTrue(details.isDefined) &&
+          assertTrue(d.value == (true: Any)) &&
+          assertTrue(d.flagKey == "test-flag")
+        }
+      }.provide(testLayer(Map("test-flag" -> true))),
+      test("finallyAfter receives None on error") {
+        val capturedDetails = Unsafe.unsafe { implicit u =>
+          Runtime.default.unsafe.run(Ref.make(Option.empty[Option[FlagResolution[_]]])).getOrThrow()
+        }
+
+        val hook = new FeatureHook {
+          override def finallyAfter(
+            ctx: HookContext,
+            details: Option[FlagResolution[_]],
+            hints: HookHints
+          ): UIO[Unit] =
+            capturedDetails.set(Some(details))
+        }
+
+        for {
+          _       <- FeatureFlags.addHook(hook)
+          tp      <- ZIO.service[TestFeatureProvider]
+          _       <- tp.setStatus(ProviderStatus.Fatal)
+          _       <- FeatureFlags.boolean("test-flag", default = false).exit
+          details <- capturedDetails.get
+        } yield assertTrue(details.contains(None))
+      }.provide(testLayer(Map("test-flag" -> true)))
+    ),
     suite("Hook Context Metadata")(
       test("hooks receive clientMetadata during evaluation") {
         val capturedMeta = Unsafe.unsafe { implicit u =>


### PR DESCRIPTION
## Summary

- Add `details: Option[FlagResolution[_]]` parameter to `FeatureHook.finallyAfter` per OpenFeature spec 4.3.8
- Update `compose` to pass details through to individual hooks
- Track evaluation result via `Ref` in `runHookPipeline` and `runHookPipelineWithHints`, passing `Some(result)` on success and `None` on error

## Test plan

- [x] Updated existing `finallyAfter` tests with new signature
- [x] New test: `finallyAfter` receives details on success
- [x] New test: `finallyAfter` receives `None` on error
- [x] All tests pass on Scala 2.13 and 3.3.4

Closes #19