### PR TITLE
Increase JVM heap for dependency check

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -27,6 +27,6 @@ jobs:
           restore-keys: nvd-db-
 
       - name: OWASP dependency check
-        run: sbt dependencyCheck
+        run: sbt -J-Xmx4g -J-Xss2m dependencyCheck
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}


### PR DESCRIPTION
## Summary

- Increase JVM heap to 4GB for the dependency check workflow to handle the initial NVD database build (~280k CVEs)
- The default heap was insufficient, causing the H2 connection pool to crash with NPEs during the first full download

## Test plan

- [ ] Trigger dependency-check workflow manually and verify it completes