### PR TITLE
Add version field to ClientMetadata

### DIFF
--- a/core/src/main/scala-2/zio/openfeature/ProviderEvent.scala
+++ b/core/src/main/scala-2/zio/openfeature/ProviderEvent.scala
@@ -19,19 +19,26 @@ object ProviderMetadata {
   * Per OpenFeature spec requirement 1.2.2, clients must have immutable metadata containing a domain field.
   */
 final case class ClientMetadata(
-  domain: Option[String] = None
+  domain: Option[String] = None,
+  version: Option[String] = None
 ) {
   /** Returns true if this client is bound to a specific domain. */
   def hasDomain: Boolean = domain.isDefined
 
-  override def toString: String = domain.getOrElse("default")
+  override def toString: String = {
+    val base = domain.getOrElse("default")
+    version.fold(base)(v => s"$base@$v")
+  }
 }
 
 object ClientMetadata {
-  val default: ClientMetadata = ClientMetadata(None)
+  val default: ClientMetadata = ClientMetadata(None, None)
 
   def apply(domain: String): ClientMetadata =
-    ClientMetadata(Some(domain))
+    ClientMetadata(Some(domain), None)
+
+  def apply(domain: String, version: String): ClientMetadata =
+    ClientMetadata(Some(domain), Some(version))
 }
 
 /** Type of provider event for use with generic event handlers. */

--- a/core/src/main/scala-3/zio/openfeature/ProviderEvent.scala
+++ b/core/src/main/scala-3/zio/openfeature/ProviderEvent.scala
@@ -17,18 +17,24 @@ object ProviderMetadata:
   * Per OpenFeature spec requirement 1.2.2, clients must have immutable metadata containing a domain field.
   */
 final case class ClientMetadata(
-  domain: Option[String] = None
+  domain: Option[String] = None,
+  version: Option[String] = None
 ):
   /** Returns true if this client is bound to a specific domain. */
   def hasDomain: Boolean = domain.isDefined
 
-  override def toString: String = domain.getOrElse("default")
+  override def toString: String =
+    val base = domain.getOrElse("default")
+    version.fold(base)(v => s"$base@$v")
 
 object ClientMetadata:
-  val default: ClientMetadata = ClientMetadata(None)
+  val default: ClientMetadata = ClientMetadata(None, None)
 
   def apply(domain: String): ClientMetadata =
-    ClientMetadata(Some(domain))
+    ClientMetadata(Some(domain), None)
+
+  def apply(domain: String, version: String): ClientMetadata =
+    ClientMetadata(Some(domain), Some(version))
 
 /** Type of provider event for use with generic event handlers. */
 enum ProviderEventType:

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -394,6 +394,7 @@ object FeatureFlags {
   private def build(
     provider: OFFeatureProvider,
     domain: Option[String],
+    version: Option[String],
     initialHooks: List[FeatureHook],
     statusRef: Option[Ref[ProviderStatus]],
     addShutdownFinalizer: Boolean,
@@ -405,9 +406,10 @@ object FeatureFlags {
         case Some(d) => ZIO.attemptBlocking(api.setProviderAndWait(d, provider))
         case None    => ZIO.attemptBlocking(api.setProviderAndWait(provider))
       }
-      client <- domain match {
-        case Some(d) => ZIO.attempt(api.getClient(d))
-        case None    => ZIO.attempt(api.getClient())
+      client <- (domain, version) match {
+        case (Some(d), Some(v)) => ZIO.attempt(api.getClient(d, v))
+        case (Some(d), None)    => ZIO.attempt(api.getClient(d))
+        case _                  => ZIO.attempt(api.getClient())
       }
       providerName = Option(provider.getMetadata).map(_.getName).getOrElse("unknown")
       baseState <- FeatureFlagsState.make
@@ -415,20 +417,44 @@ object FeatureFlags {
       _ <- state.hooksRef.set(initialHooks)
       _ <- statusRef.fold(state.statusRef.set(ProviderStatus.Ready))(_ => ZIO.unit)
       _ <- ZIO.when(addShutdownFinalizer)(ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore))
-      ff = new FeatureFlagsLive(client, provider, providerName, domain, state, api)
+      ff = new FeatureFlagsLive(client, provider, providerName, domain, version, state, api)
       _ <- ff.startEventBridge
     } yield ff
 
   /** Create a FeatureFlags layer from any OpenFeature provider. */
   def fromProvider(provider: OFFeatureProvider): ZLayer[Scope, Throwable, FeatureFlags] =
     ZLayer.scoped(
-      build(provider, domain = None, initialHooks = Nil, statusRef = None, addShutdownFinalizer = true)
+      build(provider, domain = None, version = None, initialHooks = Nil, statusRef = None, addShutdownFinalizer = true)
     )
 
   /** Create a FeatureFlags layer with a named domain/client. */
   def fromProviderWithDomain(provider: OFFeatureProvider, domain: String): ZLayer[Scope, Throwable, FeatureFlags] =
     ZLayer.scoped(
-      build(provider, domain = Some(domain), initialHooks = Nil, statusRef = None, addShutdownFinalizer = false)
+      build(
+        provider,
+        domain = Some(domain),
+        version = None,
+        initialHooks = Nil,
+        statusRef = None,
+        addShutdownFinalizer = false
+      )
+    )
+
+  /** Create a FeatureFlags layer with a named domain/client and version. */
+  def fromProviderWithDomain(
+    provider: OFFeatureProvider,
+    domain: String,
+    version: String
+  ): ZLayer[Scope, Throwable, FeatureFlags] =
+    ZLayer.scoped(
+      build(
+        provider,
+        domain = Some(domain),
+        version = Some(version),
+        initialHooks = Nil,
+        statusRef = None,
+        addShutdownFinalizer = false
+      )
     )
 
   /** Create a FeatureFlags layer with a named domain/client and a shared status ref. */
@@ -442,6 +468,7 @@ object FeatureFlags {
       build(
         provider,
         domain = Some(domain),
+        version = None,
         initialHooks = Nil,
         statusRef = Some(statusRef),
         addShutdownFinalizer = false,
@@ -470,7 +497,14 @@ object FeatureFlags {
     initialHooks: List[FeatureHook]
   ): ZLayer[Scope, Throwable, FeatureFlags] =
     ZLayer.scoped(
-      build(provider, domain = None, initialHooks = initialHooks, statusRef = None, addShutdownFinalizer = true)
+      build(
+        provider,
+        domain = None,
+        version = None,
+        initialHooks = initialHooks,
+        statusRef = None,
+        addShutdownFinalizer = true
+      )
     )
 
   // Async Factory Methods (non-blocking provider initialization)
@@ -485,6 +519,7 @@ object FeatureFlags {
   private def buildAsync(
     provider: OFFeatureProvider,
     domain: Option[String],
+    version: Option[String],
     initialHooks: List[FeatureHook],
     statusRef: Option[Ref[ProviderStatus]],
     addShutdownFinalizer: Boolean,
@@ -498,16 +533,17 @@ object FeatureFlags {
         case Some(d) => ZIO.succeed(api.setProvider(d, provider))
         case None    => ZIO.succeed(api.setProvider(provider))
       }
-      client <- domain match {
-        case Some(d) => ZIO.attempt(api.getClient(d))
-        case None    => ZIO.attempt(api.getClient())
+      client <- (domain, version) match {
+        case (Some(d), Some(v)) => ZIO.attempt(api.getClient(d, v))
+        case (Some(d), None)    => ZIO.attempt(api.getClient(d))
+        case _                  => ZIO.attempt(api.getClient())
       }
       providerName = Option(provider.getMetadata).map(_.getName).getOrElse("unknown")
       baseState <- FeatureFlagsState.make
       state = statusRef.fold(baseState)(ref => baseState.copy(statusRef = ref))
       _ <- state.hooksRef.set(initialHooks)
       _ <- ZIO.when(addShutdownFinalizer)(ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore))
-      ff = new FeatureFlagsLive(client, provider, providerName, domain, state, api, onReady)
+      ff = new FeatureFlagsLive(client, provider, providerName, domain, version, state, api, onReady)
       // Start event bridge — if provider is already ready, replay fires immediately
       _ <- ff.startEventBridge
     } yield ff
@@ -519,7 +555,14 @@ object FeatureFlags {
     */
   def fromProviderAsync(provider: OFFeatureProvider): ZLayer[Scope, Throwable, FeatureFlags] =
     ZLayer.scoped(
-      buildAsync(provider, domain = None, initialHooks = Nil, statusRef = None, addShutdownFinalizer = true)
+      buildAsync(
+        provider,
+        domain = None,
+        version = None,
+        initialHooks = Nil,
+        statusRef = None,
+        addShutdownFinalizer = true
+      )
     )
 
   /** Create a FeatureFlags layer with a named domain (non-blocking). */
@@ -528,7 +571,31 @@ object FeatureFlags {
     domain: String
   ): ZLayer[Scope, Throwable, FeatureFlags] =
     ZLayer.scoped(
-      buildAsync(provider, domain = Some(domain), initialHooks = Nil, statusRef = None, addShutdownFinalizer = false)
+      buildAsync(
+        provider,
+        domain = Some(domain),
+        version = None,
+        initialHooks = Nil,
+        statusRef = None,
+        addShutdownFinalizer = false
+      )
+    )
+
+  /** Create a FeatureFlags layer with a named domain and version (non-blocking). */
+  def fromProviderWithDomainAsync(
+    provider: OFFeatureProvider,
+    domain: String,
+    version: String
+  ): ZLayer[Scope, Throwable, FeatureFlags] =
+    ZLayer.scoped(
+      buildAsync(
+        provider,
+        domain = Some(domain),
+        version = Some(version),
+        initialHooks = Nil,
+        statusRef = None,
+        addShutdownFinalizer = false
+      )
     )
 
   /** Create a FeatureFlags layer with a named domain and shared status ref (non-blocking). */
@@ -543,6 +610,7 @@ object FeatureFlags {
       buildAsync(
         provider,
         domain = Some(domain),
+        version = None,
         initialHooks = Nil,
         statusRef = Some(statusRef),
         addShutdownFinalizer = false,
@@ -557,7 +625,14 @@ object FeatureFlags {
     initialHooks: List[FeatureHook]
   ): ZLayer[Scope, Throwable, FeatureFlags] =
     ZLayer.scoped(
-      buildAsync(provider, domain = None, initialHooks = initialHooks, statusRef = None, addShutdownFinalizer = true)
+      buildAsync(
+        provider,
+        domain = None,
+        version = None,
+        initialHooks = initialHooks,
+        statusRef = None,
+        addShutdownFinalizer = true
+      )
     )
 
   /** Create a FeatureFlags layer from multiple providers (non-blocking, first-match strategy). */

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -23,6 +23,7 @@ final private[openfeature] class FeatureFlagsLive(
   provider: OFFeatureProvider,
   providerName: String,
   domain: Option[String],
+  version: Option[String],
   state: FeatureFlagsState,
   api: OpenFeatureAPI,
   onReady: Option[java.util.concurrent.CountDownLatch] = None
@@ -138,7 +139,7 @@ final private[openfeature] class FeatureFlagsLive(
       provHooks    <- getProviderHooks
       allHooks   = currentHooks ++ extraHooks ++ provHooks
       metadata   = ProviderMetadata(providerName)
-      clientMeta = ClientMetadata(domain)
+      clientMeta = ClientMetadata(domain, version)
       hookCtx = HookContext(
         flagKey = key,
         flagType = FlagValueType.fromFlagType[A],
@@ -581,7 +582,7 @@ final private[openfeature] class FeatureFlagsLive(
     ZIO.succeed(ProviderMetadata(providerName))
 
   override def clientMetadata: UIO[ClientMetadata] =
-    ZIO.succeed(ClientMetadata(domain))
+    ZIO.succeed(ClientMetadata(domain, version))
 
   // Event Handlers - return cancellation effects per OpenFeature spec 5.2.7
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,6 +117,7 @@ FeatureFlags.fromProvider(provider)
 |:-------|:------------|
 | `fromProvider(provider)` | Create from any OpenFeature provider |
 | `fromProviderWithDomain(provider, domain)` | Create with named domain/client |
+| `fromProviderWithDomain(provider, domain, version)` | Create with domain and version |
 | `fromProviderWithHooks(provider, hooks)` | Create with initial hooks |
 | `fromMultiProvider(providers)` | Combine multiple providers (first-match strategy) |
 | `fromMultiProvider(providers, strategy)` | Combine multiple providers with custom strategy |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -198,6 +198,9 @@ For multi-provider setups, use domains to isolate providers:
 
 ```scala
 val layer = FeatureFlags.fromProviderWithDomain(provider, "my-domain")
+
+// Optionally include a version for telemetry/debugging
+val versionedLayer = FeatureFlags.fromProviderWithDomain(provider, "my-domain", "1.0.0")
 ```
 
 ### With Initial Hooks

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -297,6 +297,21 @@ Create with a named domain. Each domain gets its own client, useful for segmenti
 val layer = FeatureFlags.fromProviderWithDomain(provider, "my-service")
 ```
 
+Optionally include a version string (useful for telemetry and debugging):
+
+```scala
+val layer = FeatureFlags.fromProviderWithDomain(provider, "my-service", "1.2.3")
+```
+
+The version is available via `clientMetadata`:
+
+```scala
+for {
+  meta <- FeatureFlags.clientMetadata
+  _    <- ZIO.logInfo(s"Client: ${meta.domain} version: ${meta.version}")
+} yield ()
+```
+
 > For test isolation, prefer `TestFeatureProvider.layer` which automatically creates isolated API instances.
 
 ### fromProviderWithHooks
@@ -349,6 +364,9 @@ val layer = FeatureFlags.fromProviderAsync(provider)
 
 // With domain
 val domainLayer = FeatureFlags.fromProviderWithDomainAsync(provider, "my-service")
+
+// With domain and version
+val versionedLayer = FeatureFlags.fromProviderWithDomainAsync(provider, "my-service", "1.0.0")
 
 // With hooks
 val hookedLayer = FeatureFlags.fromProviderWithHooksAsync(provider, hooks)

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -150,8 +150,9 @@ FeatureFlags.booleanDetails("flag", false, EvaluationContext.empty, options)
 | Initialize (async) | ✅ | `setProvider` via `fromProviderAsync` variants |
 | Shutdown (1.6.1) | ✅ | Automatic via ZIO Scope finalizer + explicit `shutdown` method |
 | Provider metadata | ✅ | `providerMetadata` returns name and version |
-| Client metadata | ✅ | `clientMetadata` returns domain |
+| Client metadata | ✅ | `clientMetadata` returns domain and version |
 | Domain binding | ✅ | `fromProviderWithDomain` |
+| Client version | ✅ | `fromProviderWithDomain(provider, domain, version)` |
 
 ---
 

--- a/testkit/src/test/scala/zio/openfeature/testkit/FactoryMethodsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FactoryMethodsSpec.scala
@@ -32,6 +32,25 @@ object FactoryMethodsSpec extends ZIOSpecDefault {
         } yield assertTrue(calls == 1)
       }
     ),
+    suite("fromProviderWithDomain")(
+      test("fromProviderWithDomain with version exposes version in clientMetadata") {
+        for {
+          provider <- TestFeatureProvider.make(Map("flag" -> true))
+          domain = s"test-versioned-${java.util.UUID.randomUUID()}"
+          result <- ZIO.scoped {
+            FeatureFlags.fromProviderWithDomain(provider, domain, "2.0.0").build.flatMap { env =>
+              val ff = env.get[FeatureFlags]
+              for {
+                meta <- ff.clientMetadata
+                flag <- ff.boolean("flag", default = false)
+              } yield assertTrue(meta.domain.contains(domain)) &&
+                assertTrue(meta.version.contains("2.0.0")) &&
+                assertTrue(flag == true)
+            }
+          }
+        } yield result
+      }
+    ),
     suite("fromMultiProvider")(
       test("fromMultiProvider creates a usable layer") {
         ZIO.scoped {
@@ -93,6 +112,19 @@ object FactoryMethodsSpec extends ZIOSpecDefault {
           domain = s"test-async-factory-${java.util.UUID.randomUUID()}"
           result <- ZIO.scoped {
             FeatureFlags.fromProviderWithDomainAsync(tp, domain).build.flatMap { env =>
+              val ff = env.get[FeatureFlags]
+              ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
+                ff.boolean("flag", default = false)
+            }
+          }
+        } yield assertTrue(result == true)
+      },
+      test("fromProviderWithDomainAsync with version creates a working layer") {
+        for {
+          tp <- TestFeatureProvider.make(Map("flag" -> true))
+          domain = s"test-async-versioned-${java.util.UUID.randomUUID()}"
+          result <- ZIO.scoped {
+            FeatureFlags.fromProviderWithDomainAsync(tp, domain, "1.2.3").build.flatMap { env =>
               val ff = env.get[FeatureFlags]
               ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
                 ff.boolean("flag", default = false)

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -401,6 +401,11 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
           metadata <- FeatureFlags.clientMetadata
         } yield assertTrue(metadata.hasDomain) &&
           assertTrue(metadata.domain.exists(_.startsWith("test-")))
+      }.provide(testLayer()),
+      test("clientMetadata version is None by default") {
+        for {
+          metadata <- FeatureFlags.clientMetadata
+        } yield assertTrue(metadata.version.isEmpty)
       }.provide(testLayer())
     ),
     suite("Evaluation with Context")(


### PR DESCRIPTION
## Summary

- Adds optional `version: Option[String]` field to `ClientMetadata` (both Scala 2 and Scala 3 sources)
- Adds `fromProviderWithDomain(provider, domain, version)` factory method (sync and async variants)
- Threads version through `build`/`buildAsync` to `FeatureFlagsLive`, which passes it to the Java SDK's `getClient(domain, version)`
- Updates `ClientMetadata.toString` to include version when present (e.g., `my-domain@1.0.0`)
- Updates docs: providers, architecture, getting-started, and spec-compliance

## Tests

- `fromProviderWithDomain with version exposes version in clientMetadata` — sync factory with version
- `fromProviderWithDomainAsync with version creates a working layer` — async factory with version
- `clientMetadata version is None by default` — backwards compatibility

Closes #86