### PR TITLE
Fix dependency check false positives for Scala CVEs

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -48,6 +48,8 @@ jobs:
             --out build/reports \
             --data ~/.dependency-check \
             --nvdApiKey "$NVD_API_KEY" \
+            --suppression dependency-check-suppressions.xml \
+            --disableOssIndex \
             --failOnCVSS 7
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+   <suppress>
+      <notes><![CDATA[
+      CVE-2022-36944: Scala 2.13.x before 2.13.9 deserialization chain.
+      Fixed in 2.13.9; we use 2.13.14+. False positive from broad CPE match.
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.scala-lang/scala-library@.*$</packageUrl>
+      <cpe>cpe:/a:scala-lang:scala</cpe>
+   </suppress>
+   <suppress>
+      <notes><![CDATA[
+      CVE-2022-36944 / CVE-2017-15288: False positive on Scala 3 library.
+      These CVEs affect Scala 2.13.x < 2.13.9 and Scala < 2.12.4 respectively.
+      Scala 3 is not affected.
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.scala-lang/scala3-library_3@.*$</packageUrl>
+      <cpe>cpe:/a:scala-lang:scala</cpe>
+   </suppress>
+</suppressions>


### PR DESCRIPTION
## Summary

Add suppression file for false positive Scala CVEs (CVE-2022-36944 fixed in 2.13.9, CVE-2017-15288 fixed in 2.12.4 
- we use 2.13.14/3.3.4)
- Disable Sonatype OSS Index analyzer (401 Unauthorized without credentials)
- Fixes the weekly dependency-check action failure.