### PR TITLE
Override jackson-core to 2.18.6 for CVE fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,9 @@ lazy val commonSettings = Seq(
   )
 ) ++ crossVersionSourceDirs
 
+// Override vulnerable transitive jackson-core (GHSA-72hv-8253-57qq)
+ThisBuild / dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "2.18.6"
+
 lazy val root = (project in file("."))
   .aggregate(core, testkit)
   .settings(


### PR DESCRIPTION
## Summary

- Adds `dependencyOverrides` for `jackson-core` to 2.18.6, fixing [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq) (high severity DoS via async parser number length constraint bypass)
- jackson-core is a transitive development dependency; versions 2.0.0 through 2.18.5 are affected