### PR TITLE
Extract ClientEvaluator typeclass for type-safe flag dispatch

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -2,7 +2,7 @@ package zio.openfeature
 
 import zio._
 import zio.stream._
-import zio.openfeature.internal.ContextConverter
+import zio.openfeature.internal.{ClientEvaluator, ContextConverter}
 import dev.openfeature.sdk.{
   Client => OFClient,
   FeatureProvider => OFFeatureProvider,
@@ -249,65 +249,17 @@ final private[openfeature] class FeatureFlagsLive(
     val flagType  = FlagType[A]
     val ofContext = ContextConverter.toOpenFeature(context)
 
-    val evaluation: IO[FeatureFlagError, FlagResolution[A]] = flagType.typeName match {
-      case "Boolean" =>
-        ZIO
-          .attemptBlocking {
-            client.getBooleanDetails(key, default.asInstanceOf[Boolean], ofContext)
-          }
-          .mapError(e => FeatureFlagError.ProviderError(e))
-          .map(details => toFlagResolution(key, details).asInstanceOf[FlagResolution[A]])
-
-      case "String" =>
-        ZIO
-          .attemptBlocking {
-            client.getStringDetails(key, default.asInstanceOf[String], ofContext)
-          }
-          .mapError(e => FeatureFlagError.ProviderError(e))
-          .map(details => toFlagResolution(key, details).asInstanceOf[FlagResolution[A]])
-
-      case "Int" =>
-        ZIO
-          .attemptBlocking {
-            client.getIntegerDetails(key, Integer.valueOf(default.asInstanceOf[Int]), ofContext)
-          }
+    val evaluation: IO[FeatureFlagError, FlagResolution[A]] = ClientEvaluator.forType(flagType) match {
+      case Some(evaluator) =>
+        evaluator
+          .evaluate(client, key, default, ofContext)
           .mapError(e => FeatureFlagError.ProviderError(e))
           .map { details =>
-            val resolution = toFlagResolution(key, details)
-            resolution.copy(value = details.getValue.intValue()).asInstanceOf[FlagResolution[A]]
+            val base = toFlagResolution(key, details)
+            base.copy(value = evaluator.extractValue(details))
           }
 
-      case "Long" =>
-        ZIO
-          .attemptBlocking {
-            client.getIntegerDetails(key, Integer.valueOf(default.asInstanceOf[Long].toInt), ofContext)
-          }
-          .mapError(e => FeatureFlagError.ProviderError(e))
-          .map { details =>
-            val resolution = toFlagResolution(key, details)
-            resolution.copy(value = details.getValue.longValue()).asInstanceOf[FlagResolution[A]]
-          }
-
-      case "Float" =>
-        ZIO
-          .attemptBlocking {
-            client.getDoubleDetails(key, java.lang.Double.valueOf(default.asInstanceOf[Float].toDouble), ofContext)
-          }
-          .mapError(e => FeatureFlagError.ProviderError(e))
-          .map { details =>
-            val resolution = toFlagResolution(key, details)
-            resolution.copy(value = details.getValue.floatValue()).asInstanceOf[FlagResolution[A]]
-          }
-
-      case "Double" =>
-        ZIO
-          .attemptBlocking {
-            client.getDoubleDetails(key, java.lang.Double.valueOf(default.asInstanceOf[Double]), ofContext)
-          }
-          .mapError(e => FeatureFlagError.ProviderError(e))
-          .map(details => toFlagResolution(key, details).asInstanceOf[FlagResolution[A]])
-
-      case "Object" =>
+      case None if flagType.typeName == "Object" =>
         ZIO
           .attemptBlocking {
             val defaultValue = new dev.openfeature.sdk.Value(
@@ -331,7 +283,7 @@ final private[openfeature] class FeatureFlagsLive(
             )
           }
 
-      case _ =>
+      case None =>
         // Custom type - try to decode from object
         ZIO
           .attemptBlocking {

--- a/core/src/main/scala/zio/openfeature/internal/ClientEvaluator.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ClientEvaluator.scala
@@ -1,0 +1,93 @@
+package zio.openfeature.internal
+
+import zio._
+import zio.openfeature._
+import dev.openfeature.sdk.{Client => OFClient, EvaluationContext => OFEvaluationContext, FlagEvaluationDetails}
+
+/** Type-safe dispatch for OpenFeature client flag evaluation.
+  *
+  * Each instance knows how to call the correct Java SDK method for a specific flag type and extract the result value
+  * with proper type conversions, eliminating stringly-typed dispatch and unsafe casts.
+  */
+private[openfeature] trait ClientEvaluator[A] {
+
+  /** Evaluate a flag using the appropriate typed method on the Java SDK client. */
+  def evaluate(
+    client: OFClient,
+    key: String,
+    default: A,
+    context: OFEvaluationContext
+  ): Task[FlagEvaluationDetails[_]]
+
+  /** Extract the typed value from raw evaluation details. */
+  def extractValue(details: FlagEvaluationDetails[_]): A
+}
+
+private[openfeature] object ClientEvaluator {
+
+  val boolean: ClientEvaluator[Boolean] = new ClientEvaluator[Boolean] {
+    def evaluate(client: OFClient, key: String, default: Boolean, ctx: OFEvaluationContext) =
+      ZIO.attemptBlocking(client.getBooleanDetails(key, default, ctx))
+
+    def extractValue(d: FlagEvaluationDetails[_]) =
+      d.getValue.asInstanceOf[java.lang.Boolean].booleanValue()
+  }
+
+  val string: ClientEvaluator[String] = new ClientEvaluator[String] {
+    def evaluate(client: OFClient, key: String, default: String, ctx: OFEvaluationContext) =
+      ZIO.attemptBlocking(client.getStringDetails(key, default, ctx))
+
+    def extractValue(d: FlagEvaluationDetails[_]) =
+      d.getValue.asInstanceOf[String]
+  }
+
+  val int: ClientEvaluator[Int] = new ClientEvaluator[Int] {
+    def evaluate(client: OFClient, key: String, default: Int, ctx: OFEvaluationContext) =
+      ZIO.attemptBlocking(client.getIntegerDetails(key, Integer.valueOf(default), ctx))
+
+    def extractValue(d: FlagEvaluationDetails[_]) =
+      d.getValue.asInstanceOf[java.lang.Integer].intValue()
+  }
+
+  val long: ClientEvaluator[Long] = new ClientEvaluator[Long] {
+    def evaluate(client: OFClient, key: String, default: Long, ctx: OFEvaluationContext) =
+      ZIO.attemptBlocking(client.getIntegerDetails(key, Integer.valueOf(default.toInt), ctx))
+
+    def extractValue(d: FlagEvaluationDetails[_]) =
+      d.getValue.asInstanceOf[java.lang.Integer].longValue()
+  }
+
+  val float: ClientEvaluator[Float] = new ClientEvaluator[Float] {
+    def evaluate(client: OFClient, key: String, default: Float, ctx: OFEvaluationContext) =
+      ZIO.attemptBlocking(
+        client.getDoubleDetails(key, java.lang.Double.valueOf(default.toDouble), ctx)
+      )
+
+    def extractValue(d: FlagEvaluationDetails[_]) =
+      d.getValue.asInstanceOf[java.lang.Double].floatValue()
+  }
+
+  val double: ClientEvaluator[Double] = new ClientEvaluator[Double] {
+    def evaluate(client: OFClient, key: String, default: Double, ctx: OFEvaluationContext) =
+      ZIO.attemptBlocking(client.getDoubleDetails(key, java.lang.Double.valueOf(default), ctx))
+
+    def extractValue(d: FlagEvaluationDetails[_]) =
+      d.getValue.asInstanceOf[java.lang.Double].doubleValue()
+  }
+
+  /** Look up the appropriate evaluator for a given FlagType. Returns None for Object and custom types which require
+    * special handling.
+    */
+  def forType[A](flagType: FlagType[A]): Option[ClientEvaluator[A]] = {
+    val evaluator: Option[ClientEvaluator[_]] = flagType.typeName match {
+      case "Boolean" => Some(boolean)
+      case "String"  => Some(string)
+      case "Int"     => Some(int)
+      case "Long"    => Some(long)
+      case "Float"   => Some(float)
+      case "Double"  => Some(double)
+      case _         => None
+    }
+    evaluator.map(_.asInstanceOf[ClientEvaluator[A]])
+  }
+}

--- a/core/src/test/scala/zio/openfeature/ClientEvaluatorSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ClientEvaluatorSpec.scala
@@ -1,0 +1,88 @@
+package zio.openfeature
+
+import zio.test._
+import zio.openfeature.internal.ClientEvaluator
+import dev.openfeature.sdk.FlagEvaluationDetails
+
+object ClientEvaluatorSpec extends ZIOSpecDefault {
+
+  private def detailsWithValue[A](value: A): FlagEvaluationDetails[A] = {
+    val details = new FlagEvaluationDetails[A]()
+    details.setValue(value)
+    details
+  }
+
+  def spec = suite("ClientEvaluatorSpec")(
+    suite("forType lookup")(
+      test("resolves Boolean evaluator") {
+        val result = ClientEvaluator.forType(FlagType[Boolean])
+        assertTrue(result.isDefined)
+      },
+      test("resolves String evaluator") {
+        val result = ClientEvaluator.forType(FlagType[String])
+        assertTrue(result.isDefined)
+      },
+      test("resolves Int evaluator") {
+        val result = ClientEvaluator.forType(FlagType[Int])
+        assertTrue(result.isDefined)
+      },
+      test("resolves Long evaluator") {
+        val result = ClientEvaluator.forType(FlagType[Long])
+        assertTrue(result.isDefined)
+      },
+      test("resolves Float evaluator") {
+        val result = ClientEvaluator.forType(FlagType[Float])
+        assertTrue(result.isDefined)
+      },
+      test("resolves Double evaluator") {
+        val result = ClientEvaluator.forType(FlagType[Double])
+        assertTrue(result.isDefined)
+      },
+      test("returns None for Object type") {
+        val result = ClientEvaluator.forType(FlagType[Map[String, Any]])
+        assertTrue(result.isEmpty)
+      },
+      test("returns None for custom types") {
+        implicit val customFlagType: FlagType[List[Int]] = FlagType.from(
+          name = "CustomList",
+          default = List.empty,
+          decoder = _ => Right(List.empty)
+        )
+        val result = ClientEvaluator.forType(customFlagType)
+        assertTrue(result.isEmpty)
+      }
+    ),
+    suite("extractValue")(
+      test("Boolean extracts value from details") {
+        val details = detailsWithValue[java.lang.Boolean](java.lang.Boolean.TRUE)
+        val value   = ClientEvaluator.boolean.extractValue(details)
+        assertTrue(value == true)
+      },
+      test("String extracts value from details") {
+        val details = detailsWithValue[String]("hello")
+        val value   = ClientEvaluator.string.extractValue(details)
+        assertTrue(value == "hello")
+      },
+      test("Int extracts value from details") {
+        val details = detailsWithValue[java.lang.Integer](java.lang.Integer.valueOf(42))
+        val value   = ClientEvaluator.int.extractValue(details)
+        assertTrue(value == 42)
+      },
+      test("Long extracts value from details") {
+        val details = detailsWithValue[java.lang.Integer](java.lang.Integer.valueOf(100))
+        val value   = ClientEvaluator.long.extractValue(details)
+        assertTrue(value == 100L)
+      },
+      test("Float extracts value from details") {
+        val details = detailsWithValue[java.lang.Double](java.lang.Double.valueOf(3.14))
+        val value   = ClientEvaluator.float.extractValue(details)
+        assertTrue(value == 3.14.toFloat)
+      },
+      test("Double extracts value from details") {
+        val details = detailsWithValue[java.lang.Double](java.lang.Double.valueOf(2.718))
+        val value   = ClientEvaluator.double.extractValue(details)
+        assertTrue(value == 2.718)
+      }
+    )
+  )
+}


### PR DESCRIPTION
## Summary
- Create `internal.ClientEvaluator[A]` typeclass encapsulating Java SDK type-specific dispatch
- Provide instances for Boolean, String, Int, Long, Float, Double
- Refactor `evaluateFromClient` from 7-branch string match to 3-branch pattern match
- Eliminate 6 repetitive \`asInstanceOf\` casts for primitive types
- Object and custom types retain direct handling (need conversion helpers)