### PR TITLE
Add TypedKey for type-safe hook data access

### DIFF
--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -1,7 +1,5 @@
 package zio.openfeature
 
-import scala.annotation.targetName
-
 import zio._
 
 /** A type-safe key for storing and retrieving values from HookData and HookHints.
@@ -80,9 +78,8 @@ final case class HookHints(values: Map[String, Any]) {
   def getOrElse[A](key: TypedKey[A], default: => A): A =
     get(key).getOrElse(default)
 
-  @targetName("addTyped")
-  def +[A](entry: (TypedKey[A], A)): HookHints =
-    HookHints(values + (entry._1.name -> entry._2))
+  def add[A](key: TypedKey[A], value: A): HookHints =
+    HookHints(values + (key.name -> value))
 }
 
 object HookHints {
@@ -173,7 +170,7 @@ object FeatureHook {
 
       override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
         Clock.nanoTime.map { start =>
-          Some((ctx.evaluationContext, hints + (startTimeKey -> start)))
+          Some((ctx.evaluationContext, hints.add(startTimeKey, start)))
         }
 
       override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =

--- a/core/src/test/scala/zio/openfeature/HookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookSpec.scala
@@ -390,9 +390,9 @@ object HookSpec extends ZIOSpecDefault {
         val hints = HookHints(Map(key.name -> 42))
         assertTrue(hints.get(key) == Some(42))
       },
-      test("TypedKey + on HookHints") {
+      test("TypedKey add on HookHints") {
         val key   = TypedKey[Boolean]("enabled")
-        val hints = HookHints.empty + (key -> true)
+        val hints = HookHints.empty.add(key, true)
         assertTrue(hints.get(key) == Some(true))
       },
       test("TypedKey getOrElse on HookData") {


### PR DESCRIPTION
## Summary
- Add \`TypedKey[A]\` case class for compile-time type-safe hook data access
- Add type-safe overloads to \`HookData\` and \`HookHints\` (set, get, getOrElse, remove, +)
- Update \`FeatureHook.metrics\` to use \`TypedKey[Long]\` instead of string key
- Existing untyped API preserved for backward compatibility