### PR TITLE
Rename testFeatureFlagsLayer to scopedLayer

### DIFF
--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -280,10 +280,10 @@ object TestFeatureProvider {
   }
 
   /** Self-contained test layer that provides its own Scope. */
-  val testFeatureFlagsLayer: ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
+  val scopedLayer: ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
     Scope.default >>> TestFeatureProvider.layer
 
   /** Self-contained test layer with initial flags that provides its own Scope. */
-  def testFeatureFlagsLayer(flags: Map[String, Any]): ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
+  def scopedLayer(flags: Map[String, Any]): ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
     Scope.default >>> TestFeatureProvider.layer(flags)
 }


### PR DESCRIPTION
## Summary
- Rename `testFeatureFlagsLayer` to `scopedLayer` to better reflect that it bundles its own `Scope`
- Distinguishes it clearly from the existing `layer` method which requires a `Scope` dependency

## Test plan
- [x] `sbt testkit/compile` passes
- [x] Pre-push hook passes (scalafmt check + tests)