### PR TITLE
Use Exit terminal values for short-circuit in flatMap callbacks

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
@@ -61,7 +61,7 @@ final private class FeatureFlagRegistryLive(
   override def getClient(domain: String): UIO[FeatureFlags] =
     lock.withPermit {
       clients.get.map(_.get(domain)).flatMap {
-        case Some(c) => ZIO.succeed(c)
+        case Some(c) => Exit.succeed(c)
         case None    => createDomainClient(domain)
       }
     }
@@ -84,7 +84,7 @@ final private class FeatureFlagRegistryLive(
   override def defaultClient: UIO[FeatureFlags] =
     lock.withPermit {
       defaultRef.get.flatMap {
-        case Some(c) => ZIO.succeed(c)
+        case Some(c) => Exit.succeed(c)
         case None    => createDefaultClient
       }
     }

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -200,7 +200,7 @@ final private[openfeature] class FeatureFlagsLive(
       case ProviderStatus.Fatal    => ZIO.fail(FeatureFlagError.ProviderFatal)
       case ProviderStatus.NotReady => ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.NotReady))
       case ProviderStatus.Error    => ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.Error))
-      case _                       => ZIO.unit
+      case _                       => Exit.unit
     }
 
   // Context is already merged by evaluateWithDetails before entering the hook pipeline
@@ -583,7 +583,7 @@ final private[openfeature] class FeatureFlagsLive(
   override def currentEvaluatedFlags: UIO[Map[String, zio.openfeature.FlagEvaluation[_]]] =
     state.transactionRef.get.flatMap {
       case Some(ts) => ts.getEvaluations
-      case None     => ZIO.succeed(Map.empty)
+      case None     => Exit.succeed(Map.empty)
     }
 
   override def events: ZStream[Any, Nothing, ProviderEvent] =

--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -275,7 +275,7 @@ object FeatureHook {
             annotate(baseAnnotations(ctx) ++ contextAnnotations(ctx))(
               logAtLevel(level, s"Evaluating flag '${ctx.flagKey}'")
             )
-          case None => ZIO.unit
+          case None => Exit.unit
         }
       } yield None
 


### PR DESCRIPTION
## Summary

`ZIO.succeed(x)`, `ZIO.unit`, and `ZIO.none` create a `Sync` node that the ZIO runloop must interpret. `Exit` values (`Exit.succeed(x)`, `Exit.unit`, `Exit.none`) are pre-allocated terminal values the runloop can short-circuit on, avoiding the interpretation step.

Applied in five hot-path callbacks where the value is unconditionally terminal:

- `FeatureFlagsLive.checkProviderStatus` — `ZIO.unit` → `Exit.unit` (catch-all after error cases)
- `FeatureFlagsLive.currentEvaluatedFlags` — `ZIO.succeed(Map.empty)` → `Exit.succeed(Map.empty)` (no-transaction branch)
- `Hook.scala` `structuredLogging.before` — `ZIO.unit` → `Exit.unit` (level-disabled branch)
- `FeatureFlagRegistry.getClient` — `ZIO.succeed(c)` → `Exit.succeed(c)` (cache-hit branch)
- `FeatureFlagRegistry.defaultClient` — same

## Credit

Spotted in #110 by @guizmaii.

## Test plan

- [x] All 340 tests pass
- [x] scalafmtCheckAll clean