### PR TITLE
Fix unbounded event Hub, System.nanoTime in hooks, integer overflow, and vacuous test assertions

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
@@ -74,10 +74,7 @@ final private class FeatureFlagRegistryLive(
           case Some(client) =>
             client
               .setProvider(provider)
-              .tapBoth(
-                _ => ZIO.unit,
-                _ => providers.update(_ + (domain -> provider))
-              )
+              .tap(_ => providers.update(_ + (domain -> provider)))
           case None =>
             providers.update(_ + (domain -> provider))
         }

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -790,8 +790,12 @@ final private[openfeature] class FeatureFlagsLive(
         ZIO.attempt {
           val jCtx   = toJavaHookContext(ctx)
           val jHints = hints.values.map { case (k, v) => k -> v.asInstanceOf[Object] }.asJava
-          val ex     = err.cause.getOrElse(new RuntimeException(err.message))
-          hook.error(jCtx, ex.asInstanceOf[Exception], jHints)
+          val ex: Exception = err.cause match {
+            case Some(e: Exception) => e
+            case Some(t)            => new RuntimeException(t.getMessage, t)
+            case None               => new RuntimeException(err.message)
+          }
+          hook.error(jCtx, ex, jHints)
         }.ignore
 
       override def finallyAfter(

--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -279,39 +279,41 @@ object FeatureHook {
         }
       } yield None
 
-    private def elapsed(ctx: HookContext): Duration = {
-      val end   = java.lang.System.nanoTime()
-      val start = ctx.hookData.get(startTimeKey).getOrElse(end)
-      Duration.fromNanos(end - start)
-    }
+    private def elapsed(ctx: HookContext): UIO[Duration] =
+      Clock.nanoTime.map { end =>
+        val start = ctx.hookData.get(startTimeKey).getOrElse(end)
+        Duration.fromNanos(end - start)
+      }
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
       afterLevel match {
         case Some(level) =>
-          val duration = elapsed(ctx)
-          val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
-            zio.LogAnnotation("flag.value", String.valueOf(details.value)),
-            zio.LogAnnotation("flag.reason", details.reason.toString),
-            zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
-          ) ++ details.variant.map(v => zio.LogAnnotation("flag.variant", v)).toSet
-          annotate(annotations)(
-            logAtLevel(level, s"Flag '${ctx.flagKey}' = ${details.value} (${details.reason}, ${duration.toMillis}ms)")
-          )
+          elapsed(ctx).flatMap { duration =>
+            val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
+              zio.LogAnnotation("flag.value", String.valueOf(details.value)),
+              zio.LogAnnotation("flag.reason", details.reason.toString),
+              zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
+            ) ++ details.variant.map(v => zio.LogAnnotation("flag.variant", v)).toSet
+            annotate(annotations)(
+              logAtLevel(level, s"Flag '${ctx.flagKey}' = ${details.value} (${details.reason}, ${duration.toMillis}ms)")
+            )
+          }
         case None => ZIO.unit
       }
 
     override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
       errorLevel match {
         case Some(level) =>
-          val duration = elapsed(ctx)
-          val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
-            zio.LogAnnotation("flag.error", err.message),
-            zio.LogAnnotation("flag.error.type", err.getClass.getSimpleName),
-            zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
-          )
-          annotate(annotations)(
-            logAtLevel(level, s"Flag '${ctx.flagKey}' evaluation failed: ${err.message}")
-          )
+          elapsed(ctx).flatMap { duration =>
+            val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
+              zio.LogAnnotation("flag.error", err.message),
+              zio.LogAnnotation("flag.error.type", err.getClass.getSimpleName),
+              zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
+            )
+            annotate(annotations)(
+              logAtLevel(level, s"Flag '${ctx.flagKey}' evaluation failed: ${err.message}")
+            )
+          }
         case None => ZIO.unit
       }
   }
@@ -366,19 +368,19 @@ object FeatureHook {
         _ = ctx.hookData.set(startTimeKey, now)
       } yield None
 
-    override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] = {
-      val end      = java.lang.System.nanoTime()
-      val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
-      val duration = Duration.fromNanos(end - start)
-      onSuccess(ctx, details, duration)
-    }
+    override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+      Clock.nanoTime.flatMap { end =>
+        val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
+        val duration = Duration.fromNanos(end - start)
+        onSuccess(ctx, details, duration)
+      }
 
-    override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] = {
-      val end      = java.lang.System.nanoTime()
-      val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
-      val duration = Duration.fromNanos(end - start)
-      onError(ctx, err, duration)
-    }
+    override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
+      Clock.nanoTime.flatMap { end =>
+        val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
+        val duration = Duration.fromNanos(end - start)
+        onError(ctx, err, duration)
+      }
   }
 
   def contextValidator(

--- a/core/src/main/scala/zio/openfeature/internal/ContextConverter.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ContextConverter.scala
@@ -76,7 +76,8 @@ private[openfeature] object ContextConverter {
     else if (value.isString) AttributeValue.StringValue(value.asString())
     else if (value.isNumber) {
       val num = value.asDouble()
-      if (num == num.toLong.toDouble) AttributeValue.IntValue(num.toInt)
+      if (num == num.toLong.toDouble && num >= Int.MinValue && num <= Int.MaxValue) AttributeValue.IntValue(num.toInt)
+      else if (num == num.toLong.toDouble) AttributeValue.LongValue(num.toLong)
       else AttributeValue.DoubleValue(num)
     } else if (value.isList) {
       val list = value.asList().asScala.map(valueToAttribute).toList

--- a/core/src/main/scala/zio/openfeature/internal/ContextConverter.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ContextConverter.scala
@@ -76,9 +76,13 @@ private[openfeature] object ContextConverter {
     else if (value.isString) AttributeValue.StringValue(value.asString())
     else if (value.isNumber) {
       val num = value.asDouble()
-      if (num == num.toLong.toDouble && num >= Int.MinValue && num <= Int.MaxValue) AttributeValue.IntValue(num.toInt)
-      else if (num == num.toLong.toDouble) AttributeValue.LongValue(num.toLong)
-      else AttributeValue.DoubleValue(num)
+      // Long.MaxValue.toDouble rounds up to 2^63 (strictly greater than Long.MaxValue), so .toLong on
+      // out-of-range doubles silently saturates. Strict `<` on the upper bound rejects the saturation point.
+      if (num == num.toLong.toDouble && num >= Long.MinValue.toDouble && num < Long.MaxValue.toDouble) {
+        val asLong = num.toLong
+        if (asLong >= Int.MinValue && asLong <= Int.MaxValue) AttributeValue.IntValue(asLong.toInt)
+        else AttributeValue.LongValue(asLong)
+      } else AttributeValue.DoubleValue(num)
     } else if (value.isList) {
       val list = value.asList().asScala.map(valueToAttribute).toList
       AttributeValue.ListValue(list)

--- a/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
+++ b/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
@@ -22,7 +22,7 @@ object FeatureFlagsState {
       fiberCtxRef    <- FiberRef.make(EvaluationContext.empty)
       transactionRef <- FiberRef.make[Option[TransactionState]](None)
       hooksRef       <- Ref.make(List.empty[FeatureHook])
-      eventHub       <- Hub.unbounded[ProviderEvent]
+      eventHub       <- Hub.dropping[ProviderEvent](256)
       statusRef      <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
       trackRec       <- Ref.make(List.empty[(String, EvaluationContext, Option[TrackingEventDetails])])
     } yield FeatureFlagsState(

--- a/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
+++ b/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
@@ -22,9 +22,10 @@ object FeatureFlagsState {
       fiberCtxRef    <- FiberRef.make(EvaluationContext.empty)
       transactionRef <- FiberRef.make[Option[TransactionState]](None)
       hooksRef       <- Ref.make(List.empty[FeatureHook])
-      eventHub       <- Hub.dropping[ProviderEvent](256)
-      statusRef      <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
-      trackRec       <- Ref.make(List.empty[(String, EvaluationContext, Option[TrackingEventDetails])])
+      // Bounded; subscribers reconcile via current state on next evaluation, so dropping intermediate events is safe.
+      eventHub  <- Hub.dropping[ProviderEvent](256)
+      statusRef <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
+      trackRec  <- Ref.make(List.empty[(String, EvaluationContext, Option[TrackingEventDetails])])
     } yield FeatureFlagsState(
       globalCtxRef,
       clientCtxRef,

--- a/core/src/test/scala/zio/openfeature/HookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookSpec.scala
@@ -352,18 +352,14 @@ object HookSpec extends ZIOSpecDefault {
           result <- hook.before(makeHookContext(), HookHints.empty)
         } yield assertTrue(result.isEmpty)
       },
-      test("logging hook after logs info") {
+      test("logging hook after completes without error") {
         val hook       = FeatureHook.logging(logBefore = false, logAfter = true, logError = false)
         val resolution = FlagResolution.default("test", true)
-        for {
-          _ <- hook.after(makeHookContext(), resolution, HookHints.empty)
-        } yield assertTrue(true)
+        hook.after(makeHookContext(), resolution, HookHints.empty).as(assertCompletes)
       },
-      test("logging hook error logs error") {
+      test("logging hook error completes without error") {
         val hook = FeatureHook.logging(logBefore = false, logAfter = false, logError = true)
-        for {
-          _ <- hook.error(makeHookContext(), FeatureFlagError.FlagNotFound("test"), HookHints.empty)
-        } yield assertTrue(true)
+        hook.error(makeHookContext(), FeatureFlagError.FlagNotFound("test"), HookHints.empty).as(assertCompletes)
       },
       test("logging hook all disabled") {
         val hook       = FeatureHook.logging(logBefore = false, logAfter = false, logError = false)
@@ -386,22 +382,22 @@ object HookSpec extends ZIOSpecDefault {
         assertTrue(result.isEmpty) &&
           assertTrue(hookCtx.hookData.get(TypedKey[Long]("structuredLogging.startTime")).isDefined)
       },
-      test("after completes successfully") {
+      test("after completes and reads start time from hookData") {
         val hook       = FeatureHook.structuredLogging()
         val hookCtx    = makeHookContext()
         val resolution = FlagResolution.default("test", true)
         for {
           _ <- hook.before(hookCtx, HookHints.empty)
           _ <- hook.after(hookCtx, resolution, HookHints.empty)
-        } yield assertTrue(true)
+        } yield assertTrue(hookCtx.hookData.get(TypedKey[Long]("structuredLogging.startTime")).isDefined)
       },
-      test("error completes successfully") {
+      test("error completes and reads start time from hookData") {
         val hook    = FeatureHook.structuredLogging()
         val hookCtx = makeHookContext()
         for {
           _ <- hook.before(hookCtx, HookHints.empty)
           _ <- hook.error(hookCtx, FeatureFlagError.FlagNotFound("test"), HookHints.empty)
-        } yield assertTrue(true)
+        } yield assertTrue(hookCtx.hookData.get(TypedKey[Long]("structuredLogging.startTime")).isDefined)
       },
       test("disabled levels skip logging but still track start time") {
         val hook       = FeatureHook.structuredLogging(beforeLevel = None, afterLevel = None, errorLevel = None)
@@ -426,7 +422,7 @@ object HookSpec extends ZIOSpecDefault {
         for {
           _ <- hook.before(hookCtx, HookHints.empty)
           _ <- hook.after(hookCtx, resolution, HookHints.empty)
-        } yield assertTrue(true)
+        } yield assertTrue(hookCtx.hookData.get(TypedKey[Long]("structuredLogging.startTime")).isDefined)
       },
       test("redactKeys hides sensitive values while preserving others") {
         val hook =

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreaker.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreaker.scala
@@ -203,14 +203,17 @@ final class CircuitBreaker private[extras] (
     }
   }
 
-  /** Transition to half-open state (e.g., for stale delegate). */
+  /** Transition to half-open state (e.g., for stale delegate). Only transitions from Open — a Closed circuit is already
+    * healthy and should not be demoted.
+    */
   def transitionToHalfOpen(): Unit = {
     var done = false
     while (!done) {
       val current = stateRef.get()
       current.circuit match {
         case _: HalfOpen => done = true
-        case _ =>
+        case Closed      => done = true
+        case _: Open =>
           val next = CircuitBreakerState(HalfOpen(successes = 0, probing = false), current.consecutiveFailures)
           done = stateRef.compareAndSet(current, next)
       }

--- a/extras/src/main/scala/zio/openfeature/extras/EnvVarProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/EnvVarProvider.scala
@@ -8,7 +8,6 @@ import dev.openfeature.sdk.{
   ProviderState,
   Value
 }
-import java.util.concurrent.atomic.AtomicReference
 
 /** A feature flag provider that reads values from environment variables.
   *
@@ -28,8 +27,6 @@ final class EnvVarProvider private (
   envLookup: String => Option[String]
 ) extends FeatureProvider {
 
-  private val state = new AtomicReference[ProviderState](ProviderState.READY)
-
   private def envKey(flagKey: String): String = prefix + keyTransform(flagKey)
 
   private def lookup(flagKey: String): Option[String] = envLookup(envKey(flagKey))
@@ -39,7 +36,7 @@ final class EnvVarProvider private (
     override def getName: String = "EnvVarProvider"
   }
 
-  override def getState: ProviderState = state.get()
+  override def getState: ProviderState = ProviderState.READY
 
   override def getBooleanEvaluation(
     key: String,

--- a/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
@@ -118,7 +118,11 @@ final class HoconProvider private (
       case ConfigValueType.NULL => new Value()
     }
 
-  /** Reload the config by re-parsing from the original source. Sets state to ERROR on failure. */
+  /** Reload the config by re-parsing from the original source.
+    *
+    * On failure, the existing config is preserved and provider state transitions to `ERROR`. The state remains `ERROR`
+    * until a subsequent `reload` succeeds — callers must re-invoke to recover.
+    */
   def reload(path: String = "feature-flags"): Task[Unit] =
     ZIO
       .attempt {

--- a/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
@@ -118,13 +118,19 @@ final class HoconProvider private (
       case ConfigValueType.NULL => new Value()
     }
 
-  /** Reload the config by re-parsing from the original source. */
-  def reload(path: String = "feature-flags"): Task[Unit] = ZIO.attempt {
-    ConfigFactory.invalidateCaches()
-    val root   = ConfigFactory.load()
-    val newCfg = if (root.hasPath(path)) root.getConfig(path) else ConfigFactory.empty()
-    configRef.set(newCfg)
-  }
+  /** Reload the config by re-parsing from the original source. Sets state to ERROR on failure. */
+  def reload(path: String = "feature-flags"): Task[Unit] =
+    ZIO
+      .attempt {
+        ConfigFactory.invalidateCaches()
+        val root = ConfigFactory.load()
+        if (root.hasPath(path)) root.getConfig(path) else ConfigFactory.empty()
+      }
+      .tapBoth(
+        _ => ZIO.succeed(state.set(ProviderState.ERROR)),
+        newCfg => ZIO.succeed { configRef.set(newCfg); state.set(ProviderState.READY) }
+      )
+      .unit
 }
 
 object HoconProvider {

--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -335,9 +335,9 @@ final class TestFeatureProvider private (
   def setFailing(failing: Boolean): UIO[Unit] =
     if (failing) setErrorMode(ErrorMode.General) else clearErrorMode
 
-  /** Set the probability (0.0 to 1.0) that each evaluation fails randomly. */
+  /** Set the probability (0.0 to 1.0) that each evaluation fails randomly. Values are clamped to [0.0, 1.0]. */
   def setFailureProbability(p: Double): UIO[Unit] =
-    ZIO.succeed(behaviorRef.updateAndGet(_.copy(failureProbability = p))).unit
+    ZIO.succeed(behaviorRef.updateAndGet(_.copy(failureProbability = p.max(0.0).min(1.0)))).unit
 
   /** Reset all behavior controls to defaults. */
   def clearBehavior: UIO[Unit] =

--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -335,9 +335,13 @@ final class TestFeatureProvider private (
   def setFailing(failing: Boolean): UIO[Unit] =
     if (failing) setErrorMode(ErrorMode.General) else clearErrorMode
 
-  /** Set the probability (0.0 to 1.0) that each evaluation fails randomly. Values are clamped to [0.0, 1.0]. */
-  def setFailureProbability(p: Double): UIO[Unit] =
-    ZIO.succeed(behaviorRef.updateAndGet(_.copy(failureProbability = p.max(0.0).min(1.0)))).unit
+  /** Set the probability (0.0 to 1.0) that each evaluation fails randomly. Values outside the range — including NaN —
+    * are clamped to [0.0, 1.0]; NaN is treated as 0.0 to avoid silently disabling failure injection.
+    */
+  def setFailureProbability(p: Double): UIO[Unit] = {
+    val clamped = if (p.isNaN) 0.0 else p.max(0.0).min(1.0)
+    ZIO.succeed(behaviorRef.updateAndGet(_.copy(failureProbability = clamped))).unit
+  }
 
   /** Reset all behavior controls to defaults. */
   def clearBehavior: UIO[Unit] =


### PR DESCRIPTION
## Summary

### Hub.unbounded replaced with Hub.dropping(256)
`FeatureFlagsState` used `Hub.unbounded` for provider events, growing without limit when subscribers are slow or absent. Replaced with `Hub.dropping(256)` — missing an intermediate event is acceptable since the next evaluation picks up current state.

### System.nanoTime replaced with Clock.nanoTime in hooks
`structuredLogging` and `metricsDetailed` hooks called `java.lang.System.nanoTime()` directly in `after`/`error` callbacks, bypassing ZIO's Clock and breaking testability with TestClock. Now uses `Clock.nanoTime` consistently (matching `before` which already did).

### ContextConverter integer overflow for large values
`valueToAttribute` converted whole-number doubles via `.toInt`, silently overflowing for values > `Int.MaxValue` (e.g., Unix timestamps). Now produces `LongValue` for values outside Int range.

### Java hook error callback ClassCastException
`wrapJavaHook` used `asInstanceOf[Exception]` on the error cause, which throws `ClassCastException` for `Error` subclasses. Now wraps non-Exception `Throwable` in `RuntimeException`.

### Registry tapBoth with no-op error arm
`FeatureFlagRegistryLive.setProvider` used `tapBoth` with `_ => ZIO.unit` as the error handler. Replaced with `.tap` which expresses the intent more clearly.

### CircuitBreaker.transitionToHalfOpen demotes Closed circuit
The CAS loop's `case _` arm matched `Closed`, demoting a healthy circuit to half-open. Added explicit `case Closed => done = true` to preserve healthy state.

### HoconProvider.reload silently serves stale config on failure
If `ConfigFactory.load()` threw during reload, provider state stayed `READY` with stale config. Now sets state to `ERROR` on failure and `READY` on success.

### EnvVarProvider dead AtomicReference field
`state: AtomicReference[ProviderState]` was declared but never updated. Replaced `getState` with a direct `ProviderState.READY` return and removed the unused field.

### TestFeatureProvider failureProbability accepts invalid values
`setFailureProbability` accepted values outside [0.0, 1.0] — e.g., 1.5 caused constant failures with no indication why. Values are now clamped to [0.0, 1.0].

### Vacuous test assertions replaced
Multiple HookSpec tests for logging/structuredLogging had `assertTrue(true)` as the only assertion. Now assert that `hookData` contains the expected start time entry, or use `assertCompletes`.
