### PR TITLE
Fix incorrect code snippets and missing info in docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,6 +118,8 @@ FeatureFlags.fromProvider(provider)
 | `fromProvider(provider)` | Create from any OpenFeature provider |
 | `fromProviderWithDomain(provider, domain)` | Create with named domain for test isolation |
 | `fromProviderWithHooks(provider, hooks)` | Create with initial hooks |
+| `fromMultiProvider(providers)` | Combine multiple providers (first-match strategy) |
+| `fromMultiProvider(providers, strategy)` | Combine multiple providers with custom strategy |
 
 ---
 
@@ -271,7 +273,7 @@ FeatureFlags.boolean("feature", false)
   .catchSome {
     case FeatureFlagError.FlagNotFound(_) =>
       ZIO.succeed(false)  // Use default
-    case FeatureFlagError.ProviderNotReady =>
+    case _: FeatureFlagError.ProviderNotReady =>
       ZIO.succeed(false)  // Fail safe
   }
 ```
@@ -321,8 +323,7 @@ zio-openfeature/
 │
 └── testkit/                 # Testing utilities
     └── src/main/scala/zio/openfeature/testkit/
-        ├── TestFeatureProvider.scala # In-memory OpenFeature provider
-        └── TestAssertions.scala      # Test helpers
+        └── TestFeatureProvider.scala # In-memory OpenFeature provider
 ```
 
 ---

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -499,7 +499,7 @@ Create the FeatureFlags layer at application startup to ensure providers are rea
 ```scala
 FeatureFlags.boolean("feature", false)
   .catchAll {
-    case FeatureFlagError.ProviderNotReady =>
+    case _: FeatureFlagError.ProviderNotReady =>
       ZIO.succeed(false)  // Safe default
     case FeatureFlagError.ProviderError(cause) =>
       ZIO.logError(s"Provider error: $cause") *> ZIO.succeed(false)

--- a/docs/testkit.md
+++ b/docs/testkit.md
@@ -156,7 +156,8 @@ for
                .provide(Scope.default >>> layer)
   evals    <- provider.getEvaluations
 yield
-  // evals is List[(String, EvaluationContext)]
+  // evals is List[(String, dev.openfeature.sdk.EvaluationContext)]
+  // The context is the OpenFeature SDK's EvaluationContext (after conversion)
   assertTrue(evals.length == 2)
 ```
 
@@ -272,6 +273,8 @@ test("service evaluates expected flags") {
 
 ### Testing Context Propagation
 
+The `getEvaluations` method returns OpenFeature SDK contexts (after conversion from ZIO contexts). You can verify that context attributes were correctly propagated:
+
 ```scala
 test("context is passed to provider") {
   val ctx = EvaluationContext("user-123")
@@ -283,10 +286,11 @@ test("context is passed to provider") {
     _        <- FeatureFlags.boolean("feature", false, ctx)
                  .provide(Scope.default >>> layer)
     evals    <- provider.getEvaluations
-    (_, evalCtx) = evals.head
+    (_, sdkCtx) = evals.head
   yield
-    assertTrue(evalCtx.targetingKey == Some("user-123")) &&
-    assertTrue(evalCtx.attributes.contains("plan"))
+    // sdkCtx is dev.openfeature.sdk.EvaluationContext (Java SDK type)
+    assertTrue(sdkCtx.getTargetingKey == "user-123") &&
+    assertTrue(sdkCtx.getValue("plan") != null)
 }
 ```
 
@@ -329,19 +333,19 @@ Use `FeatureFlags.fromProviderWithDomain` for test isolation when tests run in p
 
 ```scala
 test("isolated test 1") {
-  val provider = new TestFeatureProvider(Map("flag" -> true))
-  val layer = FeatureFlags.fromProviderWithDomain(provider, "test-1")
-
-  FeatureFlags.boolean("flag", false)
-    .provide(Scope.default >>> layer)
+  for
+    provider <- TestFeatureProvider.make(Map("flag" -> true))
+    layer     = TestFeatureProvider.layerFrom(provider)
+    result   <- FeatureFlags.boolean("flag", false).provide(Scope.default >>> layer)
+  yield assertTrue(result == true)
 }
 
 test("isolated test 2") {
-  val provider = new TestFeatureProvider(Map("flag" -> false))
-  val layer = FeatureFlags.fromProviderWithDomain(provider, "test-2")
-
-  FeatureFlags.boolean("flag", false)
-    .provide(Scope.default >>> layer)
+  for
+    provider <- TestFeatureProvider.make(Map("flag" -> false))
+    layer     = TestFeatureProvider.layerFrom(provider)
+    result   <- FeatureFlags.boolean("flag", false).provide(Scope.default >>> layer)
+  yield assertTrue(result == false)
 }
 ```
 
@@ -392,6 +396,8 @@ test("premium user behavior") {
 
 ### 3. Verify Expected Evaluations
 
+Use `wasEvaluated` for cleaner flag usage assertions:
+
 ```scala
 test("service only evaluates necessary flags") {
   for
@@ -401,10 +407,11 @@ test("service only evaluates necessary flags") {
     ))
     layer     = TestFeatureProvider.layerFrom(provider)
     _        <- myService.provide(Scope.default >>> layer)
-    evals    <- provider.getEvaluations
+    wasNeeded   <- provider.wasEvaluated("needed-flag")
+    wasUnneeded <- provider.wasEvaluated("unneeded-flag")
   yield
-    assertTrue(evals.map(_._1).contains("needed-flag")) &&
-    assertTrue(!evals.map(_._1).contains("unneeded-flag"))
+    assertTrue(wasNeeded) &&
+    assertTrue(!wasUnneeded)
 }
 ```
 


### PR DESCRIPTION
## Summary

- Fix `ProviderNotReady` pattern matches in architecture.md and providers.md (it's a `case class` with a `status` parameter, not a case object)
- Remove non-existent `TestAssertions.scala` from architecture.md module structure
- Add missing `fromMultiProvider` factory methods to architecture.md factory methods table
- Fix testkit.md examples that use `new TestFeatureProvider(...)` (constructor is private, should use `TestFeatureProvider.make`)
- Fix testkit.md examples that treat `getEvaluations` result as ZIO `EvaluationContext` (it returns OpenFeature SDK's `EvaluationContext`)