### PR TITLE
Add ClientEvaluator typeclass for type-safe SDK dispatch

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -2,7 +2,7 @@ package zio.openfeature
 
 import zio._
 import zio.stream._
-import zio.openfeature.internal.{ContextConverter, ErrorCodeConverter, FeatureFlagsState}
+import zio.openfeature.internal.{ClientEvaluator, ContextConverter, ErrorCodeConverter, FeatureFlagsState}
 import dev.openfeature.sdk.{
   Client => OFClient,
   FeatureProvider => OFFeatureProvider,
@@ -240,6 +240,19 @@ final private[openfeature] class FeatureFlagsLive(
       _          <- txState.record(eval)
     } yield resolution
 
+  // Evaluate a flag using a ClientEvaluator typeclass instance for type-safe SDK dispatch
+  private def evaluateViaTypeclass[A](
+    key: String,
+    default: A,
+    ofContext: dev.openfeature.sdk.EvaluationContext
+  )(implicit ev: ClientEvaluator[A]): IO[FeatureFlagError, FlagResolution[A]] =
+    ev.evaluate(client, key, default, ofContext)
+      .mapError(e => FeatureFlagError.ProviderError(e))
+      .map { details =>
+        val resolution = toFlagResolution(key, details)
+        resolution.copy(value = ev.extractValue(details))
+      }
+
   private def evaluateFromClient[A: FlagType](
     key: String,
     default: A,
@@ -250,61 +263,28 @@ final private[openfeature] class FeatureFlagsLive(
 
     val evaluation: IO[FeatureFlagError, FlagResolution[A]] = flagType.typeName match {
       case "Boolean" =>
-        ZIO
-          .attemptBlocking {
-            client.getBooleanDetails(key, default.asInstanceOf[Boolean], ofContext)
-          }
-          .mapError(e => FeatureFlagError.ProviderError(e))
-          .map(details => toFlagResolution(key, details).asInstanceOf[FlagResolution[A]])
+        evaluateViaTypeclass(key, default.asInstanceOf[Boolean], ofContext)
+          .map(_.asInstanceOf[FlagResolution[A]])
 
       case "String" =>
-        ZIO
-          .attemptBlocking {
-            client.getStringDetails(key, default.asInstanceOf[String], ofContext)
-          }
-          .mapError(e => FeatureFlagError.ProviderError(e))
-          .map(details => toFlagResolution(key, details).asInstanceOf[FlagResolution[A]])
+        evaluateViaTypeclass(key, default.asInstanceOf[String], ofContext)
+          .map(_.asInstanceOf[FlagResolution[A]])
 
       case "Int" =>
-        ZIO
-          .attemptBlocking {
-            client.getIntegerDetails(key, Integer.valueOf(default.asInstanceOf[Int]), ofContext)
-          }
-          .mapError(e => FeatureFlagError.ProviderError(e))
-          .map { details =>
-            val resolution = toFlagResolution(key, details)
-            resolution.copy(value = details.getValue.intValue()).asInstanceOf[FlagResolution[A]]
-          }
+        evaluateViaTypeclass(key, default.asInstanceOf[Int], ofContext)
+          .map(_.asInstanceOf[FlagResolution[A]])
 
       case "Long" =>
-        ZIO
-          .attemptBlocking {
-            client.getIntegerDetails(key, Integer.valueOf(default.asInstanceOf[Long].toInt), ofContext)
-          }
-          .mapError(e => FeatureFlagError.ProviderError(e))
-          .map { details =>
-            val resolution = toFlagResolution(key, details)
-            resolution.copy(value = details.getValue.longValue()).asInstanceOf[FlagResolution[A]]
-          }
+        evaluateViaTypeclass(key, default.asInstanceOf[Long], ofContext)
+          .map(_.asInstanceOf[FlagResolution[A]])
 
       case "Float" =>
-        ZIO
-          .attemptBlocking {
-            client.getDoubleDetails(key, java.lang.Double.valueOf(default.asInstanceOf[Float].toDouble), ofContext)
-          }
-          .mapError(e => FeatureFlagError.ProviderError(e))
-          .map { details =>
-            val resolution = toFlagResolution(key, details)
-            resolution.copy(value = details.getValue.floatValue()).asInstanceOf[FlagResolution[A]]
-          }
+        evaluateViaTypeclass(key, default.asInstanceOf[Float], ofContext)
+          .map(_.asInstanceOf[FlagResolution[A]])
 
       case "Double" =>
-        ZIO
-          .attemptBlocking {
-            client.getDoubleDetails(key, java.lang.Double.valueOf(default.asInstanceOf[Double]), ofContext)
-          }
-          .mapError(e => FeatureFlagError.ProviderError(e))
-          .map(details => toFlagResolution(key, details).asInstanceOf[FlagResolution[A]])
+        evaluateViaTypeclass(key, default.asInstanceOf[Double], ofContext)
+          .map(_.asInstanceOf[FlagResolution[A]])
 
       case "Object" =>
         ZIO

--- a/core/src/main/scala/zio/openfeature/internal/ClientEvaluator.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ClientEvaluator.scala
@@ -1,0 +1,124 @@
+package zio.openfeature.internal
+
+import zio._
+import zio.openfeature._
+import dev.openfeature.sdk.{Client => OFClient, FlagEvaluationDetails}
+
+/** Typeclass that encapsulates type-safe dispatch to the OpenFeature Java SDK client methods.
+  *
+  * Each instance knows how to call the correct SDK method (getBooleanDetails, getStringDetails, etc.) for a given Scala
+  * type, handling Java boxing conversions where needed.
+  */
+private[openfeature] trait ClientEvaluator[A] {
+
+  /** Evaluate a flag using the appropriate SDK method and return raw FlagEvaluationDetails.
+    *
+    * @param client
+    *   the OpenFeature Java SDK client
+    * @param key
+    *   the flag key
+    * @param default
+    *   the default value
+    * @param context
+    *   the evaluation context
+    * @return
+    *   the evaluation details from the SDK, wrapped in a blocking ZIO
+    */
+  def evaluate(
+    client: OFClient,
+    key: String,
+    default: A,
+    context: dev.openfeature.sdk.EvaluationContext
+  ): Task[FlagEvaluationDetails[_]]
+
+  /** Extract the typed value from the raw SDK evaluation details.
+    *
+    * Some types (Long, Float) require converting the SDK result type (Integer, Double) back to the target type.
+    */
+  def extractValue(details: FlagEvaluationDetails[_]): A
+}
+
+private[openfeature] object ClientEvaluator {
+
+  implicit val booleanEvaluator: ClientEvaluator[Boolean] = new ClientEvaluator[Boolean] {
+    def evaluate(
+      client: OFClient,
+      key: String,
+      default: Boolean,
+      context: dev.openfeature.sdk.EvaluationContext
+    ): Task[FlagEvaluationDetails[_]] =
+      ZIO.attemptBlocking(client.getBooleanDetails(key, default, context))
+
+    def extractValue(details: FlagEvaluationDetails[_]): Boolean =
+      details.getValue.asInstanceOf[java.lang.Boolean].booleanValue()
+  }
+
+  implicit val stringEvaluator: ClientEvaluator[String] = new ClientEvaluator[String] {
+    def evaluate(
+      client: OFClient,
+      key: String,
+      default: String,
+      context: dev.openfeature.sdk.EvaluationContext
+    ): Task[FlagEvaluationDetails[_]] =
+      ZIO.attemptBlocking(client.getStringDetails(key, default, context))
+
+    def extractValue(details: FlagEvaluationDetails[_]): String =
+      details.getValue.asInstanceOf[String]
+  }
+
+  implicit val intEvaluator: ClientEvaluator[Int] = new ClientEvaluator[Int] {
+    def evaluate(
+      client: OFClient,
+      key: String,
+      default: Int,
+      context: dev.openfeature.sdk.EvaluationContext
+    ): Task[FlagEvaluationDetails[_]] =
+      ZIO.attemptBlocking(client.getIntegerDetails(key, Integer.valueOf(default), context))
+
+    def extractValue(details: FlagEvaluationDetails[_]): Int =
+      details.getValue.asInstanceOf[java.lang.Integer].intValue()
+  }
+
+  // Long uses Integer SDK method with conversion
+  implicit val longEvaluator: ClientEvaluator[Long] = new ClientEvaluator[Long] {
+    def evaluate(
+      client: OFClient,
+      key: String,
+      default: Long,
+      context: dev.openfeature.sdk.EvaluationContext
+    ): Task[FlagEvaluationDetails[_]] =
+      ZIO.attemptBlocking(client.getIntegerDetails(key, Integer.valueOf(default.toInt), context))
+
+    def extractValue(details: FlagEvaluationDetails[_]): Long =
+      details.getValue.asInstanceOf[java.lang.Integer].longValue()
+  }
+
+  // Float uses Double SDK method with conversion
+  implicit val floatEvaluator: ClientEvaluator[Float] = new ClientEvaluator[Float] {
+    def evaluate(
+      client: OFClient,
+      key: String,
+      default: Float,
+      context: dev.openfeature.sdk.EvaluationContext
+    ): Task[FlagEvaluationDetails[_]] =
+      ZIO.attemptBlocking(
+        client.getDoubleDetails(key, java.lang.Double.valueOf(default.toDouble), context)
+      )
+
+    def extractValue(details: FlagEvaluationDetails[_]): Float =
+      details.getValue.asInstanceOf[java.lang.Double].floatValue()
+  }
+
+  implicit val doubleEvaluator: ClientEvaluator[Double] = new ClientEvaluator[Double] {
+    def evaluate(
+      client: OFClient,
+      key: String,
+      default: Double,
+      context: dev.openfeature.sdk.EvaluationContext
+    ): Task[FlagEvaluationDetails[_]] =
+      ZIO.attemptBlocking(client.getDoubleDetails(key, java.lang.Double.valueOf(default), context))
+
+    def extractValue(details: FlagEvaluationDetails[_]): Double =
+      details.getValue.asInstanceOf[java.lang.Double].doubleValue()
+  }
+}

--- a/core/src/test/scala/zio/openfeature/ClientEvaluatorSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ClientEvaluatorSpec.scala
@@ -1,0 +1,121 @@
+package zio.openfeature
+
+import zio.test._
+import dev.openfeature.sdk.FlagEvaluationDetails
+import zio.openfeature.internal.ClientEvaluator
+
+object ClientEvaluatorSpec extends ZIOSpecDefault {
+
+  private def makeDetails[A](value: A): FlagEvaluationDetails[A] = {
+    val details = new FlagEvaluationDetails[A]()
+    details.setValue(value)
+    details.setFlagKey("test-flag")
+    details
+  }
+
+  def spec = suite("ClientEvaluator")(
+    suite("Boolean instance")(
+      test("extractValue converts Java Boolean to Scala Boolean") {
+        val details = makeDetails[java.lang.Boolean](java.lang.Boolean.TRUE)
+        val result  = ClientEvaluator.booleanEvaluator.extractValue(details)
+        assertTrue(result == true)
+      },
+      test("extractValue handles false") {
+        val details = makeDetails[java.lang.Boolean](java.lang.Boolean.FALSE)
+        val result  = ClientEvaluator.booleanEvaluator.extractValue(details)
+        assertTrue(result == false)
+      }
+    ),
+    suite("String instance")(
+      test("extractValue returns string value") {
+        val details = makeDetails[String]("hello")
+        val result  = ClientEvaluator.stringEvaluator.extractValue(details)
+        assertTrue(result == "hello")
+      },
+      test("extractValue handles empty string") {
+        val details = makeDetails[String]("")
+        val result  = ClientEvaluator.stringEvaluator.extractValue(details)
+        assertTrue(result == "")
+      }
+    ),
+    suite("Int instance")(
+      test("extractValue converts Java Integer to Scala Int") {
+        val details = makeDetails[java.lang.Integer](java.lang.Integer.valueOf(42))
+        val result  = ClientEvaluator.intEvaluator.extractValue(details)
+        assertTrue(result == 42)
+      },
+      test("extractValue handles zero") {
+        val details = makeDetails[java.lang.Integer](java.lang.Integer.valueOf(0))
+        val result  = ClientEvaluator.intEvaluator.extractValue(details)
+        assertTrue(result == 0)
+      },
+      test("extractValue handles negative values") {
+        val details = makeDetails[java.lang.Integer](java.lang.Integer.valueOf(-1))
+        val result  = ClientEvaluator.intEvaluator.extractValue(details)
+        assertTrue(result == -1)
+      }
+    ),
+    suite("Long instance")(
+      test("extractValue converts Java Integer to Scala Long") {
+        val details = makeDetails[java.lang.Integer](java.lang.Integer.valueOf(42))
+        val result  = ClientEvaluator.longEvaluator.extractValue(details)
+        assertTrue(result == 42L)
+      },
+      test("extractValue handles large values") {
+        val details = makeDetails[java.lang.Integer](java.lang.Integer.valueOf(Int.MaxValue))
+        val result  = ClientEvaluator.longEvaluator.extractValue(details)
+        assertTrue(result == Int.MaxValue.toLong)
+      }
+    ),
+    suite("Float instance")(
+      test("extractValue converts Java Double to Scala Float") {
+        val details = makeDetails[java.lang.Double](java.lang.Double.valueOf(3.14))
+        val result  = ClientEvaluator.floatEvaluator.extractValue(details)
+        assertTrue(result == 3.14.toFloat)
+      },
+      test("extractValue handles zero") {
+        val details = makeDetails[java.lang.Double](java.lang.Double.valueOf(0.0))
+        val result  = ClientEvaluator.floatEvaluator.extractValue(details)
+        assertTrue(result == 0.0f)
+      }
+    ),
+    suite("Double instance")(
+      test("extractValue converts Java Double to Scala Double") {
+        val details = makeDetails[java.lang.Double](java.lang.Double.valueOf(3.14))
+        val result  = ClientEvaluator.doubleEvaluator.extractValue(details)
+        assertTrue(result == 3.14)
+      },
+      test("extractValue handles negative values") {
+        val details = makeDetails[java.lang.Double](java.lang.Double.valueOf(-1.5))
+        val result  = ClientEvaluator.doubleEvaluator.extractValue(details)
+        assertTrue(result == -1.5)
+      }
+    ),
+    suite("implicit resolution")(
+      test("Boolean instance is resolved implicitly") {
+        val ev = implicitly[ClientEvaluator[Boolean]]
+        assertTrue(ev != null)
+      },
+      test("String instance is resolved implicitly") {
+        val ev = implicitly[ClientEvaluator[String]]
+        assertTrue(ev != null)
+      },
+      test("Int instance is resolved implicitly") {
+        val ev = implicitly[ClientEvaluator[Int]]
+        assertTrue(ev != null)
+      },
+      test("Long instance is resolved implicitly") {
+        val ev = implicitly[ClientEvaluator[Long]]
+        assertTrue(ev != null)
+      },
+      test("Float instance is resolved implicitly") {
+        val ev = implicitly[ClientEvaluator[Float]]
+        assertTrue(ev != null)
+      },
+      test("Double instance is resolved implicitly") {
+        val ev = implicitly[ClientEvaluator[Double]]
+        assertTrue(ev != null)
+      }
+    )
+  )
+}


### PR DESCRIPTION
## Summary
- Extract ClientEvaluator[A] typeclass for type-safe Java SDK method dispatch
- Simplify evaluateFromClient in FeatureFlagsLive using typeclass instances
- Cross-compilation safe (uses implicit val, not given/with)

## Test plan
- [x] All tests pass
- [x] Added ClientEvaluatorSpec tests