### PR TITLE
Use try/catch for non-blocking Java calls and log Cause

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -695,13 +695,16 @@ final private[openfeature] class FeatureFlagsLive(
 
   private def getProviderHooks: UIO[List[FeatureHook]] =
     providerRef.get.flatMap { p =>
-      ZIO
-        .attempt {
-          val javaHooks = p.getProviderHooks
+      try {
+        val javaHooks = p.getProviderHooks
+        val hooks =
           if (javaHooks == null || javaHooks.isEmpty) Nil
           else javaHooks.asScala.toList.map(wrapJavaHook)
-        }
-        .catchAll(e => ZIO.logWarning(s"Failed to get provider hooks: ${e.getMessage}").as(Nil))
+        Exit.succeed(hooks)
+      } catch {
+        case scala.util.control.NonFatal(e) =>
+          ZIO.logWarningCause("Failed to get provider hooks", Cause.fail(e)).as(Nil)
+      }
     }
 
   @scala.annotation.nowarn("msg=deprecated")
@@ -746,8 +749,8 @@ final private[openfeature] class FeatureFlagsLive(
     val hook = javaHook.asInstanceOf[dev.openfeature.sdk.Hook[Any]]
     new FeatureHook {
       override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
-        ZIO
-          .attempt {
+        ZIO.succeed {
+          try {
             val jCtx   = toJavaHookContext(ctx)
             val jHints = hints.values.map { case (k, v) => k -> v.asInstanceOf[Object] }.asJava
             val result = hook.before(jCtx, jHints)
@@ -755,8 +758,8 @@ final private[openfeature] class FeatureFlagsLive(
               val newCtx = fromJavaEvaluationContext(result.get())
               Some((newCtx, hints))
             } else None
-          }
-          .catchAll(_ => ZIO.none)
+          } catch { case scala.util.control.NonFatal(_) => None }
+        }
 
       override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
         ZIO.attempt {


### PR DESCRIPTION
## Summary

`getProviderHooks` and `wrapJavaHook.before` were wrapping Java SDK calls in `ZIO.attempt(...).catchAll(...)`. `ZIO.attempt` creates a `Sync` node and `catchAll` adds a `FlatMap` node — two ZIO instances the runloop must interpret. Since the wrapped calls are non-blocking, in-memory Java methods, a plain `try/catch` + `Exit.succeed` (or `ZIO.succeed { try { ... } catch ... }`) achieves the same safety with fewer runloop iterations.

Also upgrades `getProviderHooks` error logging from `ZIO.logWarning(s"... ${e.getMessage}")` to `ZIO.logWarningCause(...)` so the full `Cause` (with stack trace) appears in diagnostics.

## Changes

- `FeatureFlagsLive.getProviderHooks` — `ZIO.attempt + catchAll` → `try/catch + Exit.succeed`; log `Cause.fail(e)` instead of just the message
- `FeatureFlagsLive.wrapJavaHook.before` — `ZIO.attempt + catchAll(_ => ZIO.none)` → `ZIO.succeed { try { ... } catch { case NonFatal(_) => None } }`

Both call sites assume `NonFatal` (preserves original `Exception`-catching behavior; `VirtualMachineError`/`LinkageError` propagate).

## Credit

Spotted in #110 by @guizmaii. The `logWarningCause` upgrade is an addition; the original PR kept the message-only logging.