### PR TITLE
Fix FlagValueType Long/Float mapping, refine ZIO idioms, and optimize runloop usage

### DIFF
--- a/core/src/main/scala-2/zio/openfeature/FlagValueType.scala
+++ b/core/src/main/scala-2/zio/openfeature/FlagValueType.scala
@@ -24,6 +24,8 @@ object FlagValueType {
       case "Boolean" => Boolean
       case "String"  => String
       case "Int"     => Int
+      case "Long"    => Int
+      case "Float"   => Double
       case "Double"  => Double
       case _         => Object
     }

--- a/core/src/main/scala-3/zio/openfeature/FlagValueType.scala
+++ b/core/src/main/scala-3/zio/openfeature/FlagValueType.scala
@@ -17,5 +17,7 @@ object FlagValueType:
       case "Boolean" => Boolean
       case "String"  => String
       case "Int"     => Int
+      case "Long"    => Int
+      case "Float"   => Double
       case "Double"  => Double
       case _         => Object

--- a/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
@@ -60,31 +60,28 @@ final private class FeatureFlagRegistryLive(
 
   override def getClient(domain: String): UIO[FeatureFlags] =
     lock.withPermit {
-      clients.get.map(_.get(domain)).flatMap {
-        case Some(c) => ZIO.succeed(c)
+      clients.get.flatMap(_.get(domain) match {
+        case Some(c) => Exit.succeed(c)
         case None    => createDomainClient(domain)
-      }
+      })
     }
 
   override def setProvider(domain: String, provider: OFFeatureProvider): IO[FeatureFlagError, Unit] =
     lock.withPermit {
-      for {
-        existing <- clients.get.map(_.get(domain))
-        _ <- existing match {
-          case Some(client) =>
-            client
-              .setProvider(provider)
-              .tap(_ => providers.update(_ + (domain -> provider)))
-          case None =>
-            providers.update(_ + (domain -> provider))
-        }
-      } yield ()
+      clients.get.flatMap(_.get(domain) match {
+        case Some(client) =>
+          client
+            .setProvider(provider)
+            .tap(_ => providers.update(_ + (domain -> provider)))
+        case None =>
+          providers.update(_ + (domain -> provider))
+      })
     }
 
   override def defaultClient: UIO[FeatureFlags] =
     lock.withPermit {
       defaultRef.get.flatMap {
-        case Some(c) => ZIO.succeed(c)
+        case Some(c) => Exit.succeed(c)
         case None    => createDefaultClient
       }
     }

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -5,18 +5,20 @@ import zio.stream._
 import zio.openfeature.internal.{ClientEvaluator, ContextConverter, ErrorCodeConverter, FeatureFlagsState}
 import dev.openfeature.sdk.{
   Client => OFClient,
-  FeatureProvider => OFFeatureProvider,
-  FlagEvaluationDetails,
-  Reason => OFReason,
   ErrorCode => OFErrorCode,
-  OpenFeatureAPI,
-  MutableTrackingEventDetails,
-  ProviderEvent => JavaProviderEvent,
-  EventDetails,
+  FeatureProvider => OFFeatureProvider,
   FlagValueType => JavaFlagValueType,
-  HookContext => JavaHookContext
+  HookContext => JavaHookContext,
+  ProviderEvent => JavaProviderEvent,
+  Reason => OFReason,
+  EventDetails,
+  FlagEvaluationDetails,
+  MutableTrackingEventDetails,
+  OpenFeatureAPI
 }
+
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 final private[openfeature] class FeatureFlagsLive(
   client: OFClient,
@@ -77,7 +79,9 @@ final private[openfeature] class FeatureFlagsLive(
           val javaMeta = details.getEventMetadata
           if (javaMeta == null || javaMeta.isEmpty) FlagMetadata.empty
           else convertImmutableMetadata(javaMeta)
-        } catch { case _: Exception => FlagMetadata.empty }
+        } catch {
+          case _: Exception => FlagMetadata.empty
+        }
 
       val readyHandler: java.util.function.Consumer[EventDetails] = details => {
         val em = extractEventMetadata(details)
@@ -227,7 +231,7 @@ final private[openfeature] class FeatureFlagsLive(
       case ProviderStatus.Fatal    => ZIO.fail(FeatureFlagError.ProviderFatal)
       case ProviderStatus.NotReady => ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.NotReady))
       case ProviderStatus.Error    => ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.Error))
-      case _                       => ZIO.unit
+      case _                       => Exit.unit
     }
 
   // Context is already merged by evaluateWithDetails before entering the hook pipeline
@@ -610,7 +614,7 @@ final private[openfeature] class FeatureFlagsLive(
   override def currentEvaluatedFlags: UIO[Map[String, zio.openfeature.FlagEvaluation[_]]] =
     state.transactionRef.get.flatMap {
       case Some(ts) => ts.getEvaluations
-      case None     => ZIO.succeed(Map.empty)
+      case None     => Exit.succeed(Map.empty)
     }
 
   override def events: ZStream[Any, Nothing, ProviderEvent] =
@@ -722,13 +726,16 @@ final private[openfeature] class FeatureFlagsLive(
 
   private def getProviderHooks: UIO[List[FeatureHook]] =
     providerRef.get.flatMap { p =>
-      ZIO
-        .attempt {
-          val javaHooks = p.getProviderHooks
+      try {
+        val javaHooks = p.getProviderHooks
+        val res =
           if (javaHooks == null || javaHooks.isEmpty) Nil
           else javaHooks.asScala.toList.map(wrapJavaHook)
-        }
-        .catchAll(e => ZIO.logWarning(s"Failed to get provider hooks: ${e.getMessage}").as(Nil))
+        Exit.succeed(res)
+      } catch {
+        case NonFatal(e) =>
+          ZIO.logWarningCause(s"Failed to get provider hooks", Cause.fail(e)).as(Nil)
+      }
     }
 
   @scala.annotation.nowarn("msg=deprecated")
@@ -773,8 +780,8 @@ final private[openfeature] class FeatureFlagsLive(
     val hook = javaHook.asInstanceOf[dev.openfeature.sdk.Hook[Any]]
     new FeatureHook {
       override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
-        ZIO
-          .attempt {
+        ZIO.succeed {
+          try {
             val jCtx   = toJavaHookContext(ctx)
             val jHints = hints.values.map { case (k, v) => k -> v.asInstanceOf[Object] }.asJava
             val result = hook.before(jCtx, jHints)
@@ -782,8 +789,8 @@ final private[openfeature] class FeatureFlagsLive(
               val newCtx = fromJavaEvaluationContext(result.get())
               Some((newCtx, hints))
             } else None
-          }
-          .catchAll(_ => ZIO.none)
+          } catch { case NonFatal(_) => None }
+        }
 
       override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
         ZIO.attempt {
@@ -860,15 +867,13 @@ final private[openfeature] class FeatureFlagsLive(
   // Shutdown API (spec 1.6.1, 1.6.2)
 
   override def shutdown: UIO[Unit] =
-    ZIO.collectAllParDiscard(
-      List(
-        state.statusRef.set(ProviderStatus.NotReady),
-        state.hooksRef.set(List.empty),
-        state.globalContextRef.set(EvaluationContext.empty),
-        state.clientContextRef.set(EvaluationContext.empty),
-        state.trackRecorder.set(List.empty)
-      )
-    ) *> state.eventHub.shutdown *> ZIO.attemptBlocking(api.shutdown()).ignore
+    state.statusRef.set(ProviderStatus.NotReady) *>
+      state.hooksRef.set(List.empty) *>
+      state.globalContextRef.set(EvaluationContext.empty) *>
+      state.clientContextRef.set(EvaluationContext.empty) *>
+      state.trackRecorder.set(List.empty) *>
+      state.eventHub.shutdown *>
+      ZIO.attemptBlocking(api.shutdown()).ignore
 
   // Tracking API
 

--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -49,9 +49,6 @@ final class HookData {
   def getOrElse[A](key: TypedKey[A], default: => A): A =
     get(key).getOrElse(default)
 
-  private[openfeature] def getOrNull(key: TypedKey[_]): Any =
-    data.get().getOrElse(key.name, null)
-
   def remove[A](key: TypedKey[A]): Unit = {
     data.updateAndGet(_ - key.name)
     ()
@@ -270,50 +267,53 @@ object FeatureHook {
     // so that `before` can return None and avoid corrupting the compose pipeline's
     // context-modified tracking.
     override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
-      ZIO.suspendSucceed {
-        ctx.hookData.set(startTimeKey, java.lang.System.nanoTime())
-        beforeLevel match {
+      for {
+        now <- Clock.nanoTime
+        _ = ctx.hookData.set(startTimeKey, now)
+        _ <- beforeLevel match {
           case Some(level) =>
             annotate(baseAnnotations(ctx) ++ contextAnnotations(ctx))(
               logAtLevel(level, s"Evaluating flag '${ctx.flagKey}'")
-            ).as(None)
-          case None => Exit.none
+            )
+          case None => ZIO.unit
         }
-      }
+      } yield None
 
-    private def elapsed(ctx: HookContext): Duration =
-      ctx.hookData.getOrNull(startTimeKey) match {
-        case null  => Duration.Zero
-        case start => Duration.fromNanos(java.lang.System.nanoTime() - start.asInstanceOf[Long])
+    private def elapsed(ctx: HookContext): UIO[Duration] =
+      Clock.nanoTime.map { end =>
+        val start = ctx.hookData.get(startTimeKey).getOrElse(end)
+        Duration.fromNanos(end - start)
       }
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
       afterLevel match {
         case Some(level) =>
-          val duration = elapsed(ctx)
-          val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
-            zio.LogAnnotation("flag.value", String.valueOf(details.value)),
-            zio.LogAnnotation("flag.reason", details.reason.toString),
-            zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
-          ) ++ details.variant.map(v => zio.LogAnnotation("flag.variant", v)).toSet
-          annotate(annotations)(
-            logAtLevel(level, s"Flag '${ctx.flagKey}' = ${details.value} (${details.reason}, ${duration.toMillis}ms)")
-          )
+          elapsed(ctx).flatMap { duration =>
+            val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
+              zio.LogAnnotation("flag.value", String.valueOf(details.value)),
+              zio.LogAnnotation("flag.reason", details.reason.toString),
+              zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
+            ) ++ details.variant.map(v => zio.LogAnnotation("flag.variant", v)).toSet
+            annotate(annotations)(
+              logAtLevel(level, s"Flag '${ctx.flagKey}' = ${details.value} (${details.reason}, ${duration.toMillis}ms)")
+            )
+          }
         case None => ZIO.unit
       }
 
     override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
       errorLevel match {
         case Some(level) =>
-          val duration = elapsed(ctx)
-          val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
-            zio.LogAnnotation("flag.error", err.message),
-            zio.LogAnnotation("flag.error.type", err.getClass.getSimpleName),
-            zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
-          )
-          annotate(annotations)(
-            logAtLevel(level, s"Flag '${ctx.flagKey}' evaluation failed: ${err.message}")
-          )
+          elapsed(ctx).flatMap { duration =>
+            val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
+              zio.LogAnnotation("flag.error", err.message),
+              zio.LogAnnotation("flag.error.type", err.getClass.getSimpleName),
+              zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
+            )
+            annotate(annotations)(
+              logAtLevel(level, s"Flag '${ctx.flagKey}' evaluation failed: ${err.message}")
+            )
+          }
         case None => ZIO.unit
       }
   }
@@ -363,26 +363,22 @@ object FeatureHook {
     private val startTimeKey = TypedKey[Long]("metricsDetailed.startTime")
 
     override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
-      ZIO.succeed {
-        ctx.hookData.set(startTimeKey, java.lang.System.nanoTime())
-        None
-      }
+      for {
+        now <- Clock.nanoTime
+        _ = ctx.hookData.set(startTimeKey, now)
+      } yield None
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
-      ZIO.suspendSucceed {
-        val duration = ctx.hookData.getOrNull(startTimeKey) match {
-          case null  => Duration.Zero
-          case start => Duration.fromNanos(java.lang.System.nanoTime() - start.asInstanceOf[Long])
-        }
+      Clock.nanoTime.flatMap { end =>
+        val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
+        val duration = Duration.fromNanos(end - start)
         onSuccess(ctx, details, duration)
       }
 
     override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
-      ZIO.suspendSucceed {
-        val duration = ctx.hookData.getOrNull(startTimeKey) match {
-          case null  => Duration.Zero
-          case start => Duration.fromNanos(java.lang.System.nanoTime() - start.asInstanceOf[Long])
-        }
+      Clock.nanoTime.flatMap { end =>
+        val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
+        val duration = Duration.fromNanos(end - start)
         onError(ctx, err, duration)
       }
   }

--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -49,6 +49,9 @@ final class HookData {
   def getOrElse[A](key: TypedKey[A], default: => A): A =
     get(key).getOrElse(default)
 
+  private[openfeature] def getOrNull(key: TypedKey[_]): Any =
+    data.get().getOrElse(key.name, null)
+
   def remove[A](key: TypedKey[A]): Unit = {
     data.updateAndGet(_ - key.name)
     ()
@@ -267,53 +270,50 @@ object FeatureHook {
     // so that `before` can return None and avoid corrupting the compose pipeline's
     // context-modified tracking.
     override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
-      for {
-        now <- Clock.nanoTime
-        _ = ctx.hookData.set(startTimeKey, now)
-        _ <- beforeLevel match {
+      ZIO.suspendSucceed {
+        ctx.hookData.set(startTimeKey, java.lang.System.nanoTime())
+        beforeLevel match {
           case Some(level) =>
             annotate(baseAnnotations(ctx) ++ contextAnnotations(ctx))(
               logAtLevel(level, s"Evaluating flag '${ctx.flagKey}'")
-            )
-          case None => ZIO.unit
+            ).as(None)
+          case None => Exit.none
         }
-      } yield None
+      }
 
-    private def elapsed(ctx: HookContext): UIO[Duration] =
-      Clock.nanoTime.map { end =>
-        val start = ctx.hookData.get(startTimeKey).getOrElse(end)
-        Duration.fromNanos(end - start)
+    private def elapsed(ctx: HookContext): Duration =
+      ctx.hookData.getOrNull(startTimeKey) match {
+        case null  => Duration.Zero
+        case start => Duration.fromNanos(java.lang.System.nanoTime() - start.asInstanceOf[Long])
       }
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
       afterLevel match {
         case Some(level) =>
-          elapsed(ctx).flatMap { duration =>
-            val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
-              zio.LogAnnotation("flag.value", String.valueOf(details.value)),
-              zio.LogAnnotation("flag.reason", details.reason.toString),
-              zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
-            ) ++ details.variant.map(v => zio.LogAnnotation("flag.variant", v)).toSet
-            annotate(annotations)(
-              logAtLevel(level, s"Flag '${ctx.flagKey}' = ${details.value} (${details.reason}, ${duration.toMillis}ms)")
-            )
-          }
+          val duration = elapsed(ctx)
+          val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
+            zio.LogAnnotation("flag.value", String.valueOf(details.value)),
+            zio.LogAnnotation("flag.reason", details.reason.toString),
+            zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
+          ) ++ details.variant.map(v => zio.LogAnnotation("flag.variant", v)).toSet
+          annotate(annotations)(
+            logAtLevel(level, s"Flag '${ctx.flagKey}' = ${details.value} (${details.reason}, ${duration.toMillis}ms)")
+          )
         case None => ZIO.unit
       }
 
     override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
       errorLevel match {
         case Some(level) =>
-          elapsed(ctx).flatMap { duration =>
-            val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
-              zio.LogAnnotation("flag.error", err.message),
-              zio.LogAnnotation("flag.error.type", err.getClass.getSimpleName),
-              zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
-            )
-            annotate(annotations)(
-              logAtLevel(level, s"Flag '${ctx.flagKey}' evaluation failed: ${err.message}")
-            )
-          }
+          val duration = elapsed(ctx)
+          val annotations = baseAnnotations(ctx) ++ contextAnnotations(ctx) ++ Set(
+            zio.LogAnnotation("flag.error", err.message),
+            zio.LogAnnotation("flag.error.type", err.getClass.getSimpleName),
+            zio.LogAnnotation("flag.duration_ms", duration.toMillis.toString)
+          )
+          annotate(annotations)(
+            logAtLevel(level, s"Flag '${ctx.flagKey}' evaluation failed: ${err.message}")
+          )
         case None => ZIO.unit
       }
   }
@@ -363,22 +363,26 @@ object FeatureHook {
     private val startTimeKey = TypedKey[Long]("metricsDetailed.startTime")
 
     override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
-      for {
-        now <- Clock.nanoTime
-        _ = ctx.hookData.set(startTimeKey, now)
-      } yield None
+      ZIO.succeed {
+        ctx.hookData.set(startTimeKey, java.lang.System.nanoTime())
+        None
+      }
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
-      Clock.nanoTime.flatMap { end =>
-        val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
-        val duration = Duration.fromNanos(end - start)
+      ZIO.suspendSucceed {
+        val duration = ctx.hookData.getOrNull(startTimeKey) match {
+          case null  => Duration.Zero
+          case start => Duration.fromNanos(java.lang.System.nanoTime() - start.asInstanceOf[Long])
+        }
         onSuccess(ctx, details, duration)
       }
 
     override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
-      Clock.nanoTime.flatMap { end =>
-        val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
-        val duration = Duration.fromNanos(end - start)
+      ZIO.suspendSucceed {
+        val duration = ctx.hookData.getOrNull(startTimeKey) match {
+          case null  => Duration.Zero
+          case start => Duration.fromNanos(java.lang.System.nanoTime() - start.asInstanceOf[Long])
+        }
         onError(ctx, err, duration)
       }
   }

--- a/core/src/test/scala/zio/openfeature/EvaluationContextSpec.scala
+++ b/core/src/test/scala/zio/openfeature/EvaluationContextSpec.scala
@@ -232,6 +232,26 @@ object EvaluationContextSpec extends ZIOSpecDefault {
         val ofCtx     = zio.openfeature.internal.ContextConverter.toOpenFeature(ctx)
         val roundTrip = zio.openfeature.internal.ContextConverter.fromOpenFeature(ofCtx)
         assertTrue(roundTrip.targetingKey == None)
+      },
+      test("Long value larger than Int.MaxValue survives roundtrip as LongValue") {
+        val big       = Int.MaxValue.toLong + 1L
+        val ctx       = EvaluationContext.empty.withAttribute("big", AttributeValue.LongValue(big))
+        val ofCtx     = zio.openfeature.internal.ContextConverter.toOpenFeature(ctx)
+        val roundTrip = zio.openfeature.internal.ContextConverter.fromOpenFeature(ofCtx)
+        assertTrue(roundTrip.get("big") == Some(AttributeValue.LongValue(big)))
+      },
+      test("Long value smaller than Int.MinValue survives roundtrip as LongValue") {
+        val small     = Int.MinValue.toLong - 1L
+        val ctx       = EvaluationContext.empty.withAttribute("small", AttributeValue.LongValue(small))
+        val ofCtx     = zio.openfeature.internal.ContextConverter.toOpenFeature(ctx)
+        val roundTrip = zio.openfeature.internal.ContextConverter.fromOpenFeature(ofCtx)
+        assertTrue(roundTrip.get("small") == Some(AttributeValue.LongValue(small)))
+      },
+      test("Long value within Int range roundtrips as IntValue") {
+        val ctx       = EvaluationContext.empty.withAttribute("n", AttributeValue.LongValue(42L))
+        val ofCtx     = zio.openfeature.internal.ContextConverter.toOpenFeature(ctx)
+        val roundTrip = zio.openfeature.internal.ContextConverter.fromOpenFeature(ofCtx)
+        assertTrue(roundTrip.get("n") == Some(AttributeValue.IntValue(42)))
       }
     )
   )

--- a/core/src/test/scala/zio/openfeature/HookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookSpec.scala
@@ -65,6 +65,14 @@ object HookSpec extends ZIOSpecDefault {
         val fvt = FlagValueType.fromFlagType[Double]
         assertTrue(fvt == FlagValueType.Double)
       },
+      test("fromFlagType returns Int for Long") {
+        val fvt = FlagValueType.fromFlagType[Long]
+        assertTrue(fvt == FlagValueType.Int)
+      },
+      test("fromFlagType returns Double for Float") {
+        val fvt = FlagValueType.fromFlagType[Float]
+        assertTrue(fvt == FlagValueType.Double)
+      },
       test("fromFlagType returns Object for Map") {
         val fvt = FlagValueType.fromFlagType[Map[String, Any]]
         assertTrue(fvt == FlagValueType.Object)


### PR DESCRIPTION
First of all, thank you @EtaCassiopeia for the great work on this library!

After a thorough review of the codebase, we identified a few improvements — a bug fix, ZIO idiom refinements, and runloop performance opportunities. The PR has since been rebased onto the latest `main` and narrowed down following your review (see **Changes since the original review** at the bottom).

---

## Bug Fix

### `FlagValueType.fromFlagType` maps `Long` and `Float` to `Object` (`FlagValueType.scala`, both Scala 2 & 3)

Hooks that filter by `supportedFlagTypes` (spec 4.4.2.1) would incorrectly skip `Long` and `Float` evaluations because they were categorized as `Object` instead of their numeric counterparts:

```scala
// Before — Long/Float fall through to Object
case "Int"    => Int
case "Double" => Double
case _        => Object

// After — Long maps to Int (both are integral), Float maps to Double (both are fractional)
case "Int"    => Int
case "Long"   => Int
case "Float"  => Double
case "Double" => Double
case _        => Object
```

---

## ZIO Idiom Refinements

### Simplified `shutdown` (`FeatureFlagsLive.scala`)

`shutdown` parallelized 5 non-blocking `Ref.set` calls via `ZIO.collectAllParDiscard`. Since these are lock-free atomic operations that complete in nanoseconds, a sequential `*>` chain is clearer and avoids the overhead of fiber creation and scheduling.

### Fused `.map(...).flatMap(...)` → `.flatMap(...)` (`FeatureFlagRegistry.scala`)

`ZIO#map` is implemented as `flatMap(a => Exit.succeed(f(a)))`, so `.map(...).flatMap(...)` creates two `FlatMap` nodes. Inlining the map into the flatMap callback reduces this to a single `FlatMap`, applied in `getClient` and `setProvider`:

```scala
// Before — two FlatMap nodes
clients.get.map(_.get(domain)).flatMap { ... }

// After — one FlatMap node
clients.get.flatMap(_.get(domain) match { ... })
```

---

## ZIO Runloop Performance Optimizations

### `try/catch` for non-blocking Java calls (`FeatureFlagsLive.scala`)

`getProviderHooks` and `wrapJavaHook.before` wrapped non-blocking, in-memory Java calls in `ZIO.attempt { ... }.catchAll(...)`, which creates a `Sync` node plus a `FlatMap` node for the runloop to interpret. Replaced with a plain `try/catch` returning `Exit.succeed(...)` (or a suspended `ZIO.succeed { try ... catch ... }`), reducing the number of ZIO instances created and runloop iterations. While here, `getProviderHooks` now logs failures with `ZIO.logWarningCause` so the full exception cause is captured rather than just its message.

### `Exit.succeed` / `Exit.unit` / `Exit.none` inside ZIO combinators

`ZIO.succeed(x)` / `ZIO.unit` create a `Sync` node that the runloop must interpret. `Exit` values are pre-allocated terminal values the runloop can short-circuit on, avoiding the interpretation step. Applied in:

- `checkProviderStatus` — `ZIO.unit` → `Exit.unit`
- `currentEvaluatedFlags` — `ZIO.succeed(Map.empty)` → `Exit.succeed(Map.empty)`
- `getProviderHooks` — `ZIO.succeed(res)` → `Exit.succeed(res)`
- `FeatureFlagRegistry.getClient` / `defaultClient` — `ZIO.succeed(c)` → `Exit.succeed(c)`

> Note: `zio.Exit[E, A] <: ZIO[Any, E, A]`, so these are valid effects — they compile and the suite is green. The Copilot review's "won't typecheck" comments on these lines are false positives.

---

## Test plan

- [x] All core tests pass
- [x] New tests for `FlagValueType.fromFlagType[Long]` and `FlagValueType.fromFlagType[Float]`
- [x] Round-trip tests for `Long` values > `Int.MaxValue` and < `Int.MinValue` through `ContextConverter`
- [x] Compiles on Scala 3 (default)
- [x] Code formatted with scalafmt

---

## Changes since the original review

- **Dropped** the `ContextConverter` integer-overflow fix — `main` already addresses it with a stricter upper bound.
- **Reverted** the hook timing changes in `Hook.scala`: kept `Clock.nanoTime` consistently (so durations stay controllable under `TestClock`) and dropped the `ZIO.suspendSucceed` wrapping and the `HookData.getOrNull` helper, per review feedback.
- **Removed** the follow-up suggestion about the `FeatureFlags` accessor methods — keeping the accessors as they are.
