### PR TITLE
Run shutdown Ref.sets sequentially

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -830,15 +830,13 @@ final private[openfeature] class FeatureFlagsLive(
   // Shutdown API (spec 1.6.1, 1.6.2)
 
   override def shutdown: UIO[Unit] =
-    ZIO.collectAllParDiscard(
-      List(
-        state.statusRef.set(ProviderStatus.NotReady),
-        state.hooksRef.set(List.empty),
-        state.globalContextRef.set(EvaluationContext.empty),
-        state.clientContextRef.set(EvaluationContext.empty),
-        state.trackRecorder.set(List.empty)
-      )
-    ) *> state.eventHub.shutdown *> ZIO.attemptBlocking(api.shutdown()).ignore
+    state.statusRef.set(ProviderStatus.NotReady) *>
+      state.hooksRef.set(List.empty) *>
+      state.globalContextRef.set(EvaluationContext.empty) *>
+      state.clientContextRef.set(EvaluationContext.empty) *>
+      state.trackRecorder.set(List.empty) *>
+      state.eventHub.shutdown *>
+      ZIO.attemptBlocking(api.shutdown()).ignore
 
   // Tracking API
 


### PR DESCRIPTION
## Summary

`FeatureFlags#shutdown` was running five `Ref.set` calls via `ZIO.collectAllParDiscard`. Atomic `Ref.set` is a lock-free nanosecond-scale operation, so the fork/join overhead of parallel execution exceeds the work itself. A sequential `*>` chain is clearer and avoids fiber creation.

```scala
// Before
ZIO.collectAllParDiscard(List(
  state.statusRef.set(ProviderStatus.NotReady),
  state.hooksRef.set(List.empty),
  state.globalContextRef.set(EvaluationContext.empty),
  state.clientContextRef.set(EvaluationContext.empty),
  state.trackRecorder.set(List.empty)
)) *> state.eventHub.shutdown *> ZIO.attemptBlocking(api.shutdown()).ignore

// After
state.statusRef.set(ProviderStatus.NotReady) *>
  state.hooksRef.set(List.empty) *>
  state.globalContextRef.set(EvaluationContext.empty) *>
  state.clientContextRef.set(EvaluationContext.empty) *>
  state.trackRecorder.set(List.empty) *>
  state.eventHub.shutdown *>
  ZIO.attemptBlocking(api.shutdown()).ignore
```

Pure refactor; no behavior change (these Refs are independent so any order is correct).

## Credit

Spotted in #110 by @guizmaii.

## Test plan

- [x] All tests pass (340 + 99 + 170)
- [x] scalafmtCheckAll clean