### PR TITLE
Avoid Option allocation in hook duration path via HookData.getOrNull

### DIFF
--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -49,6 +49,13 @@ final class HookData {
   def getOrElse[A](key: TypedKey[A], default: => A): A =
     get(key).getOrElse(default)
 
+  /** Allocation-free lookup: returns the raw `Any` value or `null` if absent. Internal use only — callers must
+    * pattern-match on `null` and cast the non-null branch. Used in hot paths (e.g., hook duration) to avoid `Option`
+    * allocation.
+    */
+  private[openfeature] def getOrNull(key: TypedKey[_]): Any =
+    data.get().getOrElse(key.name, null)
+
   def remove[A](key: TypedKey[A]): Unit = {
     data.updateAndGet(_ - key.name)
     ()
@@ -280,9 +287,9 @@ object FeatureHook {
       } yield None
 
     private def elapsed(ctx: HookContext): UIO[Duration] =
-      Clock.nanoTime.map { end =>
-        val start = ctx.hookData.get(startTimeKey).getOrElse(end)
-        Duration.fromNanos(end - start)
+      ctx.hookData.getOrNull(startTimeKey) match {
+        case null  => Exit.succeed(Duration.Zero)
+        case start => Clock.nanoTime.map(end => Duration.fromNanos(end - start.asInstanceOf[Long]))
       }
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
@@ -369,17 +376,19 @@ object FeatureHook {
       } yield None
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
-      Clock.nanoTime.flatMap { end =>
-        val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
-        val duration = Duration.fromNanos(end - start)
-        onSuccess(ctx, details, duration)
+      ctx.hookData.getOrNull(startTimeKey) match {
+        case null =>
+          onSuccess(ctx, details, Duration.Zero)
+        case start =>
+          Clock.nanoTime.flatMap(end => onSuccess(ctx, details, Duration.fromNanos(end - start.asInstanceOf[Long])))
       }
 
     override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
-      Clock.nanoTime.flatMap { end =>
-        val start    = ctx.hookData.get(startTimeKey).getOrElse(end)
-        val duration = Duration.fromNanos(end - start)
-        onError(ctx, err, duration)
+      ctx.hookData.getOrNull(startTimeKey) match {
+        case null =>
+          onError(ctx, err, Duration.Zero)
+        case start =>
+          Clock.nanoTime.flatMap(end => onError(ctx, err, Duration.fromNanos(end - start.asInstanceOf[Long])))
       }
   }
 


### PR DESCRIPTION
## Summary

The `structuredLogging.elapsed`, `metricsDetailed.after`, and `metricsDetailed.error` hooks read the recorded start time from `HookData` to compute evaluation duration. The existing code used `hookData.get(key).getOrElse(end)` which allocates an `Option` on every flag evaluation — a hot path.

Adds `HookData.getOrNull(key): Any` (internal, `private[openfeature]`) that returns the raw value or `null`, and updates the three duration call sites to pattern-match on `null`. As a side benefit, when no start time was recorded (defensive case), the read of the end-time clock is skipped entirely and `Duration.Zero` is returned.

`Clock.nanoTime` is preserved (consistent with both `before` and tests), so `TestClock` interactions remain correct.

## Changes

- `Hook.scala`: add `HookData.getOrNull` (internal API)
- `Hook.scala`: rewrite `structuredLogging.elapsed`, `metricsDetailed.after`, `metricsDetailed.error` to use null-first pattern match

@EtaCassiopeia 

## Credit

Spotted in #110 by @guizmaii. The original PR also switched `Clock.nanoTime` → `System.nanoTime`; this PR keeps `Clock.nanoTime` for testability.
