### PR TITLE
Bridge Java SDK provider events to ZIO event system (#16)

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -465,19 +465,21 @@ object FeatureFlags {
         eventHub       <- Hub.unbounded[ProviderEvent]
         statusRef      <- Ref.make[ProviderStatus](ProviderStatus.Ready)
         _              <- ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore)
-      } yield new FeatureFlagsLive(
-        client,
-        provider,
-        providerName,
-        None, // default domain
-        globalCtxRef,
-        clientCtxRef,
-        fiberCtxRef,
-        transactionRef,
-        hooksRef,
-        eventHub,
-        statusRef
-      )
+        ff = new FeatureFlagsLive(
+          client,
+          provider,
+          providerName,
+          None, // default domain
+          globalCtxRef,
+          clientCtxRef,
+          fiberCtxRef,
+          transactionRef,
+          hooksRef,
+          eventHub,
+          statusRef
+        )
+        _ <- ff.startEventBridge
+      } yield ff
     }
 
   /** Create a FeatureFlags layer with a named domain/client. */
@@ -513,19 +515,21 @@ object FeatureFlags {
       transactionRef <- FiberRef.make[Option[TransactionState]](None)
       hooksRef       <- Ref.make(List.empty[FeatureHook])
       eventHub       <- Hub.unbounded[ProviderEvent]
-    } yield new FeatureFlagsLive(
-      client,
-      provider,
-      providerName,
-      Some(domain),
-      globalCtxRef,
-      clientCtxRef,
-      fiberCtxRef,
-      transactionRef,
-      hooksRef,
-      eventHub,
-      statusRef
-    )
+      ff = new FeatureFlagsLive(
+        client,
+        provider,
+        providerName,
+        Some(domain),
+        globalCtxRef,
+        clientCtxRef,
+        fiberCtxRef,
+        transactionRef,
+        hooksRef,
+        eventHub,
+        statusRef
+      )
+      _ <- ff.startEventBridge
+    } yield ff
 
   /** Create a FeatureFlags layer from multiple providers using the first-match strategy. */
   def fromMultiProvider(providers: List[OFFeatureProvider]): ZLayer[Scope, Throwable, FeatureFlags] = {
@@ -561,18 +565,20 @@ object FeatureFlags {
         eventHub       <- Hub.unbounded[ProviderEvent]
         statusRef      <- Ref.make[ProviderStatus](ProviderStatus.Ready)
         _              <- ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore)
-      } yield new FeatureFlagsLive(
-        client,
-        provider,
-        providerName,
-        None, // default domain
-        globalCtxRef,
-        clientCtxRef,
-        fiberCtxRef,
-        transactionRef,
-        hooksRef,
-        eventHub,
-        statusRef
-      )
+        ff = new FeatureFlagsLive(
+          client,
+          provider,
+          providerName,
+          None, // default domain
+          globalCtxRef,
+          clientCtxRef,
+          fiberCtxRef,
+          transactionRef,
+          hooksRef,
+          eventHub,
+          statusRef
+        )
+        _ <- ff.startEventBridge
+      } yield ff
     }
 }

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -10,7 +10,9 @@ import dev.openfeature.sdk.{
   Reason => OFReason,
   ErrorCode => OFErrorCode,
   OpenFeatureAPI,
-  MutableTrackingEventDetails
+  MutableTrackingEventDetails,
+  ProviderEvent => JavaProviderEvent,
+  EventDetails
 }
 import scala.jdk.CollectionConverters._
 
@@ -27,6 +29,75 @@ final private[openfeature] class FeatureFlagsLive(
   eventHub: Hub[ProviderEvent],
   statusRef: Ref[ProviderStatus]
 ) extends FeatureFlags {
+
+  // Bridge Java SDK provider events to ZIO event system
+  private[openfeature] def startEventBridge: ZIO[Scope, Nothing, Unit] = {
+    val metadata = ProviderMetadata(providerName)
+
+    val readyHandler: java.util.function.Consumer[EventDetails] = _ =>
+      Unsafe.unsafe { implicit u =>
+        Runtime.default.unsafe
+          .run(
+            statusRef.set(ProviderStatus.Ready) *>
+              eventHub.publish(ProviderEvent.Ready(metadata))
+          )
+          .getOrThrowFiberFailure()
+      }
+
+    val errorHandler: java.util.function.Consumer[EventDetails] = details =>
+      Unsafe.unsafe { implicit u =>
+        val error     = new RuntimeException(Option(details.getMessage).getOrElse("Provider error"))
+        val errorCode = Option(details.getErrorCode).map(toErrorCode)
+        Runtime.default.unsafe
+          .run(
+            statusRef.set(ProviderStatus.Error) *>
+              eventHub.publish(
+                ProviderEvent.Error(error, metadata, errorCode, Option(details.getMessage))
+              )
+          )
+          .getOrThrowFiberFailure()
+      }
+
+    val staleHandler: java.util.function.Consumer[EventDetails] = details =>
+      Unsafe.unsafe { implicit u =>
+        val reason = Option(details.getMessage).getOrElse("Provider stale")
+        Runtime.default.unsafe
+          .run(
+            statusRef.set(ProviderStatus.Stale) *>
+              eventHub.publish(ProviderEvent.Stale(reason, metadata))
+          )
+          .getOrThrowFiberFailure()
+      }
+
+    val configHandler: java.util.function.Consumer[EventDetails] = details =>
+      Unsafe.unsafe { implicit u =>
+        val flags = Option(details.getFlagsChanged)
+          .map(_.asScala.toSet)
+          .getOrElse(Set.empty[String])
+        Runtime.default.unsafe
+          .run(
+            eventHub.publish(ProviderEvent.ConfigurationChanged(flags, metadata))
+          )
+          .getOrThrowFiberFailure()
+      }
+
+    for {
+      _ <- ZIO.succeed {
+        client.on(JavaProviderEvent.PROVIDER_READY, readyHandler)
+        client.on(JavaProviderEvent.PROVIDER_ERROR, errorHandler)
+        client.on(JavaProviderEvent.PROVIDER_STALE, staleHandler)
+        client.on(JavaProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configHandler)
+        ()
+      }
+      _ <- ZIO.addFinalizer(ZIO.attempt {
+        client.removeHandler(JavaProviderEvent.PROVIDER_READY, readyHandler)
+        client.removeHandler(JavaProviderEvent.PROVIDER_ERROR, errorHandler)
+        client.removeHandler(JavaProviderEvent.PROVIDER_STALE, staleHandler)
+        client.removeHandler(JavaProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configHandler)
+        ()
+      }.ignore)
+    } yield ()
+  }
 
   // Context merges in order per OpenFeature spec: API (global) -> Client -> Transaction -> Invocation
   private def effectiveContext(invocation: EvaluationContext): UIO[EvaluationContext] =


### PR DESCRIPTION
## Summary
- Register Java SDK event listeners (`PROVIDER_READY`, `PROVIDER_ERROR`, `PROVIDER_STALE`, `PROVIDER_CONFIGURATION_CHANGED`) that bridge events into the ZIO `eventHub`
- Update `statusRef` when provider state changes
- Add scope finalizer to remove event handlers on cleanup
- Wire up event bridging in all factory methods (`fromProvider`, `buildWithDomain`, `fromProviderWithHooks`)

## Test plan
- [x] `sbt +compile` passes on both Scala 2.13 and 3.3.4
- [x] `sbt +test` passes — all 83 tests pass

Closes #16