### PR TITLE
Add self-contained testFeatureFlagsLayer helpers

### DIFF
--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -278,4 +278,12 @@ object TestFeatureProvider {
     val domain = s"test-${java.util.UUID.randomUUID()}"
     FeatureFlags.fromProviderWithDomain(provider, domain, provider.statusRef)
   }
+
+  /** Self-contained test layer that provides its own Scope. */
+  val testFeatureFlagsLayer: ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
+    Scope.default >>> TestFeatureProvider.layer
+
+  /** Self-contained test layer with initial flags that provides its own Scope. */
+  def testFeatureFlagsLayer(flags: Map[String, Any]): ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
+    Scope.default >>> TestFeatureProvider.layer(flags)
 }


### PR DESCRIPTION
## Summary
- Add `testFeatureFlagsLayer` val and method to `TestFeatureProvider` companion object
- These helpers compose `Scope.default` with `TestFeatureProvider.layer`, so callers don't need to provide a `Scope` dependency

## Test plan
- [x] `sbt testkit/compile` passes
- [x] Pre-push hook passes (scalafmt check + tests)