### PR TITLE
Fix FlagValueType.fromFlagType: map Long to Int and Float to Double

### DIFF
--- a/core/src/main/scala-2/zio/openfeature/FlagValueType.scala
+++ b/core/src/main/scala-2/zio/openfeature/FlagValueType.scala
@@ -24,6 +24,8 @@ object FlagValueType {
       case "Boolean" => Boolean
       case "String"  => String
       case "Int"     => Int
+      case "Long"    => Int
+      case "Float"   => Double
       case "Double"  => Double
       case _         => Object
     }

--- a/core/src/main/scala-3/zio/openfeature/FlagValueType.scala
+++ b/core/src/main/scala-3/zio/openfeature/FlagValueType.scala
@@ -17,5 +17,7 @@ object FlagValueType:
       case "Boolean" => Boolean
       case "String"  => String
       case "Int"     => Int
+      case "Long"    => Int
+      case "Float"   => Double
       case "Double"  => Double
       case _         => Object

--- a/core/src/test/scala/zio/openfeature/HookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookSpec.scala
@@ -65,6 +65,14 @@ object HookSpec extends ZIOSpecDefault {
         val fvt = FlagValueType.fromFlagType[Double]
         assertTrue(fvt == FlagValueType.Double)
       },
+      test("fromFlagType maps Long to Int (both are integral)") {
+        val fvt = FlagValueType.fromFlagType[Long]
+        assertTrue(fvt == FlagValueType.Int)
+      },
+      test("fromFlagType maps Float to Double (both are fractional)") {
+        val fvt = FlagValueType.fromFlagType[Float]
+        assertTrue(fvt == FlagValueType.Double)
+      },
       test("fromFlagType returns Object for Map") {
         val fvt = FlagValueType.fromFlagType[Map[String, Any]]
         assertTrue(fvt == FlagValueType.Object)


### PR DESCRIPTION
## Summary

Hooks that filter by `supportedFlagTypes` (spec 4.4.2.1) currently miss `Long` and `Float` evaluations because `FlagValueType.fromFlagType` falls them through to `Object`. Long is integral (same family as `Int`) and Float is fractional (same family as `Double`), so they should map accordingly.

## Changes

- `core/src/main/scala-3/zio/openfeature/FlagValueType.scala`: add `Long → Int`, `Float → Double` cases
- `core/src/main/scala-2/zio/openfeature/FlagValueType.scala`: same, for cross-build
- `core/src/test/scala/zio/openfeature/HookSpec.scala`: two new tests pinning the mapping

## Credit

Spotted in #110 by @guizmaii.

## Test plan

- [x] All tests pass (342)
- [x] scalafmtCheckAll clean