### PR TITLE
Support recursive merging of StructValue in EvaluationContext

### DIFF
--- a/core/src/main/scala/zio/openfeature/EvaluationContext.scala
+++ b/core/src/main/scala/zio/openfeature/EvaluationContext.scala
@@ -7,7 +7,7 @@ final case class EvaluationContext(
   def merge(other: EvaluationContext): EvaluationContext =
     EvaluationContext(
       targetingKey = other.targetingKey.orElse(targetingKey),
-      attributes = attributes ++ other.attributes
+      attributes = EvaluationContext.mergeAttributes(attributes, other.attributes)
     )
 
   def withTargetingKey(key: String): EvaluationContext =
@@ -34,6 +34,22 @@ final case class EvaluationContext(
 }
 
 object EvaluationContext {
+  private def mergeAttributes(
+    base: Map[String, AttributeValue],
+    overrides: Map[String, AttributeValue]
+  ): Map[String, AttributeValue] =
+    base ++ overrides.map { case (key, overrideVal) =>
+      key -> (base.get(key) match {
+        case Some(AttributeValue.StructValue(baseFields)) =>
+          overrideVal match {
+            case AttributeValue.StructValue(overrideFields) =>
+              AttributeValue.StructValue(mergeAttributes(baseFields, overrideFields))
+            case other => other
+          }
+        case _ => overrideVal
+      })
+    }
+
   val empty: EvaluationContext = EvaluationContext(None, Map.empty)
 
   def apply(targetingKey: String): EvaluationContext =

--- a/core/src/test/scala/zio/openfeature/EvaluationContextSpec.scala
+++ b/core/src/test/scala/zio/openfeature/EvaluationContextSpec.scala
@@ -76,6 +76,56 @@ object EvaluationContextSpec extends ZIOSpecDefault {
 
         val merged = ctx1.merge(ctx2)
         assertTrue(merged.targetingKey.contains("user-1"))
+      },
+      test("merge recursively merges StructValue attributes") {
+        val ctx1 = EvaluationContext.empty.withAttribute(
+          "user",
+          AttributeValue.struct(
+            "name" -> AttributeValue.string("Alice"),
+            "role" -> AttributeValue.string("admin")
+          )
+        )
+        val ctx2 = EvaluationContext.empty.withAttribute(
+          "user",
+          AttributeValue.struct("name" -> AttributeValue.string("Bob"))
+        )
+
+        val merged = ctx1.merge(ctx2)
+        val user   = merged.get("user").flatMap(_.asStruct).get
+        assertTrue(user("name") == AttributeValue.string("Bob")) &&
+        assertTrue(user("role") == AttributeValue.string("admin"))
+      },
+      test("merge replaces StructValue with non-struct override") {
+        val ctx1 = EvaluationContext.empty.withAttribute(
+          "data",
+          AttributeValue.struct("key" -> AttributeValue.string("value"))
+        )
+        val ctx2 = EvaluationContext.empty.withAttribute("data", AttributeValue.string("replaced"))
+
+        val merged = ctx1.merge(ctx2)
+        assertTrue(merged.getString("data").contains("replaced"))
+      },
+      test("merge handles deeply nested StructValue recursion") {
+        val ctx1 = EvaluationContext.empty.withAttribute(
+          "a",
+          AttributeValue.struct(
+            "b" -> AttributeValue.struct(
+              "c" -> AttributeValue.string("deep"),
+              "d" -> AttributeValue.string("keep")
+            )
+          )
+        )
+        val ctx2 = EvaluationContext.empty.withAttribute(
+          "a",
+          AttributeValue.struct(
+            "b" -> AttributeValue.struct("c" -> AttributeValue.string("overridden"))
+          )
+        )
+
+        val merged = ctx1.merge(ctx2)
+        val b      = merged.get("a").flatMap(_.asStruct).get("b").asStruct.get
+        assertTrue(b("c") == AttributeValue.string("overridden")) &&
+        assertTrue(b("d") == AttributeValue.string("keep"))
       }
     ),
     suite("Attribute Operations")(

--- a/docs/context.md
+++ b/docs/context.md
@@ -217,6 +217,23 @@ FeatureFlags.withContext(scopedCtx) {
 }
 ```
 
+### Recursive Struct Merging
+
+Per the OpenFeature specification (section 3.2.3), nested objects are merged recursively rather than replaced entirely. When both the base and overriding context have a `StructValue` attribute with the same key, their fields are merged:
+
+```scala
+val ctx1 = EvaluationContext.empty.withAttribute("user",
+  AttributeValue.struct("name" -> AttributeValue.string("Alice"), "role" -> AttributeValue.string("admin")))
+
+val ctx2 = EvaluationContext.empty.withAttribute("user",
+  AttributeValue.struct("name" -> AttributeValue.string("Bob")))
+
+val merged = ctx1.merge(ctx2)
+// user = {name: "Bob", role: "admin"}  — "role" is preserved from ctx1
+```
+
+Non-struct values still replace entirely, even if the base attribute was a struct.
+
 ### Merge Order
 
 Per the OpenFeature specification, contexts are merged in this order (lowest to highest precedence):


### PR DESCRIPTION
## Summary

- Implements recursive merging for `StructValue` attributes in `EvaluationContext.merge` per OpenFeature spec section 3.2.3
- Previously, merging two contexts with the same `StructValue` key would replace the entire struct; now nested fields are merged recursively
- Non-struct overrides still replace entirely, even if the base was a struct
- Documents the recursive merge behavior in the context docs

## Tests

- `merge recursively merges StructValue attributes` — basic case from the issue
- `merge replaces StructValue with non-struct override` — type mismatch edge case
- `merge handles deeply nested StructValue recursion` — multi-level nesting

Closes #85