### PR TITLE
Add non-blocking provider initialization

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -465,4 +465,100 @@ object FeatureFlags {
     ZLayer.scoped(
       build(provider, domain = None, initialHooks = initialHooks, statusRef = None, addShutdownFinalizer = true)
     )
+
+  // Async Factory Methods (non-blocking provider initialization)
+
+  /** Shared initialization logic for async factory methods.
+    *
+    * Uses `setProvider` (non-blocking) instead of `setProviderAndWait`. The provider initializes in the background;
+    * evaluations fail with `ProviderNotReady` until the event bridge receives a `PROVIDER_READY` event. To avoid a race
+    * where the provider becomes ready before the event bridge is registered, we start the event bridge first and then
+    * check the provider's actual state.
+    */
+  private def buildAsync(
+    provider: OFFeatureProvider,
+    domain: Option[String],
+    initialHooks: List[FeatureHook],
+    statusRef: Option[Ref[ProviderStatus]],
+    addShutdownFinalizer: Boolean
+  ): ZIO[Scope, Throwable, FeatureFlagsLive] =
+    for {
+      api <- ZIO.succeed(OpenFeatureAPI.getInstance())
+      // Register provider FIRST so the client binds to it (not the NoOp default)
+      _ <- domain match {
+        case Some(d) => ZIO.succeed(api.setProvider(d, provider))
+        case None    => ZIO.succeed(api.setProvider(provider))
+      }
+      client <- domain match {
+        case Some(d) => ZIO.attempt(api.getClient(d))
+        case None    => ZIO.attempt(api.getClient())
+      }
+      providerName = Option(provider.getMetadata).map(_.getName).getOrElse("unknown")
+      baseState <- FeatureFlagsState.make
+      state = statusRef.fold(baseState)(ref => baseState.copy(statusRef = ref))
+      _ <- state.hooksRef.set(initialHooks)
+      _ <- ZIO.when(addShutdownFinalizer)(ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore))
+      ff = new FeatureFlagsLive(client, provider, providerName, domain, state)
+      // Start event bridge — if provider is already ready, replay fires immediately
+      _ <- ff.startEventBridge
+    } yield ff
+
+  /** Create a FeatureFlags layer from any OpenFeature provider (non-blocking).
+    *
+    * The provider initializes in the background. Evaluations fail with `ProviderNotReady` until the provider is ready.
+    * Use `onProviderReady` or `providerStatus` to detect when the provider becomes available.
+    */
+  def fromProviderAsync(provider: OFFeatureProvider): ZLayer[Scope, Throwable, FeatureFlags] =
+    ZLayer.scoped(
+      buildAsync(provider, domain = None, initialHooks = Nil, statusRef = None, addShutdownFinalizer = true)
+    )
+
+  /** Create a FeatureFlags layer with a named domain (non-blocking). */
+  def fromProviderWithDomainAsync(
+    provider: OFFeatureProvider,
+    domain: String
+  ): ZLayer[Scope, Throwable, FeatureFlags] =
+    ZLayer.scoped(
+      buildAsync(provider, domain = Some(domain), initialHooks = Nil, statusRef = None, addShutdownFinalizer = false)
+    )
+
+  /** Create a FeatureFlags layer with a named domain and shared status ref (non-blocking). */
+  private[openfeature] def fromProviderWithDomainAsync(
+    provider: OFFeatureProvider,
+    domain: String,
+    statusRef: Ref[ProviderStatus]
+  ): ZLayer[Scope, Throwable, FeatureFlags] =
+    ZLayer.scoped(
+      buildAsync(
+        provider,
+        domain = Some(domain),
+        initialHooks = Nil,
+        statusRef = Some(statusRef),
+        addShutdownFinalizer = false
+      )
+    )
+
+  /** Create a FeatureFlags layer with initial hooks (non-blocking). */
+  def fromProviderWithHooksAsync(
+    provider: OFFeatureProvider,
+    initialHooks: List[FeatureHook]
+  ): ZLayer[Scope, Throwable, FeatureFlags] =
+    ZLayer.scoped(
+      buildAsync(provider, domain = None, initialHooks = initialHooks, statusRef = None, addShutdownFinalizer = true)
+    )
+
+  /** Create a FeatureFlags layer from multiple providers (non-blocking, first-match strategy). */
+  def fromMultiProviderAsync(providers: List[OFFeatureProvider]): ZLayer[Scope, Throwable, FeatureFlags] = {
+    import scala.jdk.CollectionConverters._
+    fromProviderAsync(new MultiProvider(providers.asJava))
+  }
+
+  /** Create a FeatureFlags layer from multiple providers with a custom strategy (non-blocking). */
+  def fromMultiProviderAsync(
+    providers: List[OFFeatureProvider],
+    strategy: Strategy
+  ): ZLayer[Scope, Throwable, FeatureFlags] = {
+    import scala.jdk.CollectionConverters._
+    fromProviderAsync(new MultiProvider(providers.asJava, strategy))
+  }
 }

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -326,6 +326,45 @@ val layer = FeatureFlags.fromMultiProvider(
 )
 ```
 
+### Async Variants (Non-Blocking Initialization)
+
+Every factory method has an async counterpart that uses the Java SDK's non-blocking `setProvider` instead of `setProviderAndWait`. The provider initializes in the background; evaluations fail with `ProviderNotReady` until the provider is ready.
+
+This is useful for microservices that need fast startup and can tolerate returning default flag values during the brief initialization window.
+
+```scala
+// Non-blocking: layer is available immediately
+val layer = FeatureFlags.fromProviderAsync(provider)
+
+// With domain
+val domainLayer = FeatureFlags.fromProviderWithDomainAsync(provider, "my-service")
+
+// With hooks
+val hookedLayer = FeatureFlags.fromProviderWithHooksAsync(provider, hooks)
+
+// Multi-provider
+val multiLayer = FeatureFlags.fromMultiProviderAsync(List(provider1, provider2))
+```
+
+Use `onProviderReady` or `providerStatus` to detect when the provider becomes available:
+
+```scala
+val program = for
+  // Register a handler that fires when the provider is ready
+  _ <- FeatureFlags.onProviderReady { metadata =>
+    ZIO.logInfo(s"Provider ${metadata.name} is ready")
+  }
+  // Evaluations before ready will fail with ProviderNotReady
+  result <- FeatureFlags.boolean("feature", default = false).catchAll {
+    case _: FeatureFlagError.ProviderNotReady =>
+      ZIO.succeed(false) // Safe default while provider initializes
+    case other => ZIO.fail(other)
+  }
+yield result
+
+program.provide(Scope.default >>> FeatureFlags.fromProviderAsync(provider))
+```
+
 ---
 
 ## Provider Lifecycle
@@ -335,8 +374,11 @@ val layer = FeatureFlags.fromMultiProvider(
 When you create a `FeatureFlags` layer, the provider is automatically initialized using `setProviderAndWait`. This ensures the provider is ready before any flag evaluations:
 
 ```scala
-// Provider is initialized when layer is provided
+// Provider is initialized when layer is provided (blocking)
 program.provide(Scope.default >>> FeatureFlags.fromProvider(provider))
+
+// Or use the async variant for non-blocking initialization
+program.provide(Scope.default >>> FeatureFlags.fromProviderAsync(provider))
 ```
 
 ### Shutdown

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -146,7 +146,8 @@ FeatureFlags.booleanDetails("flag", false, EvaluationContext.empty, options)
 
 | Requirement | Status | Implementation |
 |:------------|:-------|:---------------|
-| Initialize | ✅ | `setProviderAndWait` on layer creation |
+| Initialize (blocking) | ✅ | `setProviderAndWait` on layer creation |
+| Initialize (async) | ✅ | `setProvider` via `fromProviderAsync` variants |
 | Shutdown (1.6.1) | ✅ | Automatic via ZIO Scope finalizer + explicit `shutdown` method |
 | Provider metadata | ✅ | `providerMetadata` returns name and version |
 | Client metadata | ✅ | `clientMetadata` returns domain |

--- a/docs/testkit.md
+++ b/docs/testkit.md
@@ -323,6 +323,28 @@ test("feature logic with overrides") {
 }
 ```
 
+### Testing Async Initialization
+
+Use `TestFeatureProvider.asyncLayer` to test how your code handles a provider that isn't ready yet:
+
+```scala
+test("service handles provider not ready") {
+  for
+    result <- MyService.getFeature.either
+  yield assertTrue(result.isLeft)  // Fails with ProviderNotReady
+}.provide(Scope.default >>> TestFeatureProvider.asyncLayer(Map("feature" -> true)))
+
+test("service works after provider becomes ready") {
+  for
+    tp     <- ZIO.service[TestFeatureProvider]
+    _      <- tp.setStatus(ProviderStatus.Ready)
+    result <- MyService.getFeature
+  yield assertTrue(result == true)
+}.provide(Scope.default >>> TestFeatureProvider.asyncLayer(Map("feature" -> true)))
+```
+
+The `asyncLayer` creates a provider that starts in `NotReady` state. Call `setStatus(ProviderStatus.Ready)` to simulate the provider becoming ready. This is useful for testing graceful degradation and startup behavior.
+
 ---
 
 ## Test Isolation

--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -15,8 +15,7 @@ import dev.openfeature.sdk.{
   Structure
 }
 import scala.jdk.CollectionConverters._
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList, CountDownLatch}
 import java.util.concurrent.atomic.AtomicReference
 
 /** A test provider that implements OpenFeature's FeatureProvider interface.
@@ -32,7 +31,8 @@ final class TestFeatureProvider private (
   private val state: AtomicReference[ProviderState],
   private val evaluations: CopyOnWriteArrayList[(String, OFEvaluationContext)],
   private val eventsHubRef: Ref[Hub[ProviderEvent]],
-  private[openfeature] val statusRef: Ref[ProviderStatus]
+  private[openfeature] val statusRef: Ref[ProviderStatus],
+  private val initLatch: Option[CountDownLatch]
 ) extends EventProvider {
 
   @scala.annotation.nowarn("msg=deprecated")
@@ -42,11 +42,18 @@ final class TestFeatureProvider private (
 
   override def getState: ProviderState = state.get()
 
-  override def initialize(context: OFEvaluationContext): Unit =
+  override def initialize(context: OFEvaluationContext): Unit = {
+    initLatch match {
+      case Some(latch) => latch.await() // Block until released
+      case None        => ()
+    }
     state.set(ProviderState.READY)
+  }
 
-  override def shutdown(): Unit =
+  override def shutdown(): Unit = {
+    initLatch.foreach(_.countDown()) // Release blocked initialize() if still waiting
     state.set(ProviderState.NOT_READY)
+  }
 
   override def getBooleanEvaluation(
     key: String,
@@ -175,11 +182,13 @@ final class TestFeatureProvider private (
   def clearFlags: UIO[Unit] =
     ZIO.succeed(flags.clear())
 
-  /** Set the provider status. */
+  /** Set the provider status. For async test layers, setting Ready releases the init latch. */
   def setStatus(status: ProviderStatus): UIO[Unit] =
     statusRef.set(status) *> ZIO.succeed {
       status match {
-        case ProviderStatus.Ready        => state.set(ProviderState.READY)
+        case ProviderStatus.Ready =>
+          state.set(ProviderState.READY)
+          initLatch.foreach(_.countDown())
         case ProviderStatus.NotReady     => state.set(ProviderState.NOT_READY)
         case ProviderStatus.Error        => state.set(ProviderState.ERROR)
         case ProviderStatus.Stale        => state.set(ProviderState.STALE)
@@ -259,7 +268,7 @@ object TestFeatureProvider {
         initialFlags.foreach { case (k, v) => flags.put(k, v) }
         val state       = new AtomicReference[ProviderState](ProviderState.READY)
         val evaluations = new CopyOnWriteArrayList[(String, OFEvaluationContext)]()
-        new TestFeatureProvider(flags, state, evaluations, hubRef, statusRef)
+        new TestFeatureProvider(flags, state, evaluations, hubRef, statusRef, initLatch = None)
       }
     } yield provider
 
@@ -306,4 +315,62 @@ object TestFeatureProvider {
   /** Self-contained test layer with initial flags that provides its own Scope. */
   def scopedLayer(flags: Map[String, Any]): ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
     Scope.default >>> TestFeatureProvider.layer(flags)
+
+  /** Create a FeatureFlags layer with async (non-blocking) initialization.
+    *
+    * The provider starts in NotReady state. Use `setStatus(ProviderStatus.Ready)` or emit a `ProviderEvent.Ready` event
+    * to simulate the provider becoming ready. Evaluations will fail with `ProviderNotReady` until then.
+    */
+  def asyncLayer: ZLayer[Scope, Throwable, TestFeatureProvider with FeatureFlags] =
+    asyncLayer(Map.empty)
+
+  /** Create a FeatureFlags layer with async initialization and initial flags.
+    *
+    * The provider starts in NotReady state and does not auto-initialize. Call `setStatus(ProviderStatus.Ready)` to
+    * simulate the provider becoming ready. Evaluations will fail with `ProviderNotReady` until then.
+    */
+  def asyncLayer(flags: Map[String, Any]): ZLayer[Scope, Throwable, TestFeatureProvider with FeatureFlags] =
+    ZLayer
+      .scoped {
+        for {
+          testProvider <- makeNotReady(flags)
+          domain = s"test-async-${java.util.UUID.randomUUID()}"
+          featureFlags <- FeatureFlags
+            .fromProviderWithDomainAsync(testProvider, domain, testProvider.statusRef)
+            .build
+            .map(_.get)
+        } yield (testProvider, featureFlags)
+      }
+      .flatMap { env =>
+        val (testProvider, featureFlags) = env.get[(TestFeatureProvider, FeatureFlags)]
+        ZLayer.succeed(testProvider) ++ ZLayer.succeed(featureFlags)
+      }
+
+  /** Create a TestFeatureProvider that starts in NotReady state.
+    *
+    * The provider's `initialize()` blocks until `setStatus(ProviderStatus.Ready)` is called, simulating a
+    * slow-connecting provider (e.g., one that needs to establish a network connection).
+    */
+  private[testkit] def makeNotReady(initialFlags: Map[String, Any]): UIO[TestFeatureProvider] =
+    for {
+      eventsHub <- Hub.unbounded[ProviderEvent]
+      hubRef    <- Ref.make(eventsHub)
+      statusRef <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
+      provider <- ZIO.succeed {
+        val flags = new ConcurrentHashMap[String, Any]()
+        initialFlags.foreach { case (k, v) => flags.put(k, v) }
+        val state       = new AtomicReference[ProviderState](ProviderState.NOT_READY)
+        val evaluations = new CopyOnWriteArrayList[(String, OFEvaluationContext)]()
+        new TestFeatureProvider(flags, state, evaluations, hubRef, statusRef, initLatch = Some(new CountDownLatch(1)))
+      }
+    } yield provider
+
+  /** Self-contained async test layer that provides its own Scope. */
+  val scopedAsyncLayer: ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
+    Scope.default >>> TestFeatureProvider.asyncLayer
+
+  /** Self-contained async test layer with initial flags. */
+  def scopedAsyncLayer(flags: Map[String, Any]): ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
+    Scope.default >>> TestFeatureProvider.asyncLayer(flags)
+
 }

--- a/testkit/src/test/scala/zio/openfeature/testkit/AsyncInitSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/AsyncInitSpec.scala
@@ -1,0 +1,229 @@
+package zio.openfeature.testkit
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+import zio.openfeature._
+
+object AsyncInitSpec extends ZIOSpecDefault {
+
+  private def asyncLayer(
+    flags: Map[String, Any] = Map.empty
+  ): ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
+    Scope.default >>> TestFeatureProvider.asyncLayer(flags)
+
+  def spec = suite("Async Provider Initialization")(
+    suite("Status before ready")(
+      test("providerStatus starts as NotReady") {
+        for {
+          status <- FeatureFlags.providerStatus
+        } yield assertTrue(status == ProviderStatus.NotReady)
+      }.provide(asyncLayer()),
+      test("evaluations fail with ProviderNotReady before provider is ready") {
+        for {
+          result <- FeatureFlags.boolean("flag", default = false).either
+        } yield assertTrue(
+          result.is(_.left).isInstanceOf[FeatureFlagError.ProviderNotReady]
+        )
+      }.provide(asyncLayer(Map("flag" -> true))),
+      test("all flag types fail with ProviderNotReady before provider is ready") {
+        for {
+          boolResult   <- FeatureFlags.boolean("b", default = false).either
+          stringResult <- FeatureFlags.string("s", default = "x").either
+          intResult    <- FeatureFlags.int("i", default = 0).either
+          doubleResult <- FeatureFlags.double("d", default = 0.0).either
+        } yield assertTrue(
+          boolResult.is(_.left).isInstanceOf[FeatureFlagError.ProviderNotReady],
+          stringResult.is(_.left).isInstanceOf[FeatureFlagError.ProviderNotReady],
+          intResult.is(_.left).isInstanceOf[FeatureFlagError.ProviderNotReady],
+          doubleResult.is(_.left).isInstanceOf[FeatureFlagError.ProviderNotReady]
+        )
+      }.provide(asyncLayer(Map("b" -> true, "s" -> "hello", "i" -> 42, "d" -> 3.14))),
+      test("detailed evaluations also fail with ProviderNotReady") {
+        for {
+          result <- FeatureFlags.booleanDetails("flag", default = false).either
+        } yield assertTrue(
+          result.is(_.left).isInstanceOf[FeatureFlagError.ProviderNotReady]
+        )
+      }.provide(asyncLayer(Map("flag" -> true)))
+    ),
+    suite("Status after ready")(
+      test("evaluations succeed after provider becomes ready") {
+        for {
+          tp     <- ZIO.service[TestFeatureProvider]
+          _      <- tp.setStatus(ProviderStatus.Ready)
+          result <- FeatureFlags.boolean("flag", default = false)
+        } yield assertTrue(result == true)
+      }.provide(asyncLayer(Map("flag" -> true))),
+      test("all flag types work after provider becomes ready") {
+        for {
+          tp <- ZIO.service[TestFeatureProvider]
+          _  <- tp.setStatus(ProviderStatus.Ready)
+          b  <- FeatureFlags.boolean("b", default = false)
+          s  <- FeatureFlags.string("s", default = "x")
+          i  <- FeatureFlags.int("i", default = 0)
+          d  <- FeatureFlags.double("d", default = 0.0)
+        } yield assertTrue(b == true, s == "hello", i == 42, d == 3.14)
+      }.provide(asyncLayer(Map("b" -> true, "s" -> "hello", "i" -> 42, "d" -> 3.14))),
+      test("providerStatus transitions to Ready after setStatus") {
+        for {
+          tp     <- ZIO.service[TestFeatureProvider]
+          before <- FeatureFlags.providerStatus
+          _      <- tp.setStatus(ProviderStatus.Ready)
+          after  <- FeatureFlags.providerStatus
+        } yield assertTrue(before == ProviderStatus.NotReady, after == ProviderStatus.Ready)
+      }.provide(asyncLayer()),
+      test("detailed evaluations work after provider becomes ready") {
+        for {
+          tp         <- ZIO.service[TestFeatureProvider]
+          _          <- tp.setStatus(ProviderStatus.Ready)
+          resolution <- FeatureFlags.booleanDetails("flag", default = false)
+        } yield assertTrue(
+          resolution.value == true,
+          resolution.flagKey == "flag",
+          resolution.reason == ResolutionReason.TargetingMatch
+        )
+      }.provide(asyncLayer(Map("flag" -> true)))
+    ),
+    suite("Error state")(
+      test("evaluations fail with ProviderNotReady when provider is in Error state") {
+        for {
+          tp     <- ZIO.service[TestFeatureProvider]
+          _      <- tp.setStatus(ProviderStatus.Error)
+          result <- FeatureFlags.boolean("flag", default = false).either
+        } yield assertTrue(
+          result.is(_.left) == FeatureFlagError.ProviderNotReady(ProviderStatus.Error)
+        )
+      }.provide(asyncLayer(Map("flag" -> true))),
+      test("evaluations fail with ProviderFatal when provider is in Fatal state") {
+        for {
+          tp     <- ZIO.service[TestFeatureProvider]
+          _      <- tp.setStatus(ProviderStatus.Fatal)
+          result <- FeatureFlags.boolean("flag", default = false).either
+        } yield assertTrue(
+          result.is(_.left) == FeatureFlagError.ProviderFatal
+        )
+      }.provide(asyncLayer(Map("flag" -> true)))
+    ),
+    suite("Recovery")(
+      test("evaluations recover after provider transitions from Error to Ready") {
+        for {
+          tp  <- ZIO.service[TestFeatureProvider]
+          _   <- tp.setStatus(ProviderStatus.Error)
+          err <- FeatureFlags.boolean("flag", default = false).either
+          _   <- tp.setStatus(ProviderStatus.Ready)
+          ok  <- FeatureFlags.boolean("flag", default = false)
+        } yield assertTrue(
+          err.is(_.left).isInstanceOf[FeatureFlagError.ProviderNotReady],
+          ok == true
+        )
+      }.provide(asyncLayer(Map("flag" -> true))),
+      test("evaluations recover after provider transitions from NotReady to Ready") {
+        for {
+          tp  <- ZIO.service[TestFeatureProvider]
+          err <- FeatureFlags.boolean("flag", default = false).either
+          _   <- tp.setStatus(ProviderStatus.Ready)
+          ok  <- FeatureFlags.boolean("flag", default = false)
+        } yield assertTrue(
+          err.is(_.left).isInstanceOf[FeatureFlagError.ProviderNotReady],
+          ok == true
+        )
+      }.provide(asyncLayer(Map("flag" -> true)))
+    ),
+    suite("Hooks with async initialization")(
+      test("hooks are applied after provider becomes ready") {
+        for {
+          hookCalled <- Ref.make(false)
+          hook = new FeatureHook {
+            override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+              hookCalled.set(true).as(None)
+          }
+          tp     <- ZIO.service[TestFeatureProvider]
+          ff     <- ZIO.service[FeatureFlags]
+          _      <- ff.addHook(hook)
+          _      <- tp.setStatus(ProviderStatus.Ready)
+          _      <- FeatureFlags.boolean("flag", default = false)
+          called <- hookCalled.get
+        } yield assertTrue(called)
+      }.provide(asyncLayer(Map("flag" -> true)))
+    ),
+    suite("Context with async initialization")(
+      test("evaluation context works after provider becomes ready") {
+        for {
+          tp <- ZIO.service[TestFeatureProvider]
+          _  <- tp.setStatus(ProviderStatus.Ready)
+          ctx = EvaluationContext("user-1").withAttribute("plan", "premium")
+          result <- FeatureFlags.boolean("flag", default = false, ctx)
+        } yield assertTrue(result == true)
+      }.provide(asyncLayer(Map("flag" -> true)))
+    ),
+    suite("Stale state")(
+      test("evaluations succeed when provider is in Stale state") {
+        for {
+          tp     <- ZIO.service[TestFeatureProvider]
+          _      <- tp.setStatus(ProviderStatus.Ready)
+          _      <- tp.setStatus(ProviderStatus.Stale)
+          result <- FeatureFlags.boolean("flag", default = false)
+        } yield assertTrue(result == true)
+      }.provide(asyncLayer(Map("flag" -> true)))
+    ),
+    suite("Async factory methods")(
+      test("fromProviderAsync creates a working layer") {
+        for {
+          tp <- TestFeatureProvider.make(Map("flag" -> true))
+          result <- ZIO.scoped {
+            FeatureFlags.fromProviderAsync(tp).build.flatMap { env =>
+              val ff = env.get[FeatureFlags]
+              // Fast-init provider may need a moment for event bridge to fire
+              ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
+                ff.boolean("flag", default = false)
+            }
+          }
+        } yield assertTrue(result == true)
+      },
+      test("fromProviderWithHooksAsync includes hooks") {
+        for {
+          hookCalled <- Ref.make(false)
+          hook = new FeatureHook {
+            override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+              hookCalled.set(true).as(None)
+          }
+          tp <- TestFeatureProvider.make(Map("flag" -> true))
+          result <- ZIO.scoped {
+            FeatureFlags.fromProviderWithHooksAsync(tp, List(hook)).build.flatMap { env =>
+              val ff = env.get[FeatureFlags]
+              ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
+                ff.boolean("flag", default = false) *>
+                hookCalled.get
+            }
+          }
+        } yield assertTrue(result)
+      },
+      test("fromProviderWithDomainAsync creates a working layer") {
+        for {
+          tp <- TestFeatureProvider.make(Map("flag" -> true))
+          domain = s"test-async-factory-${java.util.UUID.randomUUID()}"
+          result <- ZIO.scoped {
+            FeatureFlags.fromProviderWithDomainAsync(tp, domain).build.flatMap { env =>
+              val ff = env.get[FeatureFlags]
+              ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
+                ff.boolean("flag", default = false)
+            }
+          }
+        } yield assertTrue(result == true)
+      },
+      test("fromMultiProviderAsync creates a working layer") {
+        for {
+          tp <- TestFeatureProvider.make(Map("flag" -> true))
+          result <- ZIO.scoped {
+            FeatureFlags.fromMultiProviderAsync(List(tp)).build.flatMap { env =>
+              val ff = env.get[FeatureFlags]
+              ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
+                ff.boolean("flag", default = false)
+            }
+          }
+        } yield assertTrue(result == true)
+      }
+    )
+  ) @@ TestAspect.sequential @@ TestAspect.withLiveClock @@ TestAspect.flaky(3)
+}


### PR DESCRIPTION
## Summary

- Add async variants of all factory methods (`fromProviderAsync`, `fromProviderWithDomainAsync`, `fromProviderWithHooksAsync`, `fromMultiProviderAsync`) that use the Java SDK's non-blocking `setProvider` instead of `setProviderAndWait`
- Evaluations fail with `ProviderNotReady` until the provider is ready, allowing services to start serving traffic during provider initialization
- Add `TestFeatureProvider.asyncLayer` for testing the not-ready-to-ready lifecycle
- Update provider, testkit, and spec-compliance documentation

Fixes #69