### PR TITLE
Make AsyncReadyLayerSpec deterministic via TestClock

### DIFF
--- a/testkit/src/test/scala/zio/openfeature/testkit/AsyncReadyLayerSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/AsyncReadyLayerSpec.scala
@@ -12,24 +12,36 @@ object AsyncReadyLayerSpec extends ZIOSpecDefault {
   ): ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
     Scope.default >>> TestFeatureProvider.asyncReadyLayer(flags, delay)
 
+  // Bound the polling loop so a real bug surfaces as a test failure instead of a hang.
+  private val waitForReady: ZIO[FeatureFlags, Nothing, ProviderStatus] =
+    FeatureFlags.providerStatus
+      .repeatUntil(_ == ProviderStatus.Ready)
+      .timeoutTo(ProviderStatus.NotReady)(identity)(5.seconds)
+      .withClock(Clock.ClockLive)
+
   def spec = suite("asyncReadyLayer")(
+    // Under TestClock the forked transition fiber inside asyncReadyLayer suspends on its `ZIO.sleep`
+    // until we explicitly adjust the clock. This eliminates the wall-clock race that made the
+    // previous `withLiveClock` version flaky on slow CI runners.
     test("starts in NotReady then auto-transitions to Ready") {
       for {
         before <- FeatureFlags.providerStatus
-        _      <- ZIO.sleep(500.millis)
-        after  <- FeatureFlags.providerStatus
+        _      <- TestClock.adjust(60.millis)
+        after  <- waitForReady
       } yield assertTrue(before == ProviderStatus.NotReady) && assertTrue(after == ProviderStatus.Ready)
     }.provide(readyLayer(Map.empty, 50.millis)),
     test("evaluations work after auto-transition") {
       for {
-        _     <- ZIO.sleep(500.millis)
+        _     <- TestClock.adjust(60.millis)
+        _     <- waitForReady
         value <- FeatureFlags.boolean("flag", default = false)
       } yield assertTrue(value == true)
     }.provide(readyLayer(Map("flag" -> true), 50.millis)),
     test("evaluations fail before init delay elapses") {
+      // No clock adjustment: the forked transition fiber stays suspended, status remains NotReady.
       for {
         result <- FeatureFlags.boolean("flag", default = false).either
       } yield assertTrue(result.isLeft)
     }.provide(readyLayer(Map("flag" -> true), 10.seconds))
-  ) @@ TestAspect.withLiveClock
+  )
 }


### PR DESCRIPTION
## Summary

`AsyncReadyLayerSpec` was racing wall-clock timing. The test under \`@@ TestAspect.withLiveClock\` asserted that `providerStatus` starts as `NotReady` then transitions to `Ready` after a 50ms async delay. On slow CI runners, layer construction itself could take longer than 50ms, causing the first `providerStatus` read to already see `Ready` and the assertion to fail. Previously hit in #116's CI run (#25769211402).

## Fix

Removed `withLiveClock` and replaced `ZIO.sleep` with `TestClock.adjust`. The forked transition fiber inside `asyncReadyLayer` uses `ZIO.sleep(initDelay)`, which under `TestClock` suspends indefinitely until the clock is explicitly advanced. This eliminates the race:

1. Layer constructs. Transition fiber forks and suspends on `TestClock.sleep(50.millis)`.
2. Test reads status → guaranteed `NotReady`.
3. Test calls `TestClock.adjust(60.millis)` → fiber's sleep elapses, fiber flips status.
4. Test polls via `repeatUntil(_ == Ready)` to await the flip (bounded by a 5s live-clock timeout for safety).

Side benefit: the suite now runs in ~160ms instead of ~1.5s (no live-clock sleeps).

## Files

- `testkit/src/test/scala/zio/openfeature/testkit/AsyncReadyLayerSpec.scala`