### PR TITLE
Add dependency vulnerability scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run tests (Scala 2.13 + 3)
         run: sbt +test
+
+      - name: Dependency vulnerability check
+        run: sbt dependencyCheck

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,18 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - uses: scalacenter/sbt-dependency-submission@v3

--- a/build.sbt
+++ b/build.sbt
@@ -91,8 +91,9 @@ lazy val commonSettings = Seq(
 lazy val root = (project in file("."))
   .aggregate(core, testkit)
   .settings(
-    name           := "zio-openfeature",
-    publish / skip := true
+    name                         := "zio-openfeature",
+    publish / skip               := true,
+    dependencyCheckFailBuildOnCVSS := 7
   )
 
 // Core module - ZIO wrapper around OpenFeature SDK

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.5.4")
-addSbtPlugin("org.scoverage"  % "sbt-scoverage"  % "2.0.9")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.2")
+addSbtPlugin("org.scalameta"      % "sbt-scalafmt"         % "2.5.4")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"        % "2.0.9")
+addSbtPlugin("com.github.sbt"     % "sbt-ci-release"       % "1.9.2")
+addSbtPlugin("net.vonbuchholtz"   % "sbt-dependency-check" % "5.0.0")


### PR DESCRIPTION
## Summary

- Add **sbt-dependency-check** (OWASP) plugin to fail builds on CVEs with CVSS >= 7 (High+)
- Add vulnerability check step to CI workflow
- Add **dependency-submission** workflow to enable Dependabot alerts and auto-update PRs

## Test plan

- [ ] `sbt dependencyCheck` runs locally and produces report
- [ ] CI runs the vulnerability check step on PRs
- [ ] After merge, dependency-submission workflow populates GitHub Security tab