### PR TITLE
Update docs for spec compliance fixes (#16-#20)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,7 +201,7 @@ Hooks execute around flag evaluation in four stages: **before**, **after**, **er
 | **before** | Before evaluation | Modify context, start timers, validate |
 | **after** | On successful evaluation | Log results, record metrics |
 | **error** | On evaluation failure | Log errors, alert, fallback logic |
-| **finallyAfter** | Always (like try-finally) | Cleanup, span completion |
+| **finallyAfter** | Always (like try-finally) | Cleanup, span completion. Receives `Option[FlagResolution[_]]` with evaluation details (spec 4.3.8) |
 
 See [Hooks]({{ site.baseurl }}/hooks) for the complete hook lifecycle, built-in hooks, and custom hook examples.
 
@@ -237,10 +237,11 @@ The OpenFeature SDK manages provider lifecycle. ZIO OpenFeature adds scoped reso
 
 | State | Description |
 |:------|:------------|
-| `NotReady` | Provider not initialized |
+| `NotReady` | Provider not initialized. Evaluations fail with `ProviderNotReady` |
 | `Ready` | Can evaluate flags |
 | `Error` | Provider encountered recoverable error |
 | `Stale` | Provider data may be outdated |
+| `Fatal` | Provider encountered unrecoverable error. Evaluations fail with `ProviderFatal` |
 
 Provider events (`Ready`, `ConfigurationChanged`, `Stale`, `Error`) can be observed via `FeatureFlags.events` stream or specific handlers like `onProviderReady`.
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -131,7 +131,7 @@ val customHook = new FeatureHook:
   override def error(ctx: HookContext, error: FeatureFlagError, hints: HookHints): UIO[Unit] =
     ZIO.logError(s"Error evaluating ${ctx.flagKey}: ${error.message}")
 
-  override def finallyAfter(ctx: HookContext, hints: HookHints): UIO[Unit] =
+  override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
     ZIO.unit
 ```
 
@@ -169,7 +169,7 @@ val spanHook = new FeatureHook:
       recordSpan(spanId, details)
     }
 
-  override def finallyAfter(ctx: HookContext, hints: HookHints): UIO[Unit] =
+  override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
     ZIO.succeed {
       ctx.hookData.clear()
     }
@@ -201,7 +201,7 @@ val timingHook = new FeatureHook:
   override def error(ctx: HookContext, error: FeatureFlagError, hints: HookHints): UIO[Unit] =
     ZIO.unit
 
-  override def finallyAfter(ctx: HookContext, hints: HookHints): UIO[Unit] =
+  override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
     ZIO.unit
 ```
 
@@ -237,7 +237,7 @@ For the `before` stage, hooks run in order. For `after`, `error`, and `finallyAf
 
 ## Hook Registration Levels
 
-Per the OpenFeature specification, hooks can be registered at three levels:
+Per the OpenFeature specification, hooks can be registered at four levels:
 
 ### API-Level Hooks
 
@@ -299,13 +299,17 @@ val options = EvaluationOptions(
 FeatureFlags.booleanDetails("feature", false, EvaluationContext.empty, options)
 ```
 
+### Provider-Level Hooks
+
+Provider hooks are automatically retrieved from the underlying provider via `provider.getProviderHooks()` and included in the hook pipeline. You don't need to register them manually.
+
 ### Hook Execution Order
 
 Per OpenFeature spec, hooks execute in this order:
 
-**Before stage:** API → Client → Invocation (in addition order within each level)
+**Before stage:** API → Client → Invocation → Provider (in addition order within each level)
 
-**After/Error/Finally stages:** Invocation → Client → API (reverse order)
+**After/Error/Finally stages:** Provider → Invocation → Client → API (reverse order)
 
 ---
 
@@ -329,7 +333,7 @@ val auditHook = new FeatureHook:
   override def error(ctx: HookContext, error: FeatureFlagError, hints: HookHints): UIO[Unit] =
     ZIO.logError(s"AUDIT: Flag evaluation failed: ${error.message}")
 
-  override def finallyAfter(ctx: HookContext, hints: HookHints): UIO[Unit] =
+  override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
     ZIO.unit
 ```
 
@@ -366,7 +370,7 @@ val enrichmentHook = new FeatureHook:
   override def error(ctx: HookContext, error: FeatureFlagError, hints: HookHints): UIO[Unit] =
     ZIO.unit
 
-  override def finallyAfter(ctx: HookContext, hints: HookHints): UIO[Unit] =
+  override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
     ZIO.unit
 ```
 
@@ -389,7 +393,7 @@ val alertingHook = new FeatureHook:
       details = Map("error" -> error.message)
     ).ignore
 
-  override def finallyAfter(ctx: HookContext, hints: HookHints): UIO[Unit] =
+  override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
     ZIO.unit
 ```
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -341,7 +341,7 @@ program.provide(Scope.default >>> FeatureFlags.fromProvider(provider))
 
 ### Shutdown
 
-When the scope ends, the OpenFeature API is automatically shut down:
+When the scope ends, the OpenFeature API is automatically shut down. Shutdown resets the provider status to `NotReady`, clears hooks and contexts, shuts down the event hub (terminating all event stream subscribers), and calls the SDK's shutdown:
 
 ```scala
 ZIO.scoped {
@@ -351,6 +351,9 @@ ZIO.scoped {
   yield ()
 }
 // Provider shutdown automatically on scope exit
+
+// Explicit shutdown is also available
+FeatureFlags.shutdown
 ```
 
 ### Provider Status
@@ -381,7 +384,9 @@ yield ()
 
 ## Provider Events
 
-ZIO OpenFeature provides two ways to handle provider events: event handlers and event streams.
+Java SDK provider events are automatically bridged to the ZIO event system. When a provider emits events (Ready, Error, Stale, ConfigurationChanged), they are captured via Java SDK event listeners and published to the ZIO event hub. The provider status is also kept in sync automatically. Event bridge handlers are registered during layer creation and cleaned up when the scope ends.
+
+ZIO OpenFeature provides two ways to consume provider events: event handlers and event streams.
 
 ### Event Handlers
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -126,7 +126,8 @@ FeatureFlags.booleanDetails("flag", false, context, options)
 | API-level hooks | ✅ | `FeatureFlags.addApiHook` / `clearApiHooks` |
 | Client-level hooks | ✅ | `FeatureFlags.addHook` / `clearHooks` |
 | Invocation-level hooks | ✅ | Via `EvaluationOptions` |
-| Execution order | ✅ | API → Client → Invocation (reversed for after/error/finally) |
+| Provider-level hooks | ✅ | Automatically included from `provider.getProviderHooks()` |
+| Execution order | ✅ | API → Client → Invocation → Provider (reversed for after/error/finally) |
 
 ### Invocation-Level Hooks Example
 
@@ -173,7 +174,7 @@ for
 yield ()
 ```
 
-When a provider enters the `Fatal` state, all flag evaluations will fail with `FeatureFlagError.ProviderFatal`.
+When a provider is in the `NotReady` state, all flag evaluations will fail with `FeatureFlagError.ProviderNotReady`. When a provider enters the `Fatal` state, all flag evaluations will fail with `FeatureFlagError.ProviderFatal`.
 
 ---
 
@@ -290,6 +291,5 @@ The following OpenFeature features are not exposed in the ZIO wrapper:
 
 | Feature | Reason |
 |:--------|:-------|
-| Provider-level hooks | Handled internally by OpenFeature SDK |
 | Context change reconciliation | Provider-specific, handled by SDK |
 | Static-context paradigm | Use standard context hierarchy instead |


### PR DESCRIPTION
## Summary

- Update `finallyAfter` signature in all hook examples to include `details: Option[FlagResolution[_]]` parameter (spec 4.3.8)
- Add provider-level hooks to hook execution order and registration docs
- Update spec-compliance.md: mark provider hooks as implemented, add NotReady evaluation guard
- Update providers.md: document event bridging, expanded shutdown behavior
- Update architecture.md: add Fatal state to lifecycle table, note finallyAfter receives details