### PR TITLE
Guard evaluation against NOT_READY provider status (#17)

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -90,13 +90,10 @@ final private[openfeature] class FeatureFlagsLive(
   }
 
   private def checkProviderStatus: IO[FeatureFlagError, Unit] =
-    providerStatus.flatMap { status =>
-      status match {
-        case ProviderStatus.Fatal =>
-          ZIO.fail(FeatureFlagError.ProviderFatal)
-        case _ =>
-          ZIO.unit
-      }
+    providerStatus.flatMap {
+      case ProviderStatus.Fatal    => ZIO.fail(FeatureFlagError.ProviderFatal)
+      case ProviderStatus.NotReady => ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.NotReady))
+      case _                       => ZIO.unit
     }
 
   private def evaluateFlag[A: FlagType](

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -605,6 +605,29 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         } yield assertTrue(details.contains(None))
       }.provide(testLayer(Map("test-flag" -> true)))
     ),
+    suite("Provider NotReady Guard (spec 1.7.6)")(
+      test("evaluation fails with ProviderNotReady when provider status is NotReady") {
+        for {
+          testProvider <- ZIO.service[TestFeatureProvider]
+          _            <- testProvider.setStatus(ProviderStatus.NotReady)
+          result       <- FeatureFlags.boolean("test-flag", default = false).exit
+        } yield assertTrue(
+          result == Exit.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.NotReady))
+        )
+      }.provide(testLayer(Map("test-flag" -> true))),
+      test("evaluation succeeds when provider is Ready") {
+        for {
+          result <- FeatureFlags.boolean("test-flag", default = false)
+        } yield assertTrue(result == true)
+      }.provide(testLayer(Map("test-flag" -> true))),
+      test("evaluation succeeds when provider is Stale") {
+        for {
+          testProvider <- ZIO.service[TestFeatureProvider]
+          _            <- testProvider.setStatus(ProviderStatus.Stale)
+          result       <- FeatureFlags.boolean("test-flag", default = false)
+        } yield assertTrue(result == true)
+      }.provide(testLayer(Map("test-flag" -> true)))
+    ),
     suite("Hook Context Metadata")(
       test("hooks receive clientMetadata during evaluation") {
         val capturedMeta = Unsafe.unsafe { implicit u =>


### PR DESCRIPTION
## Summary
- Add `NotReady` case to `checkProviderStatus` to block evaluation when provider is not ready (spec 1.7.6)
- Add test verifying that evaluation fails with `ProviderNotReady` error when status is `NotReady`

## Test plan
- [x] `sbt +compile` passes
- [x] `sbt +test` passes — all existing tests pass plus new test

Closes #17 