### PR TITLE
Add asyncReadyLayer and layer selection guide

### DIFF
--- a/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
@@ -70,8 +70,8 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
   private def buildWithDomain(provider: SimpleProvider): ZIO[Scope, Throwable, FeatureFlags] = {
     val api    = OpenFeatureAPIFactory.create()
     val domain = s"test-swap-${java.util.UUID.randomUUID()}"
-    FeatureFlags
-      .build(
+    for {
+      ff <- FeatureFlags.build(
         provider,
         domain = Some(domain),
         version = None,
@@ -80,6 +80,10 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
         addShutdownFinalizer = false,
         apiOverride = Some(api)
       )
+      // Wait for the Java SDK's initial PROVIDER_READY event to settle so it doesn't
+      // race with subsequent setProvider calls in tests
+      _ <- ZIO.attemptBlocking(Thread.sleep(50)).ignore
+    } yield ff
   }
 
   def spec = suite("Provider Hot-Swap")(

--- a/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
@@ -4,6 +4,7 @@ import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
   EventProvider,
   Metadata,
+  OpenFeatureAPIFactory,
   ProviderEvaluation,
   ProviderState,
   Value
@@ -66,13 +67,16 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
       ProviderEvaluation.builder[Value]().value(defaultValue).reason("STATIC").build()
   }
 
-  // Use unique domains per test to avoid OpenFeatureAPI singleton pollution
-  private def uniqueDomain: String = s"test-swap-${java.util.UUID.randomUUID()}"
-
-  private def buildWithDomain(provider: SimpleProvider): ZIO[Scope, Throwable, FeatureFlags] = {
-    val domain = uniqueDomain
-    FeatureFlags.fromProviderWithDomain(provider, domain).build.map(_.get[FeatureFlags])
-  }
+  private def buildWithDomain(provider: SimpleProvider): ZIO[Scope, Throwable, FeatureFlags] =
+    for {
+      statusRef <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
+      api    = OpenFeatureAPIFactory.create()
+      domain = s"test-swap-${java.util.UUID.randomUUID()}"
+      ff <- FeatureFlags
+        .fromProviderWithDomain(provider, domain, statusRef, api = Some(api))
+        .build
+        .map(_.get[FeatureFlags])
+    } yield ff
 
   def spec = suite("Provider Hot-Swap")(
     test("setProvider swaps to a new provider") {

--- a/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
@@ -67,16 +67,20 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
       ProviderEvaluation.builder[Value]().value(defaultValue).reason("STATIC").build()
   }
 
-  private def buildWithDomain(provider: SimpleProvider): ZIO[Scope, Throwable, FeatureFlags] =
-    for {
-      statusRef <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
-      api    = OpenFeatureAPIFactory.create()
-      domain = s"test-swap-${java.util.UUID.randomUUID()}"
-      ff <- FeatureFlags
-        .fromProviderWithDomain(provider, domain, statusRef, api = Some(api))
-        .build
-        .map(_.get[FeatureFlags])
-    } yield ff
+  private def buildWithDomain(provider: SimpleProvider): ZIO[Scope, Throwable, FeatureFlags] = {
+    val api    = OpenFeatureAPIFactory.create()
+    val domain = s"test-swap-${java.util.UUID.randomUUID()}"
+    FeatureFlags
+      .build(
+        provider,
+        domain = Some(domain),
+        version = None,
+        initialHooks = Nil,
+        statusRef = None,
+        addShutdownFinalizer = false,
+        apiOverride = Some(api)
+      )
+  }
 
   def spec = suite("Provider Hot-Swap")(
     test("setProvider swaps to a new provider") {

--- a/docs/testkit.md
+++ b/docs/testkit.md
@@ -38,6 +38,19 @@ libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-testkit" % 
 
 ---
 
+## Choosing a Layer
+
+| Layer | Provider starts as | Use when |
+|:------|:-------------------|:---------|
+| `layer(flags)` | `Ready` | Most tests — flags work immediately |
+| `scopedLayer(flags)` | `Ready` | Same, self-contained scope |
+| `asyncLayer(flags)` | `NotReady` | Testing startup/initialization behavior — requires manual `setStatus` |
+| `asyncReadyLayer(flags, delay)` | `NotReady` → `Ready` | Simulating real async init without manual status management |
+
+**Rule of thumb:** Use `layer` unless you specifically need to test how your code handles a provider that isn't ready yet.
+
+---
+
 ## Basic Usage
 
 ### Creating a Test Layer
@@ -352,6 +365,24 @@ test("service works after provider becomes ready") {
 ```
 
 The `asyncLayer` creates a provider that starts in `NotReady` state. Call `setStatus(ProviderStatus.Ready)` to simulate the provider becoming ready. This is useful for testing graceful degradation and startup behavior.
+
+### Simulating Real Async Init
+
+If you don't need to test the `NotReady` state directly, use `asyncReadyLayer` which auto-transitions to `Ready` after a configurable delay:
+
+```scala
+test("service works with async provider") {
+  for
+    _      <- ZIO.sleep(200.millis) // Wait for auto-init
+    result <- MyService.getFeature
+  yield assertTrue(result == true)
+}.provide(Scope.default >>> TestFeatureProvider.asyncReadyLayer(
+  Map("feature" -> true),
+  initDelay = 100.millis
+))
+```
+
+This simulates a real provider (e.g., Optimizely connecting to its server) without requiring manual `setStatus` calls in every test.
 
 ---
 

--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -426,6 +426,40 @@ object TestFeatureProvider {
       }
     } yield provider
 
+  /** Create a FeatureFlags layer with async initialization that auto-transitions to Ready.
+    *
+    * Like `asyncLayer`, the provider starts in NotReady state. After `initDelay`, it automatically transitions to Ready
+    * without manual `setStatus` calls. Useful for simulating a real async provider (e.g., connecting to a remote
+    * service) without needing to manage the state transition in tests.
+    */
+  def asyncReadyLayer(
+    flags: Map[String, Any] = Map.empty,
+    initDelay: Duration = 100.millis
+  ): ZLayer[Scope, Throwable, TestFeatureProvider with FeatureFlags] =
+    ZLayer
+      .scoped {
+        for {
+          testProvider <- makeNotReady(flags)
+          api    = OpenFeatureAPIFactory.create()
+          domain = s"test-async-ready-${java.util.UUID.randomUUID()}"
+          featureFlags <- FeatureFlags
+            .fromProviderWithDomainAsync(
+              testProvider,
+              domain,
+              testProvider.statusRef,
+              api = Some(api),
+              onReady = testProvider.initDone
+            )
+            .build
+            .map(_.get)
+          _ <- (ZIO.sleep(initDelay) *> testProvider.setStatus(ProviderStatus.Ready)).forkScoped
+        } yield (testProvider, featureFlags)
+      }
+      .flatMap { env =>
+        val (testProvider, featureFlags) = env.get[(TestFeatureProvider, FeatureFlags)]
+        ZLayer.succeed(testProvider) ++ ZLayer.succeed(featureFlags)
+      }
+
   /** Self-contained async test layer that provides its own Scope. */
   val scopedAsyncLayer: ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
     Scope.default >>> TestFeatureProvider.asyncLayer

--- a/testkit/src/test/scala/zio/openfeature/testkit/AsyncReadyLayerSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/AsyncReadyLayerSpec.scala
@@ -1,0 +1,35 @@
+package zio.openfeature.testkit
+
+import zio._
+import zio.test._
+import zio.openfeature._
+
+object AsyncReadyLayerSpec extends ZIOSpecDefault {
+
+  private def readyLayer(
+    flags: Map[String, Any],
+    delay: Duration
+  ): ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
+    Scope.default >>> TestFeatureProvider.asyncReadyLayer(flags, delay)
+
+  def spec = suite("asyncReadyLayer")(
+    test("starts in NotReady then auto-transitions to Ready") {
+      for {
+        before <- FeatureFlags.providerStatus
+        _      <- ZIO.sleep(200.millis)
+        after  <- FeatureFlags.providerStatus
+      } yield assertTrue(before == ProviderStatus.NotReady) && assertTrue(after == ProviderStatus.Ready)
+    }.provide(readyLayer(Map.empty, 50.millis)),
+    test("evaluations work after auto-transition") {
+      for {
+        _     <- ZIO.sleep(200.millis)
+        value <- FeatureFlags.boolean("flag", default = false)
+      } yield assertTrue(value == true)
+    }.provide(readyLayer(Map("flag" -> true), 50.millis)),
+    test("evaluations fail before init delay elapses") {
+      for {
+        result <- FeatureFlags.boolean("flag", default = false).either
+      } yield assertTrue(result.isLeft)
+    }.provide(readyLayer(Map("flag" -> true), 10.seconds))
+  ) @@ TestAspect.withLiveClock
+}


### PR DESCRIPTION
## Summary

- Adds `TestFeatureProvider.asyncReadyLayer(flags, initDelay)` that starts in `NotReady` and auto-transitions to `Ready` after a configurable delay, simulating real async provider init without manual `setStatus` calls
- Adds layer selection guide to `docs/testkit.md` with a decision table for choosing the right test layer
- Documents `asyncReadyLayer` usage in the async initialization testing section

Closes #103

## Test plan

- [ ] Provider starts in `NotReady` then auto-transitions to `Ready` after delay
- [ ] Evaluations work after auto-transition completes
- [ ] Evaluations fail with `ProviderNotReady` before init delay elapses