### PR TITLE
Move OWASP dependency check to scheduled workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,3 @@ jobs:
 
       - name: Run tests (Scala 2.13 + 3)
         run: sbt +test
-
-      - name: Dependency vulnerability check
-        if: env.NVD_API_KEY != ''
-        run: sbt dependencyCheck
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,32 @@
+name: Dependency Check
+
+on:
+  schedule:
+    - cron: '0 8 * * 1' # every Monday at 8am UTC
+  workflow_dispatch:
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: sbt/setup-sbt@v1
+
+      - name: Cache NVD database
+        uses: actions/cache@v4
+        with:
+          path: ~/.dependency-check
+          key: nvd-db-${{ github.run_id }}
+          restore-keys: nvd-db-
+
+      - name: OWASP dependency check
+        run: sbt dependencyCheck
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,8 @@ lazy val root = (project in file("."))
     name                           := "zio-openfeature",
     publish / skip                 := true,
     dependencyCheckFailBuildOnCVSS := 7,
-    dependencyCheckNvdApi          := NvdApiSettings(apiKey = sys.env.getOrElse("NVD_API_KEY", ""))
+    dependencyCheckNvdApi          := NvdApiSettings(apiKey = sys.env.getOrElse("NVD_API_KEY", "")),
+    dependencyCheckDataDirectory   := Some(new File(Path.userHome.absolutePath, ".dependency-check/data"))
   )
 
 // Core module - ZIO wrapper around OpenFeature SDK


### PR DESCRIPTION
## Summary

- Move OWASP dependency check from CI to a dedicated weekly scheduled workflow with NVD database caching
- The initial NVD database build causes a connection pool NPE in CI due to a known concurrency bug in dependency-check during first-time full database creation
- Scheduled workflow runs weekly (Monday 8am UTC) and on manual trigger, with `actions/cache` for the NVD database
- CI remains fast and clean — Dependabot (via dependency-submission workflow) handles real-time vulnerability alerts on PRs

## Test plan

- [ ] CI passes without the dependency check step
- [ ] Trigger dependency-check workflow manually via Actions tab
- [ ] NVD database gets cached after first successful run