### PR TITLE
Block evaluation when provider status is Error

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -170,6 +170,7 @@ final private[openfeature] class FeatureFlagsLive(
     providerStatus.flatMap {
       case ProviderStatus.Fatal    => ZIO.fail(FeatureFlagError.ProviderFatal)
       case ProviderStatus.NotReady => ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.NotReady))
+      case ProviderStatus.Error    => ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.Error))
       case _                       => ZIO.unit
     }
 

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -709,6 +709,15 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
           _            <- testProvider.setStatus(ProviderStatus.Stale)
           result       <- FeatureFlags.boolean("test-flag", default = false)
         } yield assertTrue(result == true)
+      }.provide(testLayer(Map("test-flag" -> true))),
+      test("evaluation fails with ProviderNotReady when provider is in Error status (spec 1.7.3)") {
+        for {
+          testProvider <- ZIO.service[TestFeatureProvider]
+          _            <- testProvider.setStatus(ProviderStatus.Error)
+          result       <- FeatureFlags.boolean("test-flag", default = false).exit
+        } yield assertTrue(
+          result == Exit.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.Error))
+        )
       }.provide(testLayer(Map("test-flag" -> true)))
     ),
     suite("Hook Context Metadata")(


### PR DESCRIPTION
## Summary

- Update `checkProviderStatus` in `FeatureFlagsLive` to fail with `ProviderNotReady(ProviderStatus.Error)` when provider is in Error state, per OpenFeature spec 1.7.3
- Add test verifying evaluation fails when provider status is Error

Fixes #59