### PR TITLE
Use captured runtime in event bridge

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -36,69 +36,71 @@ final private[openfeature] class FeatureFlagsLive(
   private[openfeature] def startEventBridge: ZIO[Scope, Nothing, Unit] = {
     val metadata = ProviderMetadata(providerName)
 
-    val readyHandler: java.util.function.Consumer[EventDetails] = _ =>
-      Unsafe.unsafe { implicit u =>
-        Runtime.default.unsafe
-          .run(
-            statusRef.set(ProviderStatus.Ready) *>
-              eventHub.publish(ProviderEvent.Ready(metadata))
-          )
-          .getOrThrowFiberFailure()
-      }
+    ZIO.runtime[Any].flatMap { runtime =>
+      val readyHandler: java.util.function.Consumer[EventDetails] = _ =>
+        Unsafe.unsafe { implicit u =>
+          runtime.unsafe
+            .run(
+              statusRef.set(ProviderStatus.Ready) *>
+                eventHub.publish(ProviderEvent.Ready(metadata))
+            )
+            .getOrThrowFiberFailure()
+        }
 
-    val errorHandler: java.util.function.Consumer[EventDetails] = details =>
-      Unsafe.unsafe { implicit u =>
-        val error     = new RuntimeException(Option(details.getMessage).getOrElse("Provider error"))
-        val errorCode = Option(details.getErrorCode).map(ErrorCodeConverter.fromJava)
-        Runtime.default.unsafe
-          .run(
-            statusRef.set(ProviderStatus.Error) *>
-              eventHub.publish(
-                ProviderEvent.Error(error, metadata, errorCode, Option(details.getMessage))
-              )
-          )
-          .getOrThrowFiberFailure()
-      }
+      val errorHandler: java.util.function.Consumer[EventDetails] = details =>
+        Unsafe.unsafe { implicit u =>
+          val error     = new RuntimeException(Option(details.getMessage).getOrElse("Provider error"))
+          val errorCode = Option(details.getErrorCode).map(ErrorCodeConverter.fromJava)
+          runtime.unsafe
+            .run(
+              statusRef.set(ProviderStatus.Error) *>
+                eventHub.publish(
+                  ProviderEvent.Error(error, metadata, errorCode, Option(details.getMessage))
+                )
+            )
+            .getOrThrowFiberFailure()
+        }
 
-    val staleHandler: java.util.function.Consumer[EventDetails] = details =>
-      Unsafe.unsafe { implicit u =>
-        val reason = Option(details.getMessage).getOrElse("Provider stale")
-        Runtime.default.unsafe
-          .run(
-            statusRef.set(ProviderStatus.Stale) *>
-              eventHub.publish(ProviderEvent.Stale(reason, metadata))
-          )
-          .getOrThrowFiberFailure()
-      }
+      val staleHandler: java.util.function.Consumer[EventDetails] = details =>
+        Unsafe.unsafe { implicit u =>
+          val reason = Option(details.getMessage).getOrElse("Provider stale")
+          runtime.unsafe
+            .run(
+              statusRef.set(ProviderStatus.Stale) *>
+                eventHub.publish(ProviderEvent.Stale(reason, metadata))
+            )
+            .getOrThrowFiberFailure()
+        }
 
-    val configHandler: java.util.function.Consumer[EventDetails] = details =>
-      Unsafe.unsafe { implicit u =>
-        val flags = Option(details.getFlagsChanged)
-          .map(_.asScala.toSet)
-          .getOrElse(Set.empty[String])
-        Runtime.default.unsafe
-          .run(
-            eventHub.publish(ProviderEvent.ConfigurationChanged(flags, metadata))
-          )
-          .getOrThrowFiberFailure()
-      }
+      val configHandler: java.util.function.Consumer[EventDetails] = details =>
+        Unsafe.unsafe { implicit u =>
+          val flags = Option(details.getFlagsChanged)
+            .map(_.asScala.toSet)
+            .getOrElse(Set.empty[String])
+          runtime.unsafe
+            .run(
+              eventHub.publish(ProviderEvent.ConfigurationChanged(flags, metadata))
+            )
+            .getOrThrowFiberFailure()
+        }
 
-    for {
-      _ <- ZIO.succeed {
-        client.on(JavaProviderEvent.PROVIDER_READY, readyHandler)
-        client.on(JavaProviderEvent.PROVIDER_ERROR, errorHandler)
-        client.on(JavaProviderEvent.PROVIDER_STALE, staleHandler)
-        client.on(JavaProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configHandler)
-        ()
-      }
-      _ <- ZIO.addFinalizer(ZIO.attempt {
-        client.removeHandler(JavaProviderEvent.PROVIDER_READY, readyHandler)
-        client.removeHandler(JavaProviderEvent.PROVIDER_ERROR, errorHandler)
-        client.removeHandler(JavaProviderEvent.PROVIDER_STALE, staleHandler)
-        client.removeHandler(JavaProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configHandler)
-        ()
-      }.ignore)
-    } yield ()
+      for {
+        _ <- ZIO.succeed {
+          client.on(JavaProviderEvent.PROVIDER_READY, readyHandler)
+          client.on(JavaProviderEvent.PROVIDER_ERROR, errorHandler)
+          client.on(JavaProviderEvent.PROVIDER_STALE, staleHandler)
+          client.on(JavaProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configHandler)
+          ()
+        }
+        _ <- ZIO.addFinalizer(ZIO.attempt {
+          client.removeHandler(JavaProviderEvent.PROVIDER_READY, readyHandler)
+          client.removeHandler(JavaProviderEvent.PROVIDER_ERROR, errorHandler)
+          client.removeHandler(JavaProviderEvent.PROVIDER_STALE, staleHandler)
+          client.removeHandler(JavaProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configHandler)
+          ()
+        }.ignore)
+      } yield ()
+    }
   }
 
   // Context merges in order per OpenFeature spec: API (global) -> Client -> Transaction -> Invocation


### PR DESCRIPTION
## Summary
- Capture the current ZIO runtime via `ZIO.runtime[Any]` in `startEventBridge`
- Use the captured runtime in all 4 Java SDK event handler callbacks instead of `Runtime.default`
- Ensures event handlers respect custom runtime configuration (logging, metrics, etc.)

## Test plan
- [x] All 274 existing tests pass
- [x] Event handler tests verify correct behavior