### PR TITLE
Consolidate error code conversions into ErrorCodeConverter

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -2,7 +2,7 @@ package zio.openfeature
 
 import zio._
 import zio.stream._
-import zio.openfeature.internal.ContextConverter
+import zio.openfeature.internal.{ContextConverter, ErrorCodeConverter}
 import dev.openfeature.sdk.{
   Client => OFClient,
   FeatureProvider => OFFeatureProvider,
@@ -49,7 +49,7 @@ final private[openfeature] class FeatureFlagsLive(
     val errorHandler: java.util.function.Consumer[EventDetails] = details =>
       Unsafe.unsafe { implicit u =>
         val error     = new RuntimeException(Option(details.getMessage).getOrElse("Provider error"))
-        val errorCode = Option(details.getErrorCode).map(toErrorCode)
+        val errorCode = Option(details.getErrorCode).map(ErrorCodeConverter.fromJava)
         Runtime.default.unsafe
           .run(
             statusRef.set(ProviderStatus.Error) *>
@@ -326,7 +326,7 @@ final private[openfeature] class FeatureFlagsLive(
               reason = toResolutionReason(details.getReason),
               metadata = toFlagMetadata(details.getFlagMetadata),
               flagKey = key,
-              errorCode = Option(details.getErrorCode).map(toErrorCode),
+              errorCode = Option(details.getErrorCode).map(ErrorCodeConverter.fromJava),
               errorMessage = Option(details.getErrorMessage)
             )
           }
@@ -349,7 +349,7 @@ final private[openfeature] class FeatureFlagsLive(
                     reason = toResolutionReason(details.getReason),
                     metadata = toFlagMetadata(details.getFlagMetadata),
                     flagKey = key,
-                    errorCode = Option(details.getErrorCode).map(toErrorCode),
+                    errorCode = Option(details.getErrorCode).map(ErrorCodeConverter.fromJava),
                     errorMessage = Option(details.getErrorMessage)
                   )
                 )
@@ -380,7 +380,7 @@ final private[openfeature] class FeatureFlagsLive(
       reason = toResolutionReason(details.getReason),
       metadata = toFlagMetadata(details.getFlagMetadata),
       flagKey = key,
-      errorCode = Option(details.getErrorCode).map(toErrorCode),
+      errorCode = Option(details.getErrorCode).map(ErrorCodeConverter.fromJava),
       errorMessage = Option(details.getErrorMessage)
     )
 
@@ -398,18 +398,6 @@ final private[openfeature] class FeatureFlagsLive(
         case "ERROR"           => ResolutionReason.Error
         case _                 => ResolutionReason.Unknown
       }
-
-  private def toErrorCode(errorCode: OFErrorCode): ErrorCode =
-    errorCode match {
-      case OFErrorCode.PROVIDER_NOT_READY    => ErrorCode.ProviderNotReady
-      case OFErrorCode.PROVIDER_FATAL        => ErrorCode.ProviderFatal
-      case OFErrorCode.FLAG_NOT_FOUND        => ErrorCode.FlagNotFound
-      case OFErrorCode.PARSE_ERROR           => ErrorCode.ParseError
-      case OFErrorCode.TYPE_MISMATCH         => ErrorCode.TypeMismatch
-      case OFErrorCode.TARGETING_KEY_MISSING => ErrorCode.TargetingKeyMissing
-      case OFErrorCode.INVALID_CONTEXT       => ErrorCode.InvalidContext
-      case OFErrorCode.GENERAL               => ErrorCode.General
-    }
 
   private def toFlagMetadata(metadata: dev.openfeature.sdk.ImmutableMetadata): FlagMetadata =
     if (metadata == null || metadata.isEmpty) FlagMetadata.empty
@@ -910,20 +898,9 @@ final private[openfeature] class FeatureFlagsLive(
     details.setValue(res.value)
     res.variant.foreach(details.setVariant)
     details.setReason(res.reason.toString)
-    res.errorCode.foreach(ec => details.setErrorCode(toJavaErrorCode(ec)))
+    res.errorCode.foreach(ec => details.setErrorCode(ErrorCodeConverter.toJava(ec)))
     res.errorMessage.foreach(details.setErrorMessage)
     details
-  }
-
-  private def toJavaErrorCode(ec: ErrorCode): OFErrorCode = ec match {
-    case ErrorCode.ProviderNotReady    => OFErrorCode.PROVIDER_NOT_READY
-    case ErrorCode.ProviderFatal       => OFErrorCode.PROVIDER_FATAL
-    case ErrorCode.FlagNotFound        => OFErrorCode.FLAG_NOT_FOUND
-    case ErrorCode.ParseError          => OFErrorCode.PARSE_ERROR
-    case ErrorCode.TypeMismatch        => OFErrorCode.TYPE_MISMATCH
-    case ErrorCode.TargetingKeyMissing => OFErrorCode.TARGETING_KEY_MISSING
-    case ErrorCode.InvalidContext      => OFErrorCode.INVALID_CONTEXT
-    case ErrorCode.General             => OFErrorCode.GENERAL
   }
 
   private def fromJavaEvaluationContext(ctx: dev.openfeature.sdk.EvaluationContext): EvaluationContext =

--- a/core/src/main/scala/zio/openfeature/internal/ErrorCodeConverter.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ErrorCodeConverter.scala
@@ -1,0 +1,31 @@
+package zio.openfeature.internal
+
+import zio.openfeature.ErrorCode
+import dev.openfeature.sdk.{ErrorCode => OFErrorCode}
+
+private[openfeature] object ErrorCodeConverter {
+
+  def fromJava(errorCode: OFErrorCode): ErrorCode =
+    errorCode match {
+      case OFErrorCode.PROVIDER_NOT_READY    => ErrorCode.ProviderNotReady
+      case OFErrorCode.PROVIDER_FATAL        => ErrorCode.ProviderFatal
+      case OFErrorCode.FLAG_NOT_FOUND        => ErrorCode.FlagNotFound
+      case OFErrorCode.PARSE_ERROR           => ErrorCode.ParseError
+      case OFErrorCode.TYPE_MISMATCH         => ErrorCode.TypeMismatch
+      case OFErrorCode.TARGETING_KEY_MISSING => ErrorCode.TargetingKeyMissing
+      case OFErrorCode.INVALID_CONTEXT       => ErrorCode.InvalidContext
+      case OFErrorCode.GENERAL               => ErrorCode.General
+    }
+
+  def toJava(errorCode: ErrorCode): OFErrorCode =
+    errorCode match {
+      case ErrorCode.ProviderNotReady    => OFErrorCode.PROVIDER_NOT_READY
+      case ErrorCode.ProviderFatal       => OFErrorCode.PROVIDER_FATAL
+      case ErrorCode.FlagNotFound        => OFErrorCode.FLAG_NOT_FOUND
+      case ErrorCode.ParseError          => OFErrorCode.PARSE_ERROR
+      case ErrorCode.TypeMismatch        => OFErrorCode.TYPE_MISMATCH
+      case ErrorCode.TargetingKeyMissing => OFErrorCode.TARGETING_KEY_MISSING
+      case ErrorCode.InvalidContext      => OFErrorCode.INVALID_CONTEXT
+      case ErrorCode.General             => OFErrorCode.GENERAL
+    }
+}

--- a/core/src/test/scala/zio/openfeature/ErrorCodeConverterSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ErrorCodeConverterSpec.scala
@@ -1,0 +1,49 @@
+package zio.openfeature
+
+import zio.test._
+import dev.openfeature.sdk.{ErrorCode => OFErrorCode}
+import zio.openfeature.internal.ErrorCodeConverter
+
+object ErrorCodeConverterSpec extends ZIOSpecDefault {
+  def spec = suite("ErrorCodeConverter")(
+    suite("fromJava")(
+      test("converts all Java SDK error codes") {
+        assertTrue(ErrorCodeConverter.fromJava(OFErrorCode.PROVIDER_NOT_READY) == ErrorCode.ProviderNotReady) &&
+        assertTrue(ErrorCodeConverter.fromJava(OFErrorCode.PROVIDER_FATAL) == ErrorCode.ProviderFatal) &&
+        assertTrue(ErrorCodeConverter.fromJava(OFErrorCode.FLAG_NOT_FOUND) == ErrorCode.FlagNotFound) &&
+        assertTrue(ErrorCodeConverter.fromJava(OFErrorCode.PARSE_ERROR) == ErrorCode.ParseError) &&
+        assertTrue(ErrorCodeConverter.fromJava(OFErrorCode.TYPE_MISMATCH) == ErrorCode.TypeMismatch) &&
+        assertTrue(ErrorCodeConverter.fromJava(OFErrorCode.TARGETING_KEY_MISSING) == ErrorCode.TargetingKeyMissing) &&
+        assertTrue(ErrorCodeConverter.fromJava(OFErrorCode.INVALID_CONTEXT) == ErrorCode.InvalidContext) &&
+        assertTrue(ErrorCodeConverter.fromJava(OFErrorCode.GENERAL) == ErrorCode.General)
+      }
+    ),
+    suite("toJava")(
+      test("converts all ZIO error codes") {
+        assertTrue(ErrorCodeConverter.toJava(ErrorCode.ProviderNotReady) == OFErrorCode.PROVIDER_NOT_READY) &&
+        assertTrue(ErrorCodeConverter.toJava(ErrorCode.ProviderFatal) == OFErrorCode.PROVIDER_FATAL) &&
+        assertTrue(ErrorCodeConverter.toJava(ErrorCode.FlagNotFound) == OFErrorCode.FLAG_NOT_FOUND) &&
+        assertTrue(ErrorCodeConverter.toJava(ErrorCode.ParseError) == OFErrorCode.PARSE_ERROR) &&
+        assertTrue(ErrorCodeConverter.toJava(ErrorCode.TypeMismatch) == OFErrorCode.TYPE_MISMATCH) &&
+        assertTrue(ErrorCodeConverter.toJava(ErrorCode.TargetingKeyMissing) == OFErrorCode.TARGETING_KEY_MISSING) &&
+        assertTrue(ErrorCodeConverter.toJava(ErrorCode.InvalidContext) == OFErrorCode.INVALID_CONTEXT) &&
+        assertTrue(ErrorCodeConverter.toJava(ErrorCode.General) == OFErrorCode.GENERAL)
+      }
+    ),
+    suite("round-trip")(
+      test("fromJava and toJava are inverses") {
+        val javaCodes = List(
+          OFErrorCode.PROVIDER_NOT_READY,
+          OFErrorCode.PROVIDER_FATAL,
+          OFErrorCode.FLAG_NOT_FOUND,
+          OFErrorCode.PARSE_ERROR,
+          OFErrorCode.TYPE_MISMATCH,
+          OFErrorCode.TARGETING_KEY_MISSING,
+          OFErrorCode.INVALID_CONTEXT,
+          OFErrorCode.GENERAL
+        )
+        assertTrue(javaCodes.forall(code => ErrorCodeConverter.toJava(ErrorCodeConverter.fromJava(code)) == code))
+      }
+    )
+  )
+}


### PR DESCRIPTION
## Summary
- Create `internal.ErrorCodeConverter` with bidirectional `fromJava`/`toJava` methods
- Remove duplicate `toErrorCode` and `toJavaErrorCode` private methods from `FeatureFlagsLive`
- Add unit tests for all conversions and round-trip property