### PR TITLE
Simplify FeatureFlagRegistry control flow

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
@@ -60,25 +60,22 @@ final private class FeatureFlagRegistryLive(
 
   override def getClient(domain: String): UIO[FeatureFlags] =
     lock.withPermit {
-      clients.get.map(_.get(domain)).flatMap {
+      clients.get.flatMap(_.get(domain) match {
         case Some(c) => ZIO.succeed(c)
         case None    => createDomainClient(domain)
-      }
+      })
     }
 
   override def setProvider(domain: String, provider: OFFeatureProvider): IO[FeatureFlagError, Unit] =
     lock.withPermit {
-      for {
-        existing <- clients.get.map(_.get(domain))
-        _ <- existing match {
-          case Some(client) =>
-            client
-              .setProvider(provider)
-              .tap(_ => providers.update(_ + (domain -> provider)))
-          case None =>
-            providers.update(_ + (domain -> provider))
-        }
-      } yield ()
+      clients.get.flatMap(_.get(domain) match {
+        case Some(client) =>
+          client
+            .setProvider(provider)
+            .tap(_ => providers.update(_ + (domain -> provider)))
+        case None =>
+          providers.update(_ + (domain -> provider))
+      })
     }
 
   override def defaultClient: UIO[FeatureFlags] =


### PR DESCRIPTION
## Summary

Two small simplifications in `FeatureFlagRegistryLive`:

1. **`getClient` — fuse `.map(...).flatMap(...)`**

   `ZIO#map(f)` is implemented as `flatMap(a => Exit.succeed(f(a)))`, so `clients.get.map(_.get(domain)).flatMap(...)` constructs two `FlatMap` nodes. Inlining the map into the flatMap callback reduces it to one:

   ```scala
   // Before
   clients.get.map(_.get(domain)).flatMap {
     case Some(c) => ZIO.succeed(c)
     case None    => createDomainClient(domain)
   }
   // After
   clients.get.flatMap(_.get(domain) match {
     case Some(c) => ZIO.succeed(c)
     case None    => createDomainClient(domain)
   })
   ```

2. **`setProvider` — collapse two-step for-comprehension**

   The for-comprehension introduced an `existing` binding that was used exactly once. Inlining produces the same effect with less indirection.

Pure refactor; no behavior change.

## Credit

Spotted in #110 by @guizmaii.

## Test plan

- [x] All tests pass (340 + 99 + 170)
- [x] scalafmtCheckAll clean