### PR TITLE
Update OpenFeature Java SDK to 1.20.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ZIO OpenFeature provides a type-safe, functional interface for feature flag eval
 
 | ZIO OpenFeature | OpenFeature Spec | OpenFeature Java SDK |
 |:----------------|:-----------------|:---------------------|
-| 0.3.x | [v0.8.0](https://github.com/open-feature/spec/releases/tag/v0.8.0) | 1.20.1 |
+| 0.3.x | [v0.8.0](https://github.com/open-feature/spec/releases/tag/v0.8.0) | 1.20.2 |
 
 This library implements the **dynamic-context paradigm** (server-side) of the OpenFeature specification. See [Spec Compliance](https://etacassiopeia.github.io/zio-openfeature/spec-compliance) for details.
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import net.nmoncho.sbt.dependencycheck.settings._
 val scala213Version       = "2.13.16"
 val scala3Version         = "3.3.4"
 val zioVersion            = "2.1.14"
-val openFeatureSdkVersion = "1.20.1"
+val openFeatureSdkVersion = "1.20.2"
 
 // OpenFeature Specification Compatibility
 // Spec version: v0.8.0 (https://github.com/open-feature/spec)

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -15,7 +15,7 @@ ZIO OpenFeature wraps the [OpenFeature Java SDK](https://openfeature.dev/docs/re
 | Component | Version | Notes |
 |:----------|:--------|:------|
 | **OpenFeature Spec** | v0.8.0 | [Specification](https://github.com/open-feature/spec) |
-| **OpenFeature Java SDK** | 1.20.1 | [Java SDK](https://github.com/open-feature/java-sdk) |
+| **OpenFeature Java SDK** | 1.20.2 | [Java SDK](https://github.com/open-feature/java-sdk) |
 | **ZIO OpenFeature** | [![Maven Central](https://img.shields.io/maven-central/v/io.github.etacassiopeia/zio-openfeature-core_3.svg)](https://search.maven.org/search?q=g:io.github.etacassiopeia%20AND%20a:zio-openfeature-core_3) | This library |
 
 This library targets the **dynamic-context paradigm** (server-side) of the OpenFeature specification.
@@ -277,9 +277,9 @@ Beyond the OpenFeature spec, ZIO OpenFeature provides:
 
 ## Provider SDK Version Compatibility
 
-ZIO OpenFeature ships with OpenFeature Java SDK 1.20.1. You may use providers compiled against older SDK versions, with the following considerations:
+ZIO OpenFeature ships with OpenFeature Java SDK 1.20.2. You may use providers compiled against older SDK versions, with the following considerations:
 
-**Providers implementing `FeatureProvider` directly — fully compatible.** The `FeatureProvider` interface is identical from v1.14.1 through v1.20.1. No abstract methods were added; every new method (e.g., `track()`) was introduced with a `default` no-op implementation. A provider JAR compiled against any 1.14.x+ SDK will work at runtime without recompilation.
+**Providers implementing `FeatureProvider` directly — fully compatible.** The `FeatureProvider` interface is identical from v1.14.1 through v1.20.2. No abstract methods were added; every new method (e.g., `track()`) was introduced with a `default` no-op implementation. A provider JAR compiled against any 1.14.x+ SDK will work at runtime without recompilation.
 
 **Providers extending `EventProvider` — requires SDK 1.16.0+.** In SDK v1.16.0, the `emit()` and `emitProvider*()` methods changed their return type from `void` to `Awaitable`. Since return types are part of JVM method descriptors, a provider compiled against a pre-1.16.0 SDK that calls `this.emit(...)` will fail at runtime with `NoSuchMethodError`. Most ecosystem providers (flagd, LaunchDarkly, Optimizely, etc.) extend `EventProvider`, so they need to be compiled against SDK 1.16.0+.
 


### PR DESCRIPTION
## Summary

Updates the OpenFeature Java SDK dependency from 1.20.1 to 1.20.2.