### PR TITLE
Fix async init timing for slow CI runners

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -484,7 +484,8 @@ object FeatureFlags {
     initialHooks: List[FeatureHook],
     statusRef: Option[Ref[ProviderStatus]],
     addShutdownFinalizer: Boolean,
-    apiOverride: Option[OpenFeatureAPI] = None
+    apiOverride: Option[OpenFeatureAPI] = None,
+    onReady: Option[java.util.concurrent.CountDownLatch] = None
   ): ZIO[Scope, Throwable, FeatureFlagsLive] =
     for {
       api <- ZIO.succeed(apiOverride.getOrElse(OpenFeatureAPI.getInstance()))
@@ -502,7 +503,7 @@ object FeatureFlags {
       state = statusRef.fold(baseState)(ref => baseState.copy(statusRef = ref))
       _ <- state.hooksRef.set(initialHooks)
       _ <- ZIO.when(addShutdownFinalizer)(ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore))
-      ff = new FeatureFlagsLive(client, provider, providerName, domain, state, api)
+      ff = new FeatureFlagsLive(client, provider, providerName, domain, state, api, onReady)
       // Start event bridge — if provider is already ready, replay fires immediately
       _ <- ff.startEventBridge
     } yield ff
@@ -531,7 +532,8 @@ object FeatureFlags {
     provider: OFFeatureProvider,
     domain: String,
     statusRef: Ref[ProviderStatus],
-    api: Option[OpenFeatureAPI] = None
+    api: Option[OpenFeatureAPI] = None,
+    onReady: Option[java.util.concurrent.CountDownLatch] = None
   ): ZLayer[Scope, Throwable, FeatureFlags] =
     ZLayer.scoped(
       buildAsync(
@@ -540,7 +542,8 @@ object FeatureFlags {
         initialHooks = Nil,
         statusRef = Some(statusRef),
         addShutdownFinalizer = false,
-        apiOverride = api
+        apiOverride = api,
+        onReady = onReady
       )
     )
 

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -24,7 +24,8 @@ final private[openfeature] class FeatureFlagsLive(
   providerName: String,
   domain: Option[String],
   state: FeatureFlagsState,
-  api: OpenFeatureAPI
+  api: OpenFeatureAPI,
+  onReady: Option[java.util.concurrent.CountDownLatch] = None
 ) extends FeatureFlags {
 
   // Bridge Java SDK provider events to ZIO event system
@@ -48,6 +49,7 @@ final private[openfeature] class FeatureFlagsLive(
                 state.eventHub.publish(ProviderEvent.Ready(metadata, em))
             )
             .getOrThrowFiberFailure()
+          onReady.foreach(_.countDown())
         }
 
       val errorHandler: java.util.function.Consumer[EventDetails] = details =>

--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -35,7 +35,7 @@ final class TestFeatureProvider private (
   private val eventsHubRef: Ref[Hub[ProviderEvent]],
   private[openfeature] val statusRef: Ref[ProviderStatus],
   private val initLatch: Option[CountDownLatch],
-  private val initDone: Option[CountDownLatch]
+  private[testkit] val initDone: Option[CountDownLatch]
 ) extends EventProvider {
 
   @scala.annotation.nowarn("msg=deprecated")
@@ -51,7 +51,9 @@ final class TestFeatureProvider private (
       case None        => ()
     }
     state.set(ProviderState.READY)
-    initDone.foreach(_.countDown()) // Signal that initialize() has completed
+    // Note: initDone is NOT counted down here. It is counted down by the event bridge's
+    // readyHandler when the Java SDK fires PROVIDER_READY, ensuring the SDK has fully
+    // processed the initialization before setStatus(Ready) returns.
   }
 
   override def shutdown(): Unit = {
@@ -196,8 +198,9 @@ final class TestFeatureProvider private (
         case ProviderStatus.Ready =>
           state.set(ProviderState.READY)
           initLatch.foreach(_.countDown())
-          // Wait for the Java SDK's background initialize() thread to complete, ensuring
-          // the provider is fully registered before evaluations are attempted.
+          // Wait for the event bridge to receive PROVIDER_READY from the Java SDK.
+          // This confirms the SDK has fully processed the initialization and the
+          // provider is registered as ready — no sleep needed.
           initDone.foreach(_.await())
         case ProviderStatus.NotReady     => state.set(ProviderState.NOT_READY)
         case ProviderStatus.Error        => state.set(ProviderState.ERROR)
@@ -380,7 +383,13 @@ object TestFeatureProvider {
           api    = OpenFeatureAPIFactory.create()
           domain = s"test-async-${java.util.UUID.randomUUID()}"
           featureFlags <- FeatureFlags
-            .fromProviderWithDomainAsync(testProvider, domain, testProvider.statusRef, api = Some(api))
+            .fromProviderWithDomainAsync(
+              testProvider,
+              domain,
+              testProvider.statusRef,
+              api = Some(api),
+              onReady = testProvider.initDone
+            )
             .build
             .map(_.get)
         } yield (testProvider, featureFlags)


### PR DESCRIPTION
## Summary

The "evaluations recover after provider transitions from NotReady to Ready" test in `AsyncInitSpec` intermittently failed on CI. The root cause: `initDone` was counted down inside `initialize()`, but the Java SDK's `ProviderRepository` hadn't finished updating its internal `FeatureProviderStateManager` yet — causing the subsequent evaluation to get a `PROVIDER_NOT_READY` error code.

## Fix

Instead of counting down `initDone` inside `initialize()` (which fires before the SDK is fully ready), the latch is now counted down by the event bridge's `readyHandler` when it receives the `PROVIDER_READY` event from the Java SDK. This is the exact signal that confirms the SDK has fully processed the initialization.

**Flow:**
1. `setStatus(Ready)` releases `initLatch` → `initialize()` completes
2. Java SDK processes the result → updates `ProviderStateManager` → fires `PROVIDER_READY`
3. Event bridge's `readyHandler` fires → counts down `initDone`
4. `setStatus(Ready)` returns — SDK is fully ready, no sleep needed

**Changes:**
- `FeatureFlagsLive` accepts optional `onReady: CountDownLatch` — readyHandler counts it down
- `buildAsync` / `fromProviderWithDomainAsync` thread the latch through
- `TestFeatureProvider.asyncLayer` passes `initDone` as `onReady`
- `initialize()` no longer counts down `initDone`