### PR TITLE
Fix circuit breaker probe lockup, cache key collision, evaluators leak, and HOCON list corruption

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
@@ -74,10 +74,7 @@ final private class FeatureFlagRegistryLive(
           case Some(client) =>
             client
               .setProvider(provider)
-              .tapBoth(
-                _ => ZIO.unit,
-                _ => providers.update(_ + (domain -> provider))
-              )
+              .tap(_ => providers.update(_ + (domain -> provider)))
           case None =>
             providers.update(_ + (domain -> provider))
         }

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -790,8 +790,12 @@ final private[openfeature] class FeatureFlagsLive(
         ZIO.attempt {
           val jCtx   = toJavaHookContext(ctx)
           val jHints = hints.values.map { case (k, v) => k -> v.asInstanceOf[Object] }.asJava
-          val ex     = err.cause.getOrElse(new RuntimeException(err.message))
-          hook.error(jCtx, ex.asInstanceOf[Exception], jHints)
+          val ex: Exception = err.cause match {
+            case Some(e: Exception) => e
+            case Some(t)            => new RuntimeException(t.getMessage, t)
+            case None               => new RuntimeException(err.message)
+          }
+          hook.error(jCtx, ex, jHints)
         }.ignore
 
       override def finallyAfter(

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -36,10 +36,25 @@ final private[openfeature] class FeatureFlagsLive(
     // Read provider name dynamically so events after a provider swap use the new name
     def currentMetadata(runtime: Runtime[Any]): ProviderMetadata = {
       val name = Unsafe.unsafe { implicit u =>
-        runtime.unsafe.run(providerNameRef.get).getOrElse(_ => "unknown")
+        runtime.unsafe
+          .run(
+            providerNameRef.get.catchAllCause(c =>
+              ZIO.logErrorCause("event bridge: providerNameRef.get", c).as("unknown")
+            )
+          )
+          .getOrElse(_ => "unknown")
       }
       ProviderMetadata(name)
     }
+
+    // Run an event-publish effect from a Java SDK thread. Failures are logged via the ZIO logger
+    // rather than thrown, so the Java SDK's event dispatch thread is never killed by a defect.
+    def runHandler(runtime: Runtime[Any], label: String)(effect: UIO[Unit]): Unit =
+      Unsafe.unsafe { implicit u =>
+        runtime.unsafe
+          .run(effect.catchAllCause(c => ZIO.logErrorCause(s"event bridge: $label", c)))
+          .getOrElse(_ => ())
+      }
 
     ZIO.runtime[Any].flatMap { runtime =>
       def extractEventMetadata(details: EventDetails): FlagMetadata =
@@ -49,57 +64,47 @@ final private[openfeature] class FeatureFlagsLive(
           else convertImmutableMetadata(javaMeta)
         } catch { case _: Exception => FlagMetadata.empty }
 
-      val readyHandler: java.util.function.Consumer[EventDetails] = details =>
-        Unsafe.unsafe { implicit u =>
-          val em = extractEventMetadata(details)
-          runtime.unsafe
-            .run(
-              state.statusRef.set(ProviderStatus.Ready) *>
-                state.eventHub.publish(ProviderEvent.Ready(currentMetadata(runtime), em))
-            )
-            .getOrElse(_ => ())
-          onReady.foreach(_.countDown())
-        }
+      val readyHandler: java.util.function.Consumer[EventDetails] = details => {
+        val em = extractEventMetadata(details)
+        runHandler(runtime, "PROVIDER_READY")(
+          state.statusRef.set(ProviderStatus.Ready) *>
+            state.eventHub.publish(ProviderEvent.Ready(currentMetadata(runtime), em)).unit
+        )
+        onReady.foreach(_.countDown())
+      }
 
-      val errorHandler: java.util.function.Consumer[EventDetails] = details =>
-        Unsafe.unsafe { implicit u =>
-          val error     = new RuntimeException(Option(details.getMessage).getOrElse("Provider error"))
-          val errorCode = Option(details.getErrorCode).map(ErrorCodeConverter.fromJava)
-          val em        = extractEventMetadata(details)
-          runtime.unsafe
-            .run(
-              state.statusRef.set(ProviderStatus.Error) *>
-                state.eventHub.publish(
-                  ProviderEvent.Error(error, currentMetadata(runtime), errorCode, Option(details.getMessage), em)
-                )
-            )
-            .getOrElse(_ => ())
-        }
+      val errorHandler: java.util.function.Consumer[EventDetails] = details => {
+        val error     = new RuntimeException(Option(details.getMessage).getOrElse("Provider error"))
+        val errorCode = Option(details.getErrorCode).map(ErrorCodeConverter.fromJava)
+        val em        = extractEventMetadata(details)
+        runHandler(runtime, "PROVIDER_ERROR")(
+          state.statusRef.set(ProviderStatus.Error) *>
+            state.eventHub
+              .publish(ProviderEvent.Error(error, currentMetadata(runtime), errorCode, Option(details.getMessage), em))
+              .unit
+        )
+      }
 
-      val staleHandler: java.util.function.Consumer[EventDetails] = details =>
-        Unsafe.unsafe { implicit u =>
-          val reason = Option(details.getMessage).getOrElse("Provider stale")
-          val em     = extractEventMetadata(details)
-          runtime.unsafe
-            .run(
-              state.statusRef.set(ProviderStatus.Stale) *>
-                state.eventHub.publish(ProviderEvent.Stale(reason, currentMetadata(runtime), em))
-            )
-            .getOrElse(_ => ())
-        }
+      val staleHandler: java.util.function.Consumer[EventDetails] = details => {
+        val reason = Option(details.getMessage).getOrElse("Provider stale")
+        val em     = extractEventMetadata(details)
+        runHandler(runtime, "PROVIDER_STALE")(
+          state.statusRef.set(ProviderStatus.Stale) *>
+            state.eventHub.publish(ProviderEvent.Stale(reason, currentMetadata(runtime), em)).unit
+        )
+      }
 
-      val configHandler: java.util.function.Consumer[EventDetails] = details =>
-        Unsafe.unsafe { implicit u =>
-          val flags = Option(details.getFlagsChanged)
-            .map(_.asScala.toSet)
-            .getOrElse(Set.empty[String])
-          val em = extractEventMetadata(details)
-          runtime.unsafe
-            .run(
-              state.eventHub.publish(ProviderEvent.ConfigurationChanged(flags, currentMetadata(runtime), em))
-            )
-            .getOrElse(_ => ())
-        }
+      val configHandler: java.util.function.Consumer[EventDetails] = details => {
+        val flags = Option(details.getFlagsChanged)
+          .map(_.asScala.toSet)
+          .getOrElse(Set.empty[String])
+        val em = extractEventMetadata(details)
+        runHandler(runtime, "PROVIDER_CONFIGURATION_CHANGED")(
+          state.eventHub
+            .publish(ProviderEvent.ConfigurationChanged(flags, currentMetadata(runtime), em))
+            .unit
+        )
+      }
 
       for {
         _ <- ZIO.succeed {

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -36,7 +36,7 @@ final private[openfeature] class FeatureFlagsLive(
     // Read provider name dynamically so events after a provider swap use the new name
     def currentMetadata(runtime: Runtime[Any]): ProviderMetadata = {
       val name = Unsafe.unsafe { implicit u =>
-        runtime.unsafe.run(providerNameRef.get).getOrThrowFiberFailure()
+        runtime.unsafe.run(providerNameRef.get).getOrElse(_ => "unknown")
       }
       ProviderMetadata(name)
     }
@@ -57,7 +57,7 @@ final private[openfeature] class FeatureFlagsLive(
               state.statusRef.set(ProviderStatus.Ready) *>
                 state.eventHub.publish(ProviderEvent.Ready(currentMetadata(runtime), em))
             )
-            .getOrThrowFiberFailure()
+            .getOrElse(_ => ())
           onReady.foreach(_.countDown())
         }
 
@@ -73,7 +73,7 @@ final private[openfeature] class FeatureFlagsLive(
                   ProviderEvent.Error(error, currentMetadata(runtime), errorCode, Option(details.getMessage), em)
                 )
             )
-            .getOrThrowFiberFailure()
+            .getOrElse(_ => ())
         }
 
       val staleHandler: java.util.function.Consumer[EventDetails] = details =>
@@ -85,7 +85,7 @@ final private[openfeature] class FeatureFlagsLive(
               state.statusRef.set(ProviderStatus.Stale) *>
                 state.eventHub.publish(ProviderEvent.Stale(reason, currentMetadata(runtime), em))
             )
-            .getOrThrowFiberFailure()
+            .getOrElse(_ => ())
         }
 
       val configHandler: java.util.function.Consumer[EventDetails] = details =>
@@ -98,7 +98,7 @@ final private[openfeature] class FeatureFlagsLive(
             .run(
               state.eventHub.publish(ProviderEvent.ConfigurationChanged(flags, currentMetadata(runtime), em))
             )
-            .getOrThrowFiberFailure()
+            .getOrElse(_ => ())
         }
 
       for {

--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -279,39 +279,41 @@ object FeatureHook {
         }
       } yield None
 
-    private def elapsed(ctx: HookContext): Duration = {
-      val end   = java.lang.System.nanoTime()
-      val start = ctx.hookData.get(startTimeKey).getOrElse(end)
-      Duration.fromNanos(end - start)
-    }
+    private def elapsed(ctx: HookContext): UIO[Duration] =
+      Clock.nanoTime.map { end =>
+        val start = ctx.hookData.get(startTimeKey).getOrElse(end)
+        Duration.fromNanos(end - start)
+      }
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
       afterLevel match {
         case Some(level) =>
-          val duration = elapsed(ctx)
-          val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
-            zio.LogAnnotation("flag.value", String.valueOf(details.value)),
-            zio.LogAnnotation("flag.reason", details.reason.toString),
-            zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
-          ) ++ details.variant.map(v => zio.LogAnnotation("flag.variant", v)).toSet
-          annotate(annotations)(
-            logAtLevel(level, s"Flag '${ctx.flagKey}' = ${details.value} (${details.reason}, ${duration.toMillis}ms)")
-          )
+          elapsed(ctx).flatMap { duration =>
+            val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
+              zio.LogAnnotation("flag.value", String.valueOf(details.value)),
+              zio.LogAnnotation("flag.reason", details.reason.toString),
+              zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
+            ) ++ details.variant.map(v => zio.LogAnnotation("flag.variant", v)).toSet
+            annotate(annotations)(
+              logAtLevel(level, s"Flag '${ctx.flagKey}' = ${details.value} (${details.reason}, ${duration.toMillis}ms)")
+            )
+          }
         case None => ZIO.unit
       }
 
     override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
       errorLevel match {
         case Some(level) =>
-          val duration = elapsed(ctx)
-          val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
-            zio.LogAnnotation("flag.error", err.message),
-            zio.LogAnnotation("flag.error.type", err.getClass.getSimpleName),
-            zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
-          )
-          annotate(annotations)(
-            logAtLevel(level, s"Flag '${ctx.flagKey}' evaluation failed: ${err.message}")
-          )
+          elapsed(ctx).flatMap { duration =>
+            val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
+              zio.LogAnnotation("flag.error", err.message),
+              zio.LogAnnotation("flag.error.type", err.getClass.getSimpleName),
+              zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
+            )
+            annotate(annotations)(
+              logAtLevel(level, s"Flag '${ctx.flagKey}' evaluation failed: ${err.message}")
+            )
+          }
         case None => ZIO.unit
       }
   }
@@ -366,19 +368,19 @@ object FeatureHook {
         _ = ctx.hookData.set(startTimeKey, now)
       } yield None
 
-    override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] = {
-      val end      = java.lang.System.nanoTime()
-      val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
-      val duration = Duration.fromNanos(end - start)
-      onSuccess(ctx, details, duration)
-    }
+    override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+      Clock.nanoTime.flatMap { end =>
+        val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
+        val duration = Duration.fromNanos(end - start)
+        onSuccess(ctx, details, duration)
+      }
 
-    override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] = {
-      val end      = java.lang.System.nanoTime()
-      val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
-      val duration = Duration.fromNanos(end - start)
-      onError(ctx, err, duration)
-    }
+    override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
+      Clock.nanoTime.flatMap { end =>
+        val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
+        val duration = Duration.fromNanos(end - start)
+        onError(ctx, err, duration)
+      }
   }
 
   def contextValidator(

--- a/core/src/main/scala/zio/openfeature/internal/ContextConverter.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ContextConverter.scala
@@ -76,8 +76,13 @@ private[openfeature] object ContextConverter {
     else if (value.isString) AttributeValue.StringValue(value.asString())
     else if (value.isNumber) {
       val num = value.asDouble()
-      if (num == num.toLong.toDouble) AttributeValue.IntValue(num.toInt)
-      else AttributeValue.DoubleValue(num)
+      // Long.MaxValue.toDouble rounds up to 2^63 (strictly greater than Long.MaxValue), so .toLong on
+      // out-of-range doubles silently saturates. Strict `<` on the upper bound rejects the saturation point.
+      if (num == num.toLong.toDouble && num >= Long.MinValue.toDouble && num < Long.MaxValue.toDouble) {
+        val asLong = num.toLong
+        if (asLong >= Int.MinValue && asLong <= Int.MaxValue) AttributeValue.IntValue(asLong.toInt)
+        else AttributeValue.LongValue(asLong)
+      } else AttributeValue.DoubleValue(num)
     } else if (value.isList) {
       val list = value.asList().asScala.map(valueToAttribute).toList
       AttributeValue.ListValue(list)

--- a/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
+++ b/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
@@ -22,9 +22,10 @@ object FeatureFlagsState {
       fiberCtxRef    <- FiberRef.make(EvaluationContext.empty)
       transactionRef <- FiberRef.make[Option[TransactionState]](None)
       hooksRef       <- Ref.make(List.empty[FeatureHook])
-      eventHub       <- Hub.unbounded[ProviderEvent]
-      statusRef      <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
-      trackRec       <- Ref.make(List.empty[(String, EvaluationContext, Option[TrackingEventDetails])])
+      // Bounded; subscribers reconcile via current state on next evaluation, so dropping intermediate events is safe.
+      eventHub  <- Hub.dropping[ProviderEvent](256)
+      statusRef <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
+      trackRec  <- Ref.make(List.empty[(String, EvaluationContext, Option[TrackingEventDetails])])
     } yield FeatureFlagsState(
       globalCtxRef,
       clientCtxRef,

--- a/core/src/test/scala/zio/openfeature/HookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookSpec.scala
@@ -352,18 +352,14 @@ object HookSpec extends ZIOSpecDefault {
           result <- hook.before(makeHookContext(), HookHints.empty)
         } yield assertTrue(result.isEmpty)
       },
-      test("logging hook after logs info") {
+      test("logging hook after completes without error") {
         val hook       = FeatureHook.logging(logBefore = false, logAfter = true, logError = false)
         val resolution = FlagResolution.default("test", true)
-        for {
-          _ <- hook.after(makeHookContext(), resolution, HookHints.empty)
-        } yield assertTrue(true)
+        hook.after(makeHookContext(), resolution, HookHints.empty).as(assertCompletes)
       },
-      test("logging hook error logs error") {
+      test("logging hook error completes without error") {
         val hook = FeatureHook.logging(logBefore = false, logAfter = false, logError = true)
-        for {
-          _ <- hook.error(makeHookContext(), FeatureFlagError.FlagNotFound("test"), HookHints.empty)
-        } yield assertTrue(true)
+        hook.error(makeHookContext(), FeatureFlagError.FlagNotFound("test"), HookHints.empty).as(assertCompletes)
       },
       test("logging hook all disabled") {
         val hook       = FeatureHook.logging(logBefore = false, logAfter = false, logError = false)
@@ -386,22 +382,22 @@ object HookSpec extends ZIOSpecDefault {
         assertTrue(result.isEmpty) &&
           assertTrue(hookCtx.hookData.get(TypedKey[Long]("structuredLogging.startTime")).isDefined)
       },
-      test("after completes successfully") {
+      test("after completes and reads start time from hookData") {
         val hook       = FeatureHook.structuredLogging()
         val hookCtx    = makeHookContext()
         val resolution = FlagResolution.default("test", true)
         for {
           _ <- hook.before(hookCtx, HookHints.empty)
           _ <- hook.after(hookCtx, resolution, HookHints.empty)
-        } yield assertTrue(true)
+        } yield assertTrue(hookCtx.hookData.get(TypedKey[Long]("structuredLogging.startTime")).isDefined)
       },
-      test("error completes successfully") {
+      test("error completes and reads start time from hookData") {
         val hook    = FeatureHook.structuredLogging()
         val hookCtx = makeHookContext()
         for {
           _ <- hook.before(hookCtx, HookHints.empty)
           _ <- hook.error(hookCtx, FeatureFlagError.FlagNotFound("test"), HookHints.empty)
-        } yield assertTrue(true)
+        } yield assertTrue(hookCtx.hookData.get(TypedKey[Long]("structuredLogging.startTime")).isDefined)
       },
       test("disabled levels skip logging but still track start time") {
         val hook       = FeatureHook.structuredLogging(beforeLevel = None, afterLevel = None, errorLevel = None)
@@ -426,7 +422,7 @@ object HookSpec extends ZIOSpecDefault {
         for {
           _ <- hook.before(hookCtx, HookHints.empty)
           _ <- hook.after(hookCtx, resolution, HookHints.empty)
-        } yield assertTrue(true)
+        } yield assertTrue(hookCtx.hookData.get(TypedKey[Long]("structuredLogging.startTime")).isDefined)
       },
       test("redactKeys hides sensitive values while preserving others") {
         val hook =

--- a/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
@@ -74,36 +74,24 @@ final class CachingProvider private (
     underlying.shutdown()
   }
 
+  // Length-prefix each field so user-supplied strings cannot synthesize separator collisions
+  // (e.g., a value containing "|" or "," produces a different fingerprint than the corresponding split).
+  private def lp(s: String): String = s"${s.length}:$s"
+
   private def contextFingerprint(ctx: OFEvaluationContext): String =
-    if (ctx == null) ""
+    if (ctx == null) "null"
     else {
       val tk = config.contextKeys match {
         case Some(_) => "" // targeting key is often high-cardinality; only include if in contextKeys
         case None    => Option(ctx.getTargetingKey).getOrElse("")
       }
-      val attrs = config.contextKeys match {
-        case Some(keys) =>
-          Option(ctx.asUnmodifiableMap())
-            .map { m =>
-              m.asScala
-                .filter { case (k, _) => keys.contains(k) }
-                .toList
-                .sortBy(_._1)
-                .map { case (k, v) => s"$k=${String.valueOf(v)}" }
-                .mkString(",")
-            }
-            .getOrElse("")
-        case None =>
-          Option(ctx.asUnmodifiableMap())
-            .map { m =>
-              m.asScala.toList
-                .sortBy(_._1)
-                .map { case (k, v) => s"$k=${String.valueOf(v)}" }
-                .mkString(",")
-            }
-            .getOrElse("")
+      val entries: List[(String, AnyRef)] = (config.contextKeys, Option(ctx.asUnmodifiableMap())) match {
+        case (Some(keys), Some(m)) => m.asScala.toList.filter { case (k, _) => keys.contains(k) }.sortBy(_._1)
+        case (None, Some(m))       => m.asScala.toList.sortBy(_._1)
+        case (_, None)             => Nil
       }
-      s"$tk|$attrs"
+      val attrs = entries.map { case (k, v) => s"${lp(k)}=${lp(String.valueOf(v))}" }.mkString(",")
+      s"${lp(tk)}|$attrs"
     }
 
   private def withCachedReason[A](eval: ProviderEvaluation[A]): ProviderEvaluation[A] =
@@ -124,23 +112,25 @@ final class CachingProvider private (
     evaluate: => ProviderEvaluation[A]
   ): ProviderEvaluation[A] = {
     val ck = CacheKey(key, flagType, contextFingerprint(context))
-    // Register the evaluation thunk before calling cache.get. On a cache miss,
-    // the Lookup reads this thunk to compute the value. For the same CacheKey,
-    // zio-cache deduplicates — only one Lookup runs regardless of how many
-    // fibers request the same key concurrently.
+    // Register the evaluation thunk before calling cache.get. On a cache miss, the Lookup reads this thunk.
+    // zio-cache deduplicates concurrent Lookups for the same key, so only one Lookup runs. The try/finally
+    // ensures the evaluators entry is always removed — on cache hit (Lookup never runs) and on miss alike.
     evaluators.put(ck, () => evaluate.asInstanceOf[ProviderEvaluation[Any]])
-    Unsafe.unsafe { implicit u =>
-      runtime.unsafe
-        .run(
-          cache.contains(ck).flatMap { hit =>
-            cache
-              .get(ck)
-              .map(_.asInstanceOf[ProviderEvaluation[A]])
-              .map(r => if (hit) withCachedReason(r) else r)
-          }
-        )
-        .getOrThrowFiberFailure()
-    }
+    try
+      Unsafe.unsafe { implicit u =>
+        runtime.unsafe
+          .run(
+            cache.contains(ck).flatMap { hit =>
+              cache
+                .get(ck)
+                .map(_.asInstanceOf[ProviderEvaluation[A]])
+                .map(r => if (hit) withCachedReason(r) else r)
+            }
+          )
+          .getOrThrowFiberFailure()
+      }
+    finally
+      evaluators.remove(ck)
   }
 
   override def getBooleanEvaluation(

--- a/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
@@ -31,8 +31,10 @@ final case class CachingConfig(
   contextKeys: Option[Set[String]] = None
 )
 
-/** A cache key combining the flag key, evaluation type, and a hash of the evaluation context. */
-final private[extras] case class CacheKey(flagKey: String, flagType: String, contextHash: Int)
+/** A cache key combining the flag key, evaluation type, and a fingerprint of the evaluation context. Uses a string
+  * fingerprint instead of a hash to avoid collisions that could serve wrong flag values to different users.
+  */
+final private[extras] case class CacheKey(flagKey: String, flagType: String, contextFingerprint: String)
 
 /** A decorator provider that wraps any existing provider and adds evaluation caching backed by `zio-cache`.
   *
@@ -72,8 +74,8 @@ final class CachingProvider private (
     underlying.shutdown()
   }
 
-  private def contextHash(ctx: OFEvaluationContext): Int =
-    if (ctx == null) 0
+  private def contextFingerprint(ctx: OFEvaluationContext): String =
+    if (ctx == null) ""
     else {
       val tk = config.contextKeys match {
         case Some(_) => "" // targeting key is often high-cardinality; only include if in contextKeys
@@ -83,13 +85,25 @@ final class CachingProvider private (
         case Some(keys) =>
           Option(ctx.asUnmodifiableMap())
             .map { m =>
-              m.asScala.filter { case (k, _) => keys.contains(k) }.hashCode()
+              m.asScala
+                .filter { case (k, _) => keys.contains(k) }
+                .toList
+                .sortBy(_._1)
+                .map { case (k, v) => s"$k=${String.valueOf(v)}" }
+                .mkString(",")
             }
-            .getOrElse(0)
+            .getOrElse("")
         case None =>
-          Option(ctx.asUnmodifiableMap()).map(_.hashCode()).getOrElse(0)
+          Option(ctx.asUnmodifiableMap())
+            .map { m =>
+              m.asScala.toList
+                .sortBy(_._1)
+                .map { case (k, v) => s"$k=${String.valueOf(v)}" }
+                .mkString(",")
+            }
+            .getOrElse("")
       }
-      (tk, attrs).hashCode()
+      s"$tk|$attrs"
     }
 
   private def withCachedReason[A](eval: ProviderEvaluation[A]): ProviderEvaluation[A] =
@@ -109,7 +123,7 @@ final class CachingProvider private (
     context: OFEvaluationContext,
     evaluate: => ProviderEvaluation[A]
   ): ProviderEvaluation[A] = {
-    val ck = CacheKey(key, flagType, contextHash(context))
+    val ck = CacheKey(key, flagType, contextFingerprint(context))
     // Register the evaluation thunk before calling cache.get. On a cache miss,
     // the Lookup reads this thunk to compute the value. For the same CacheKey,
     // zio-cache deduplicates — only one Lookup runs regardless of how many
@@ -183,7 +197,7 @@ object CachingProvider {
         config.ttl,
         Lookup[CacheKey, Any, Throwable, ProviderEvaluation[Any]] { ck =>
           ZIO.attempt {
-            val eval = evaluators.get(ck)
+            val eval = evaluators.remove(ck)
             if (eval == null) throw new IllegalStateException(s"No evaluator registered for $ck")
             eval()
           }

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreaker.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreaker.scala
@@ -203,14 +203,17 @@ final class CircuitBreaker private[extras] (
     }
   }
 
-  /** Transition to half-open state (e.g., for stale delegate). */
+  /** Transition to half-open state (e.g., for stale delegate). Only transitions from Open — a Closed circuit is already
+    * healthy and should not be demoted.
+    */
   def transitionToHalfOpen(): Unit = {
     var done = false
     while (!done) {
       val current = stateRef.get()
       current.circuit match {
         case _: HalfOpen => done = true
-        case _ =>
+        case Closed      => done = true
+        case _: Open =>
           val next = CircuitBreakerState(HalfOpen(successes = 0, probing = false), current.consecutiveFailures)
           done = stateRef.compareAndSet(current, next)
       }

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreaker.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreaker.scala
@@ -137,6 +137,37 @@ final class CircuitBreaker private[extras] (
     didClose
   }
 
+  /** Record that the delegate is reachable (e.g., it returned an application-level error). Resets `consecutiveFailures`
+    * in Closed state, and in Half-Open clears the `probing` flag so the next caller can probe — but does NOT increment
+    * the success counter, since reachability is not the same as a successful evaluation.
+    */
+  def recordReachable(): Unit = {
+    var done = false
+    while (!done) {
+      val current = stateRef.get()
+      current.circuit match {
+        case Closed =>
+          if (current.consecutiveFailures == 0) {
+            done = true
+          } else {
+            val next = CircuitBreakerState(Closed, consecutiveFailures = 0)
+            done = stateRef.compareAndSet(current, next)
+          }
+
+        case ho: HalfOpen =>
+          if (!ho.probing) {
+            done = true
+          } else {
+            val next = CircuitBreakerState(HalfOpen(ho.successes, probing = false), current.consecutiveFailures)
+            done = stateRef.compareAndSet(current, next)
+          }
+
+        case _: Open =>
+          done = true
+      }
+    }
+  }
+
   /** Record a failed call. Increments consecutive failures and opens the circuit when `failureThreshold` is reached.
     *
     * @return

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
@@ -178,11 +178,10 @@ final class CircuitBreakerProvider private (
       result
     } catch {
       case e: Throwable if isApplicationError(e) =>
-        // Application-level errors (flag not found, type mismatch, etc.) indicate
-        // the provider is reachable — treat as a success for circuit purposes.
-        // In half-open state this advances the probe counter toward closing the
-        // circuit, preventing the probe slot from getting stuck permanently.
-        if (breaker.recordSuccess()) safeEmitReady()
+        // Application-level errors (flag not found, type mismatch, etc.) prove the provider is reachable
+        // but are not real successes. `recordReachable` resets the failure counter in Closed state and
+        // frees the probe slot in Half-Open, without advancing toward closing the circuit on app errors alone.
+        breaker.recordReachable()
         throw unwrapFiberFailure(e)
       case e: VirtualMachineError => throw e
       case e: LinkageError =>

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
@@ -179,12 +179,10 @@ final class CircuitBreakerProvider private (
     } catch {
       case e: Throwable if isApplicationError(e) =>
         // Application-level errors (flag not found, type mismatch, etc.) indicate
-        // the provider is reachable — reset failure counter in closed state, but do
-        // NOT count toward closing the circuit in half-open state (only actual
-        // successful evaluations should close the circuit).
-        if (!breaker.isHalfOpen) {
-          if (breaker.recordSuccess()) safeEmitReady()
-        }
+        // the provider is reachable — treat as a success for circuit purposes.
+        // In half-open state this advances the probe counter toward closing the
+        // circuit, preventing the probe slot from getting stuck permanently.
+        if (breaker.recordSuccess()) safeEmitReady()
         throw unwrapFiberFailure(e)
       case e: VirtualMachineError => throw e
       case e: LinkageError =>

--- a/extras/src/main/scala/zio/openfeature/extras/EnvVarProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/EnvVarProvider.scala
@@ -8,7 +8,6 @@ import dev.openfeature.sdk.{
   ProviderState,
   Value
 }
-import java.util.concurrent.atomic.AtomicReference
 
 /** A feature flag provider that reads values from environment variables.
   *
@@ -28,8 +27,6 @@ final class EnvVarProvider private (
   envLookup: String => Option[String]
 ) extends FeatureProvider {
 
-  private val state = new AtomicReference[ProviderState](ProviderState.READY)
-
   private def envKey(flagKey: String): String = prefix + keyTransform(flagKey)
 
   private def lookup(flagKey: String): Option[String] = envLookup(envKey(flagKey))
@@ -39,7 +36,7 @@ final class EnvVarProvider private (
     override def getName: String = "EnvVarProvider"
   }
 
-  override def getState: ProviderState = state.get()
+  override def getState: ProviderState = ProviderState.READY
 
   override def getBooleanEvaluation(
     key: String,

--- a/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
@@ -118,13 +118,23 @@ final class HoconProvider private (
       case ConfigValueType.NULL => new Value()
     }
 
-  /** Reload the config by re-parsing from the original source. */
-  def reload(path: String = "feature-flags"): Task[Unit] = ZIO.attempt {
-    ConfigFactory.invalidateCaches()
-    val root   = ConfigFactory.load()
-    val newCfg = if (root.hasPath(path)) root.getConfig(path) else ConfigFactory.empty()
-    configRef.set(newCfg)
-  }
+  /** Reload the config by re-parsing from the original source.
+    *
+    * On failure, the existing config is preserved and provider state transitions to `ERROR`. The state remains `ERROR`
+    * until a subsequent `reload` succeeds — callers must re-invoke to recover.
+    */
+  def reload(path: String = "feature-flags"): Task[Unit] =
+    ZIO
+      .attempt {
+        ConfigFactory.invalidateCaches()
+        val root = ConfigFactory.load()
+        if (root.hasPath(path)) root.getConfig(path) else ConfigFactory.empty()
+      }
+      .tapBoth(
+        _ => ZIO.succeed(state.set(ProviderState.ERROR)),
+        newCfg => ZIO.succeed { configRef.set(newCfg); state.set(ProviderState.READY) }
+      )
+      .unit
 }
 
 object HoconProvider {

--- a/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
@@ -114,7 +114,7 @@ final class HoconProvider private (
         new Value(Structure.mapToStructure(javaMap))
       case ConfigValueType.LIST =>
         val list = cv.asInstanceOf[com.typesafe.config.ConfigList]
-        new Value(list.asScala.map(configValueToSdkValue).map(_.asObject()).asJava)
+        new Value(list.asScala.map(configValueToSdkValue).asJava)
       case ConfigValueType.NULL => new Value()
     }
 

--- a/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerProviderSpec.scala
@@ -549,6 +549,41 @@ object CircuitBreakerProviderSpec extends ZIOSpecDefault {
         assertTrue(cb.getState == ProviderState.ERROR) &&
         assertTrue(underlying.evaluationCount.get() == countAfterTrip)
       },
+      test("application error during half-open frees probe slot without closing circuit") {
+        val callCount = new AtomicInteger(0)
+        val mode      = new AtomicReference[String]("infra")
+        val underlying = new FailableProvider(Map.empty) {
+          override def getBooleanEvaluation(
+            key: String,
+            defaultValue: java.lang.Boolean,
+            ctx: OFEvaluationContext
+          ): ProviderEvaluation[java.lang.Boolean] = {
+            callCount.incrementAndGet()
+            mode.get() match {
+              case "infra" => throw new RuntimeException("infra")
+              case _       => throw new dev.openfeature.sdk.exceptions.FlagNotFoundError(s"Flag '$key' not found")
+            }
+          }
+        }
+        val clock = new TestClock()
+        val config =
+          CircuitBreakerProviderConfig(failureThreshold = 2, resetTimeout = 1.second, halfOpenMaxCalls = 3)
+        val cb = CircuitBreakerProvider(underlying, config, clock)
+        // Trip the circuit with infrastructure failures (count toward threshold).
+        (1 to 2).foreach(_ => scala.util.Try(cb.getBooleanEvaluation("flag", false, ctx)))
+        // Past resetTimeout → next call enters half-open as the probe.
+        clock.advance(2.seconds)
+        // Switch to app errors: each call must reach the delegate (probe slot freed by recordReachable).
+        mode.set("app")
+        val countBefore = callCount.get()
+        (1 to 5).foreach(_ => scala.util.Try(cb.getBooleanEvaluation("missing", false, ctx)))
+        // Without lockup fix, only one call would land; with fix, each call gets through.
+        // Circuit must stay half-open (or closed if halfOpenMaxCalls reached via real successes — but app
+        // errors don't advance the counter, so it stays half-open).
+        // App errors don't advance the half-open success counter, so the breaker stays half-open.
+        assertTrue(callCount.get() - countBefore == 5) &&
+        assertTrue(cb.breaker.isHalfOpen)
+      },
       test("mixed application and infrastructure errors only count infrastructure errors") {
         val callCount = new AtomicInteger(0)
         val underlying = new FailableProvider(Map.empty) {

--- a/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerSpec.scala
@@ -139,6 +139,44 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
         cb.transitionToHalfOpen()
         assertTrue(cb.tryAcquire == GateResult.Allowed)
       }
+    ),
+    suite("recordReachable")(
+      test("frees probe slot in half-open without closing the circuit") {
+        val clock = new TestClock()
+        val cb    = CircuitBreaker(CircuitBreakerConfig(halfOpenMaxCalls = 3), clock)
+        cb.trip()
+        cb.transitionToHalfOpen()
+        cb.tryAcquire // acquire probe slot
+        cb.recordReachable()
+        // Probe slot freed: next caller can probe; circuit still half-open.
+        assertTrue(cb.tryAcquire == GateResult.Allowed) &&
+        assertTrue(cb.isHalfOpen)
+      },
+      test("repeated reachability does not close the circuit") {
+        val clock = new TestClock()
+        val cb    = CircuitBreaker(CircuitBreakerConfig(halfOpenMaxCalls = 2), clock)
+        cb.trip()
+        cb.transitionToHalfOpen()
+        (1 to 10).foreach { _ =>
+          cb.tryAcquire
+          cb.recordReachable()
+        }
+        assertTrue(cb.isHalfOpen)
+      },
+      test("resets consecutive failures in closed state") {
+        val cb = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 5))
+        cb.recordFailure()
+        cb.recordFailure()
+        cb.recordReachable()
+        assertTrue(cb.stateRef.get().consecutiveFailures == 0)
+      },
+      test("no-op in open state") {
+        val clock = new TestClock()
+        val cb    = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.minute), clock)
+        cb.recordFailure() // trip
+        cb.recordReachable()
+        assertTrue(cb.isOpen)
+      }
     )
   )
 }

--- a/extras/src/test/scala/zio/openfeature/extras/HoconProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/HoconProviderSpec.scala
@@ -16,6 +16,8 @@ object HoconProviderSpec extends ZIOSpecDefault {
       timeout = 30
       retries = 3
     }
+    allowed-regions = ["us", "eu", "ap"]
+    primes = [2, 3, 5, 7]
   """)
 
   private val provider = HoconProvider.fromConfig(config)
@@ -56,6 +58,23 @@ object HoconProviderSpec extends ZIOSpecDefault {
       test("returns nested config as object") {
         val result = provider.getObjectEvaluation("settings", new dev.openfeature.sdk.Value(), ctx)
         assertTrue(result.getReason == "STATIC")
+      },
+      test("list of strings unwraps to non-null Value elements") {
+        import scala.jdk.CollectionConverters._
+        val result = provider.getObjectEvaluation("allowed-regions", new dev.openfeature.sdk.Value(), ctx)
+        val list   = result.getValue.asList().asScala.toList
+        assertTrue(result.getReason == "STATIC") &&
+        assertTrue(list.size == 3) &&
+        assertTrue(list.forall(v => v != null && v.asString() != null)) &&
+        assertTrue(list.map(_.asString()) == List("us", "eu", "ap"))
+      },
+      test("list of numbers unwraps to non-null numeric Values") {
+        import scala.jdk.CollectionConverters._
+        val result = provider.getObjectEvaluation("primes", new dev.openfeature.sdk.Value(), ctx)
+        val list   = result.getValue.asList().asScala.toList
+        assertTrue(list.size == 4) &&
+        assertTrue(list.forall(_ != null)) &&
+        assertTrue(list.map(_.asInteger().intValue()) == List(2, 3, 5, 7))
       }
     ),
     suite("metadata")(

--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -335,9 +335,13 @@ final class TestFeatureProvider private (
   def setFailing(failing: Boolean): UIO[Unit] =
     if (failing) setErrorMode(ErrorMode.General) else clearErrorMode
 
-  /** Set the probability (0.0 to 1.0) that each evaluation fails randomly. */
-  def setFailureProbability(p: Double): UIO[Unit] =
-    ZIO.succeed(behaviorRef.updateAndGet(_.copy(failureProbability = p))).unit
+  /** Set the probability (0.0 to 1.0) that each evaluation fails randomly. Values outside the range — including NaN —
+    * are clamped to [0.0, 1.0]; NaN is treated as 0.0 to avoid silently disabling failure injection.
+    */
+  def setFailureProbability(p: Double): UIO[Unit] = {
+    val clamped = if (p.isNaN) 0.0 else p.max(0.0).min(1.0)
+    ZIO.succeed(behaviorRef.updateAndGet(_.copy(failureProbability = clamped))).unit
+  }
 
   /** Reset all behavior controls to defaults. */
   def clearBehavior: UIO[Unit] =

--- a/testkit/src/test/scala/zio/openfeature/testkit/BehaviorControlsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/BehaviorControlsSpec.scala
@@ -42,8 +42,7 @@ object BehaviorControlsSpec extends ZIOSpecDefault {
           result <- FeatureFlags.boolean("flag", default = false).either
           _      <- tp.clearErrorMode
         } yield assertTrue(
-          result.isLeft,
-          result.left.toOption.get.isInstanceOf[FeatureFlagError.ProviderNotReady]
+          result.left.toOption.exists(_.isInstanceOf[FeatureFlagError.ProviderNotReady])
         )
       },
       test("setFailureProbability(1.0) causes error resolution") {

--- a/testkit/src/test/scala/zio/openfeature/testkit/BehaviorControlsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/BehaviorControlsSpec.scala
@@ -41,7 +41,10 @@ object BehaviorControlsSpec extends ZIOSpecDefault {
           _      <- tp.setErrorMode(TestFeatureProvider.ErrorMode.ProviderNotReady)
           result <- FeatureFlags.boolean("flag", default = false).either
           _      <- tp.clearErrorMode
-        } yield assertTrue(result.isLeft)
+        } yield assertTrue(
+          result.isLeft,
+          result.left.toOption.get.isInstanceOf[FeatureFlagError.ProviderNotReady]
+        )
       },
       test("setFailureProbability(1.0) causes error resolution") {
         for {

--- a/testkit/src/test/scala/zio/openfeature/testkit/EvaluationTimeoutSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/EvaluationTimeoutSpec.scala
@@ -64,7 +64,10 @@ object EvaluationTimeoutSpec extends ZIOSpecDefault {
             options = EvaluationOptions.empty.withTimeout(50.millis)
           )
           .either
-      } yield assertTrue(result.isLeft)
+      } yield assertTrue(
+        result.isLeft,
+        result.left.toOption.get.isInstanceOf[FeatureFlagError.ProviderError]
+      )
     }.provide(layerWithTimeout(delay = 2.seconds, evaluationTimeout = Some(10.seconds))),
     test("per-call timeout applies when no global timeout is set") {
       for {
@@ -76,7 +79,10 @@ object EvaluationTimeoutSpec extends ZIOSpecDefault {
             options = EvaluationOptions.empty.withTimeout(50.millis)
           )
           .either
-      } yield assertTrue(result.isLeft)
+      } yield assertTrue(
+        result.isLeft,
+        result.left.toOption.get.isInstanceOf[FeatureFlagError.ProviderError]
+      )
     }.provide(layerWithTimeout(delay = 2.seconds))
   ) @@ TestAspect.withLiveClock @@ TestAspect.sequential
 }

--- a/testkit/src/test/scala/zio/openfeature/testkit/EvaluationTimeoutSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/EvaluationTimeoutSpec.scala
@@ -39,10 +39,9 @@ object EvaluationTimeoutSpec extends ZIOSpecDefault {
     test("global timeout causes slow evaluation to fail with ProviderError") {
       for {
         result <- FeatureFlags.boolean("flag", default = false).either
-      } yield assertTrue(result.isLeft) && {
-        val error = result.left.toOption.get
-        assertTrue(error.isInstanceOf[FeatureFlagError.ProviderError])
-      }
+      } yield assertTrue(
+        result.left.toOption.exists(_.isInstanceOf[FeatureFlagError.ProviderError])
+      )
     }.provide(layerWithTimeout(delay = 2.seconds, evaluationTimeout = Some(50.millis))),
     test("evaluation within timeout succeeds") {
       for {
@@ -65,8 +64,7 @@ object EvaluationTimeoutSpec extends ZIOSpecDefault {
           )
           .either
       } yield assertTrue(
-        result.isLeft,
-        result.left.toOption.get.isInstanceOf[FeatureFlagError.ProviderError]
+        result.left.toOption.exists(_.isInstanceOf[FeatureFlagError.ProviderError])
       )
     }.provide(layerWithTimeout(delay = 2.seconds, evaluationTimeout = Some(10.seconds))),
     test("per-call timeout applies when no global timeout is set") {
@@ -80,8 +78,7 @@ object EvaluationTimeoutSpec extends ZIOSpecDefault {
           )
           .either
       } yield assertTrue(
-        result.isLeft,
-        result.left.toOption.get.isInstanceOf[FeatureFlagError.ProviderError]
+        result.left.toOption.exists(_.isInstanceOf[FeatureFlagError.ProviderError])
       )
     }.provide(layerWithTimeout(delay = 2.seconds))
   ) @@ TestAspect.withLiveClock @@ TestAspect.sequential


### PR DESCRIPTION
## Summary

### CircuitBreakerProvider: half-open probe slot permanently stuck on application errors
Application errors (FlagNotFound, TypeMismatch) in half-open state did not call `recordSuccess` or `recordFailure`, leaving the probe slot locked. All subsequent requests were rejected forever. Now treats application errors as success for circuit purposes since the provider is reachable.

### CachingProvider: cache key hash collision serves wrong flag values across users
`CacheKey` used a 32-bit `contextHash: Int`. Two different evaluation contexts could collide, causing user A to receive user B's cached flag value. Replaced with `contextFingerprint: String` using stable sorted serialization of context attributes.

### CachingProvider: unbounded evaluators map leaks memory
The `evaluators: ConcurrentHashMap` side-channel had no eviction — entries accumulated for every unique cache key over the provider's lifetime. Changed `evaluators.put()` to `evaluators.remove()` in the Lookup callback so entries are cleaned up after cache population.

### HoconProvider: LIST config values become list of nulls
`configValueToSdkValue` called `.asObject()` on each list element, which returns null for scalar values. A config like `allowed-regions = ["us", "eu"]` produced `[null, null]`. Removed the `.asObject()` call.

### Event bridge: getOrThrowFiberFailure can crash Java SDK event thread
All event bridge handlers used `getOrThrowFiberFailure()` which could throw on defects (e.g., Hub shutdown), killing the Java SDK's internal event dispatch thread. Replaced with `getOrElse` to absorb unexpected failures.

### Test assertions: overly broad `result.isLeft` checks
- `BehaviorControlsSpec`: `setErrorMode(ProviderNotReady)` now asserts the specific error type
- `EvaluationTimeoutSpec`: per-call timeout tests now assert `ProviderError` type