### PR TITLE
Add supportedFlagTypes filtering to hooks

### DIFF
--- a/core/src/main/scala-2/zio/openfeature/FlagValueType.scala
+++ b/core/src/main/scala-2/zio/openfeature/FlagValueType.scala
@@ -17,6 +17,8 @@ object FlagValueType {
   case object Double  extends FlagValueType
   case object Object  extends FlagValueType
 
+  val allTypes: Set[FlagValueType] = Set(Boolean, String, Int, Double, Object)
+
   def fromFlagType[A](implicit ft: FlagType[A]): FlagValueType =
     ft.typeName match {
       case "Boolean" => Boolean

--- a/core/src/main/scala-3/zio/openfeature/FlagValueType.scala
+++ b/core/src/main/scala-3/zio/openfeature/FlagValueType.scala
@@ -10,6 +10,8 @@ enum FlagValueType:
   def name: String = toString
 
 object FlagValueType:
+  val allTypes: Set[FlagValueType] = FlagValueType.values.toSet
+
   def fromFlagType[A](using ft: FlagType[A]): FlagValueType =
     ft.typeName match
       case "Boolean" => Boolean

--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -102,6 +102,12 @@ object HookHints {
 }
 
 trait FeatureHook {
+
+  /** The set of flag value types this hook supports. Hooks are only invoked for evaluations whose flag type is in this
+    * set. By default all types are supported, matching the Java SDK's `Hook.supportsFlagValueType()` (spec 4.4.2.1).
+    */
+  def supportedFlagTypes: Set[FlagValueType] = FlagValueType.allTypes
+
   def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
     ZIO.none
 
@@ -127,26 +133,35 @@ object FeatureHook {
     private def ctxForHook(ctx: HookContext, hook: FeatureHook): HookContext =
       ctx.copy(hookData = hookDataMap.getOrElse(hook, HookData.empty))
 
+    // Filter hooks to those that support the given flag type (spec 4.4.2.1)
+    private def applicableHooks(flagType: FlagValueType): List[FeatureHook] =
+      hooks.filter(_.supportedFlagTypes.contains(flagType))
+
     override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
       ZIO
-        .foldLeft(hooks)((ctx.evaluationContext, hints, false)) { case ((currentCtx, currentHints, modified), hook) =>
-          hook.before(ctxForHook(ctx.copy(evaluationContext = currentCtx), hook), currentHints).map {
-            case Some((newCtx, newHints)) => (currentCtx.merge(newCtx), newHints, true)
-            case None                     => (currentCtx, currentHints, modified)
-          }
+        .foldLeft(applicableHooks(ctx.flagType))((ctx.evaluationContext, hints, false)) {
+          case ((currentCtx, currentHints, modified), hook) =>
+            hook.before(ctxForHook(ctx.copy(evaluationContext = currentCtx), hook), currentHints).map {
+              case Some((newCtx, newHints)) => (currentCtx.merge(newCtx), newHints, true)
+              case None                     => (currentCtx, currentHints, modified)
+            }
         }
         .map { case (finalCtx, finalHints, wasModified) =>
           if (wasModified) Some((finalCtx, finalHints)) else None
         }
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
-      ZIO.foreachDiscard(hooks.reverse)(hook => hook.after(ctxForHook(ctx, hook), details, hints))
+      ZIO.foreachDiscard(applicableHooks(ctx.flagType).reverse)(hook =>
+        hook.after(ctxForHook(ctx, hook), details, hints)
+      )
 
     override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
-      ZIO.foreachDiscard(hooks.reverse)(hook => hook.error(ctxForHook(ctx, hook), err, hints))
+      ZIO.foreachDiscard(applicableHooks(ctx.flagType).reverse)(hook => hook.error(ctxForHook(ctx, hook), err, hints))
 
     override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
-      ZIO.foreachDiscard(hooks.reverse)(hook => hook.finallyAfter(ctxForHook(ctx, hook), details, hints))
+      ZIO.foreachDiscard(applicableHooks(ctx.flagType).reverse)(hook =>
+        hook.finallyAfter(ctxForHook(ctx, hook), details, hints)
+      )
   }
 
   def logging(

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -351,7 +351,32 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
           _    <- FeatureFlags.booleanDetails("hint-test", default = false, EvaluationContext.empty, options)
           hint <- receivedHints.get
         } yield assertTrue(hint.contains("hint-value"))
-      }.provide(testLayer(Map("hint-test" -> true)))
+      }.provide(testLayer(Map("hint-test" -> true))),
+      test("hooks with unsupported flag type are skipped (spec 4.4.2.1)") {
+        val callsRef = Unsafe.unsafe { implicit u =>
+          Runtime.default.unsafe.run(Ref.make(List.empty[String])).getOrThrow()
+        }
+
+        // Hook that only supports String flags
+        val stringOnlyHook = new FeatureHook {
+          override def supportedFlagTypes: Set[FlagValueType] = Set(FlagValueType.String)
+
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+            callsRef.update(_ :+ s"before:${ctx.flagKey}").as(None)
+
+          override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+            callsRef.update(_ :+ s"after:${ctx.flagKey}")
+        }
+
+        for {
+          _         <- FeatureFlags.addHook(stringOnlyHook)
+          _         <- FeatureFlags.boolean("bool-flag", default = false)
+          afterBool <- callsRef.get
+          _         <- FeatureFlags.string("str-flag", default = "default")
+          afterStr  <- callsRef.get
+        } yield assertTrue(afterBool.isEmpty) &&
+          assertTrue(afterStr == List("before:str-flag", "after:str-flag"))
+      }.provide(testLayer(Map("bool-flag" -> true, "str-flag" -> "hello")))
     ),
     suite("Provider Status")(
       test("providerStatus returns current status") {


### PR DESCRIPTION
## Summary

- Adds `supportedFlagTypes` method to `FeatureHook` trait with a default that supports all flag types, matching the Java SDK's `Hook.supportsFlagValueType()` (spec 4.4.2.1)
- Updates `FeatureHook.compose` to filter hooks based on `HookContext.flagType` before invoking each stage (before, after, error, finallyAfter)
- Adds `FlagValueType.allTypes` to both Scala 2 and Scala 3 sources for cross-compilation support
- Adds test verifying hooks with unsupported flag types are skipped during evaluation

Closes #61

## Test plan

- [ ] Verify existing hook tests still pass (no behavioral change for hooks using default `supportedFlagTypes`)
- [ ] Verify new test: string-only hook is skipped for boolean evaluation but invoked for string evaluation
- [ ] Verify cross-compilation for both Scala 2.13 and Scala 3