### PR TITLE
Reset status and shutdown event hub on shutdown (#18)

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -860,9 +860,11 @@ final private[openfeature] class FeatureFlagsLive(
 
   override def shutdown: UIO[Unit] =
     for {
+      _ <- statusRef.set(ProviderStatus.NotReady)
       _ <- hooksRef.set(List.empty)
       _ <- globalContextRef.set(EvaluationContext.empty)
       _ <- clientContextRef.set(EvaluationContext.empty)
+      _ <- eventHub.shutdown
       _ <- ZIO.attemptBlocking(OpenFeatureAPI.getInstance().shutdown()).ignore
     } yield ()
 


### PR DESCRIPTION
## Summary
- Set `statusRef` to `NotReady` during shutdown
- Call `eventHub.shutdown` to terminate all event stream subscribers
- Prevents stale event delivery after provider shutdown

## Test plan
- [x] `sbt +compile` passes on both Scala 2.13 and 3.3.4
- [x] `sbt +test` passes — all tests pass

Closes #18