### PR TITLE
Use OWASP Dependency-Check Action for CI scanning

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -19,14 +19,26 @@ jobs:
 
       - uses: sbt/setup-sbt@v1
 
-      - name: Cache NVD database
-        uses: actions/cache@v4
-        with:
-          path: ~/.dependency-check
-          key: nvd-db-${{ github.run_id }}
-          restore-keys: nvd-db-
+      - name: Generate dependency list
+        run: |
+          sbt 'show core/managedClasspath' 'show testkit/managedClasspath' \
+            | grep -oP '/.+?\.jar' | sort -u > /tmp/dep-jars.txt
+          mkdir -p /tmp/deps
+          while read jar; do cp "$jar" /tmp/deps/ 2>/dev/null; done < /tmp/dep-jars.txt
 
       - name: OWASP dependency check
-        run: sbt -J-Xmx4g -J-Xss2m dependencyCheck
-        env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        uses: dependency-check/Dependency-Check_Action@main
+        with:
+          project: zio-openfeature
+          path: /tmp/deps
+          format: HTML
+          args: >-
+            --nvdApiKey ${{ secrets.NVD_API_KEY }}
+            --failOnCVSS 7
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: reports/


### PR DESCRIPTION
## Summary

- Replace sbt-dependency-check plugin with the official OWASP Dependency-Check GitHub Action for CI scanning
- The sbt plugin has a known concurrency bug in its embedded H2 database that crashes on initial NVD download
- The GitHub Action manages its own database properly and handles cold starts reliably
- Exports sbt dependencies as JARs and scans them with the action
- Generates HTML report uploaded as a workflow artifact
- sbt plugin remains available for local use

## Test plan

- [ ] Trigger dependency-check workflow manually and verify it completes
- [ ] Check uploaded artifact contains the HTML report