### PR TITLE
Run after/error/finally hooks in reverse order

### DIFF
--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -140,13 +140,13 @@ object FeatureHook {
         }
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
-      ZIO.foreachDiscard(hooks)(hook => hook.after(ctxForHook(ctx, hook), details, hints))
+      ZIO.foreachDiscard(hooks.reverse)(hook => hook.after(ctxForHook(ctx, hook), details, hints))
 
     override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
-      ZIO.foreachDiscard(hooks)(hook => hook.error(ctxForHook(ctx, hook), err, hints))
+      ZIO.foreachDiscard(hooks.reverse)(hook => hook.error(ctxForHook(ctx, hook), err, hints))
 
     override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
-      ZIO.foreachDiscard(hooks)(hook => hook.finallyAfter(ctxForHook(ctx, hook), details, hints))
+      ZIO.foreachDiscard(hooks.reverse)(hook => hook.finallyAfter(ctxForHook(ctx, hook), details, hints))
   }
 
   def logging(

--- a/core/src/test/scala/zio/openfeature/HookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookSpec.scala
@@ -133,7 +133,7 @@ object HookSpec extends ZIOSpecDefault {
 
         for {
           _ <- composed.after(makeHookContext(), resolution, HookHints.empty)
-        } yield assertTrue(callOrder.get() == List("hook1", "hook2"))
+        } yield assertTrue(callOrder.get() == List("hook2", "hook1"))
       },
       test("compose before merges contexts preserving existing attributes") {
         val hook = new FeatureHook {

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -308,6 +308,34 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
           calls <- callsRef.get
         } yield assertTrue(calls.take(2) == List("client-before", "invocation-before"))
       }.provide(testLayer(Map("order-test" -> true))),
+      test("after hooks run in reverse order (spec 4.4.6)") {
+        val callsRef = Unsafe.unsafe { implicit u =>
+          Runtime.default.unsafe.run(Ref.make(List.empty[String])).getOrThrow()
+        }
+
+        val hook1 = new FeatureHook {
+          override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+            callsRef.update(_ :+ "first")
+        }
+
+        val hook2 = new FeatureHook {
+          override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+            callsRef.update(_ :+ "second")
+        }
+
+        val hook3 = new FeatureHook {
+          override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+            callsRef.update(_ :+ "third")
+        }
+
+        for {
+          _     <- FeatureFlags.addHook(hook1)
+          _     <- FeatureFlags.addHook(hook2)
+          _     <- FeatureFlags.addHook(hook3)
+          _     <- FeatureFlags.boolean("test-flag", default = false)
+          calls <- callsRef.get
+        } yield assertTrue(calls == List("third", "second", "first"))
+      }.provide(testLayer(Map("test-flag" -> true))),
       test("hook hints are passed to invocation hooks") {
         val receivedHints = Unsafe.unsafe { implicit u =>
           Runtime.default.unsafe.run(Ref.make(Option.empty[String])).getOrThrow()


### PR DESCRIPTION
## Summary

- Fix `FeatureHook.compose` to run `after`, `error`, and `finallyAfter` hooks in reverse order per OpenFeature spec (4.4.6)
- Update existing `composes multiple hooks` test to expect reverse order
- Add new integration test verifying 3 hooks run `after` in reverse order

Fixes #60

## Test plan

- [x] Existing `composes multiple hooks` test updated and passes
- [x] New `after hooks run in reverse order (spec 4.4.6)` test passes