### PR TITLE
Simplify FlagValueType.name to use toString in Scala 3

### DIFF
--- a/core/src/main/scala-3/zio/openfeature/FlagValueType.scala
+++ b/core/src/main/scala-3/zio/openfeature/FlagValueType.scala
@@ -7,12 +7,7 @@ enum FlagValueType:
   case Double
   case Object
 
-  def name: String = this match
-    case Boolean => "Boolean"
-    case String  => "String"
-    case Int     => "Int"
-    case Double  => "Double"
-    case Object  => "Object"
+  def name: String = toString
 
 object FlagValueType:
   def fromFlagType[A](using ft: FlagType[A]): FlagValueType =


### PR DESCRIPTION
## Summary
- Replace manual pattern match in `FlagValueType.name` with delegation to `toString` for Scala 3 enum
- Scala 2 version left unchanged (sealed trait needs manual `name` method)