### PR TITLE
Fix event propagation from TestFeatureProvider (#58)

### DIFF
--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -3,11 +3,13 @@ package zio.openfeature.testkit
 import zio._
 import zio.stream._
 import zio.openfeature._
+import zio.openfeature.internal.ErrorCodeConverter
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
-  FeatureProvider => OFFeatureProvider,
+  EventProvider,
   Metadata,
   ProviderEvaluation,
+  ProviderEventDetails,
   ProviderState,
   Value,
   Structure
@@ -16,7 +18,6 @@ import scala.jdk.CollectionConverters._
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicReference
-import dev.openfeature.sdk.EventProvider
 
 /** A test provider that implements OpenFeature's FeatureProvider interface.
   *
@@ -32,7 +33,7 @@ final class TestFeatureProvider private (
   private val evaluations: CopyOnWriteArrayList[(String, OFEvaluationContext)],
   private val eventsHubRef: Ref[Hub[ProviderEvent]],
   private[openfeature] val statusRef: Ref[ProviderStatus]
-) extends OFFeatureProvider {
+) extends EventProvider {
 
   @scala.annotation.nowarn("msg=deprecated")
   override def getMetadata: Metadata = new Metadata {
@@ -191,9 +192,28 @@ final class TestFeatureProvider private (
   def getStatus: UIO[ProviderStatus] =
     statusRef.get
 
-  /** Emit a provider event. */
+  /** Emit a provider event through the Java SDK event system so it reaches FeatureFlagsLive handlers. */
   def emitEvent(event: ProviderEvent): UIO[Unit] =
-    eventsHubRef.get.flatMap(_.publish(event)).unit
+    eventsHubRef.get.flatMap(_.publish(event)).unit *>
+      ZIO.succeed {
+        event match {
+          case ProviderEvent.Ready(_) =>
+            emitProviderReady(ProviderEventDetails.builder().build())
+          case ProviderEvent.Error(_, _, errorCode, errorMessage) =>
+            val builder = ProviderEventDetails.builder()
+            errorMessage.foreach(builder.message(_))
+            errorCode.foreach(ec => builder.errorCode(ErrorCodeConverter.toJava(ec)))
+            emitProviderError(builder.build())
+          case ProviderEvent.Stale(reason, _) =>
+            emitProviderStale(ProviderEventDetails.builder().message(reason).build())
+          case ProviderEvent.ConfigurationChanged(changedFlags, _) =>
+            emitProviderConfigurationChanged(
+              ProviderEventDetails.builder().flagsChanged(changedFlags.toList.asJava).build()
+            )
+          case ProviderEvent.Reconnecting(_) =>
+            () // No Java SDK equivalent for reconnecting
+        }
+      }
 
   /** Get all evaluations that have been made. */
   def getEvaluations: UIO[List[(String, OFEvaluationContext)]] =

--- a/testkit/src/test/scala/zio/openfeature/testkit/SpecComplianceSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/SpecComplianceSpec.scala
@@ -1,0 +1,56 @@
+package zio.openfeature.testkit
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+import zio.openfeature._
+
+object SpecComplianceSpec extends ZIOSpecDefault {
+
+  private def testLayer(
+    flags: Map[String, Any] = Map.empty
+  ): ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
+    Scope.default >>> TestFeatureProvider.layer(flags)
+
+  def spec = suite("SpecComplianceSpec")(
+    suite("Event Propagation")(
+      test("onConfigurationChanged receives changed flag keys (spec 5.2.5)") {
+        for {
+          tp       <- ZIO.service[TestFeatureProvider]
+          received <- Ref.make(Option.empty[Set[String]])
+          _        <- FeatureFlags.onConfigurationChanged((flags, _) => received.set(Some(flags)))
+          _        <- ZIO.sleep(200.millis)
+          _        <- tp.emitEvent(ProviderEvent.ConfigurationChanged(Set("flag-a", "flag-b"), tp.metadata))
+          result   <- received.get.repeatUntil(_.isDefined).timeout(5.seconds)
+        } yield assertTrue(result.flatten.contains(Set("flag-a", "flag-b")))
+      }.provide(testLayer()),
+      test("events stream receives published events (spec 5.1.1)") {
+        for {
+          tp    <- ZIO.service[TestFeatureProvider]
+          queue <- Queue.unbounded[ProviderEvent]
+          fiber <- FeatureFlags.events.foreach(e => queue.offer(e)).fork
+          _     <- ZIO.sleep(200.millis)
+          _     <- tp.emitEvent(ProviderEvent.ConfigurationChanged(Set("x"), tp.metadata))
+          event <- queue.take.timeout(5.seconds)
+          _     <- fiber.interrupt
+        } yield assertTrue(event.exists {
+          case ProviderEvent.ConfigurationChanged(flags, _) => flags == Set("x")
+          case _                                            => false
+        })
+      }.provide(testLayer()),
+      test("error in one handler doesn't prevent others (spec 5.2.6)") {
+        for {
+          tp       <- ZIO.service[TestFeatureProvider]
+          received <- Ref.make(false)
+          // First handler dies
+          _ <- FeatureFlags.onConfigurationChanged((_, _) => ZIO.die(new RuntimeException("boom")))
+          // Second handler records that it fired
+          _       <- FeatureFlags.onConfigurationChanged((_, _) => received.set(true))
+          _       <- ZIO.sleep(200.millis)
+          _       <- tp.emitEvent(ProviderEvent.ConfigurationChanged(Set("flag-1"), tp.metadata))
+          didFire <- received.get.repeatUntil(identity).timeout(5.seconds)
+        } yield assertTrue(didFire.contains(true))
+      }.provide(testLayer())
+    )
+  ) @@ TestAspect.withLiveClock @@ TestAspect.timeout(30.seconds) @@ TestAspect.flaky(3)
+}


### PR DESCRIPTION
## Summary

- Make `TestFeatureProvider` extend `EventProvider` instead of `FeatureProvider` so that `emitEvent` sends events through the Java SDK event system
- Events now properly reach `FeatureFlagsLive` handlers via the `startEventBridge` mechanism
- Add `SpecComplianceSpec` with 3 event propagation tests covering specs 5.1.1, 5.2.5, and 5.2.6

## Problem

`TestFeatureProvider.emitEvent` was publishing events to its own internal ZIO Hub, but `FeatureFlagsLive` reads events from the Java SDK event bridge (`client.on(JavaProviderEvent.*)`). This meant:
- `FeatureFlags.onConfigurationChanged` handlers never fired
- `FeatureFlags.events` stream never received events
- Event handler isolation could not be verified end-to-end

## Fix

`TestFeatureProvider` now extends `EventProvider` (which itself extends `FeatureProvider`) and calls the appropriate Java SDK emit methods (`emitProviderReady`, `emitProviderError`, `emitProviderStale`, `emitProviderConfigurationChanged`) in addition to publishing to its own Hub.

## Test plan

- [x] `onConfigurationChanged` receives changed flag keys (spec 5.2.5)
- [x] Events stream receives published events (spec 5.1.1)
- [x] Error in one handler doesn't prevent others (spec 5.2.6)

Closes #58