### PR TITLE
Classify auth/network errors and validate OFREP construction

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagError.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagError.scala
@@ -45,6 +45,22 @@ object FeatureFlagError {
     override def cause: Option[Throwable] = Some(underlying)
   }
 
+  /** The remote provider refused the request because of an authentication or authorization failure (HTTP 401 / 403, or
+    * an analogous SDK signal). Operators should alert on this distinctly from generic provider errors — it almost
+    * always indicates a misconfigured SDK key.
+    */
+  final case class Unauthorized(reason: String) extends FeatureFlagError {
+    def message: String = s"Provider rejected request: $reason"
+  }
+
+  /** The remote provider could not be reached at the network layer (DNS failure, connection refused, no route).
+    * Distinct from a slow response (`ProviderError(TimeoutException)`) or an HTTP-level rejection (`Unauthorized`).
+    */
+  final case class Unreachable(cause0: Throwable) extends FeatureFlagError {
+    def message: String                   = s"Provider unreachable: ${cause0.getMessage}"
+    override def cause: Option[Throwable] = Some(cause0)
+  }
+
   final case class InvalidConfiguration(reason: String) extends FeatureFlagError {
     def message: String = s"Invalid provider configuration: $reason"
   }
@@ -76,6 +92,8 @@ object FeatureFlagError {
     case ProviderFatal                   => true
     case _: ProviderInitializationFailed => true
     case _: ProviderError                => true
+    case _: Unauthorized                 => true
+    case _: Unreachable                  => true
     case _: InvalidConfiguration         => true
     case _                               => false
   }
@@ -91,8 +109,48 @@ object FeatureFlagError {
     case ProviderFatal                   => ErrorCode.ProviderFatal
     case _: ProviderInitializationFailed => ErrorCode.ProviderNotReady
     case _: ProviderError                => ErrorCode.General
+    case _: Unauthorized                 => ErrorCode.General
+    case _: Unreachable                  => ErrorCode.General
     case _: InvalidConfiguration         => ErrorCode.General
     case NestedTransactionNotAllowed     => ErrorCode.General
     case _: OverrideTypeMismatch         => ErrorCode.TypeMismatch
   }
+
+  /** Classify a Throwable raised by an underlying provider (Java SDK, contrib provider, or transport library) into a
+    * typed `FeatureFlagError`. The classifier is intentionally conservative — only well-known network and HTTP failure
+    * shapes get specific cases; everything else falls back to `ProviderError` with the original cause preserved.
+    *
+    * Used by both `core` (wrapping evaluation/tracking failures) and downstream provider modules (OFREP, Optimizely) so
+    * operators see consistent error types regardless of which provider is in use.
+    */
+  def classify(t: Throwable): FeatureFlagError = {
+    val msg = Option(t.getMessage).getOrElse("")
+    t match {
+      case _: java.net.UnknownHostException                                                   => Unreachable(t)
+      case _: java.net.NoRouteToHostException                                                 => Unreachable(t)
+      case _: java.net.ConnectException                                                       => Unreachable(t)
+      case _: java.nio.channels.ClosedChannelException if msg.toLowerCase.contains("connect") => Unreachable(t)
+      case _ if isHttpAuthFailure(t, msg) => Unauthorized(extractAuthReason(t, msg))
+      case _                              => ProviderError(t)
+    }
+  }
+
+  // The HTTP client used by contrib providers (java.net.http) doesn't expose status codes via a fixed exception type,
+  // so we fall back to scanning the exception message for the canonical "401"/"403" tokens. This is permissive — if a
+  // provider message happens to contain those substrings for another reason it will be misclassified, but the cost is
+  // low (caller still sees the original Throwable on Unauthorized.cause-equivalent flows when needed).
+  private def isHttpAuthFailure(t: Throwable, msg: String): Boolean = {
+    val cls    = t.getClass.getName
+    val msgLow = msg.toLowerCase
+    cls.endsWith("HttpResponseException") ||
+    cls.endsWith("UnauthorizedException") ||
+    cls.endsWith("ForbiddenException") ||
+    msgLow.contains("401") ||
+    msgLow.contains("403") ||
+    msgLow.contains("unauthorized") ||
+    msgLow.contains("forbidden")
+  }
+
+  private def extractAuthReason(t: Throwable, msg: String): String =
+    if (msg.nonEmpty) msg else t.getClass.getSimpleName
 }

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -303,7 +303,7 @@ final private[openfeature] class FeatureFlagsLive(
             case None => erased.task
           }
           timedEval
-            .mapError(e => FeatureFlagError.ProviderError(e))
+            .mapError(e => FeatureFlagError.classify(e))
             .flatMap { details =>
               toFlagResolution(key, details).map(r => r.copy(value = erased.extract(details)))
             }
@@ -318,7 +318,7 @@ final private[openfeature] class FeatureFlagsLive(
               )
               client.getObjectDetails(key, defaultValue, ofContext)
             }
-          ).mapError(e => FeatureFlagError.ProviderError(e))
+          ).mapError(e => FeatureFlagError.classify(e))
             .flatMap { details =>
               val value = valueToMap(details.getValue)
               toFlagMetadata(details.getFlagMetadata).map { metadata =>
@@ -340,7 +340,7 @@ final private[openfeature] class FeatureFlagsLive(
             ZIO.attemptBlocking {
               client.getObjectDetails(key, new dev.openfeature.sdk.Value(), ofContext)
             }
-          ).mapError(e => FeatureFlagError.ProviderError(e))
+          ).mapError(e => FeatureFlagError.classify(e))
             .flatMap { details =>
               valueToAny(details.getValue) match {
                 case Some(rawValue) =>
@@ -850,7 +850,7 @@ final private[openfeature] class FeatureFlagsLive(
             val ofContext = ContextConverter.toOpenFeature(merged)
             client.track(eventName, ofContext)
           }
-          .mapError(e => FeatureFlagError.ProviderError(e))
+          .mapError(e => FeatureFlagError.classify(e))
     }
 
   override def track(eventName: String, context: EvaluationContext): IO[FeatureFlagError, Unit] =
@@ -861,7 +861,7 @@ final private[openfeature] class FeatureFlagsLive(
             val ofContext = ContextConverter.toOpenFeature(merged)
             client.track(eventName, ofContext)
           }
-          .mapError(e => FeatureFlagError.ProviderError(e))
+          .mapError(e => FeatureFlagError.classify(e))
     }
 
   override def track(eventName: String, details: TrackingEventDetails): IO[FeatureFlagError, Unit] =
@@ -873,7 +873,7 @@ final private[openfeature] class FeatureFlagsLive(
             val ofDetails = toOpenFeatureDetails(details)
             client.track(eventName, ofContext, ofDetails)
           }
-          .mapError(e => FeatureFlagError.ProviderError(e))
+          .mapError(e => FeatureFlagError.classify(e))
     }
 
   override def track(
@@ -889,7 +889,7 @@ final private[openfeature] class FeatureFlagsLive(
             val ofDetails = toOpenFeatureDetails(details)
             client.track(eventName, ofContext, ofDetails)
           }
-          .mapError(e => FeatureFlagError.ProviderError(e))
+          .mapError(e => FeatureFlagError.classify(e))
     }
 
   override def trackedEvents: UIO[List[(String, EvaluationContext, Option[TrackingEventDetails])]] =

--- a/core/src/test/scala/zio/openfeature/FeatureFlagErrorSpec.scala
+++ b/core/src/test/scala/zio/openfeature/FeatureFlagErrorSpec.scala
@@ -60,6 +60,15 @@ object FeatureFlagErrorSpec extends ZIOSpecDefault {
       test("InvalidConfiguration has correct message") {
         val error = FeatureFlagError.InvalidConfiguration("missing API key")
         assertTrue(error.message == "Invalid provider configuration: missing API key")
+      },
+      test("Unauthorized has correct message") {
+        val error = FeatureFlagError.Unauthorized("invalid SDK key")
+        assertTrue(error.message == "Provider rejected request: invalid SDK key")
+      },
+      test("Unreachable preserves the underlying cause") {
+        val cause = new java.net.UnknownHostException("flags.example.com")
+        val error = FeatureFlagError.Unreachable(cause)
+        assertTrue(error.cause.contains(cause), error.message.contains("flags.example.com"))
       }
     ),
     suite("Transaction errors")(
@@ -84,6 +93,8 @@ object FeatureFlagErrorSpec extends ZIOSpecDefault {
         assertTrue(!FeatureFlagError.isRecoverable(FeatureFlagError.ProviderNotReady(ProviderStatus.NotReady))) &&
         assertTrue(!FeatureFlagError.isRecoverable(FeatureFlagError.ProviderInitializationFailed(new Exception))) &&
         assertTrue(!FeatureFlagError.isRecoverable(FeatureFlagError.ProviderError(new Exception))) &&
+        assertTrue(!FeatureFlagError.isRecoverable(FeatureFlagError.Unauthorized("reason"))) &&
+        assertTrue(!FeatureFlagError.isRecoverable(FeatureFlagError.Unreachable(new Exception))) &&
         assertTrue(!FeatureFlagError.isRecoverable(FeatureFlagError.InvalidConfiguration("reason")))
       },
       test("transaction errors are not recoverable") {
@@ -97,6 +108,8 @@ object FeatureFlagErrorSpec extends ZIOSpecDefault {
         assertTrue(FeatureFlagError.isProviderError(FeatureFlagError.ProviderFatal)) &&
         assertTrue(FeatureFlagError.isProviderError(FeatureFlagError.ProviderInitializationFailed(new Exception))) &&
         assertTrue(FeatureFlagError.isProviderError(FeatureFlagError.ProviderError(new Exception))) &&
+        assertTrue(FeatureFlagError.isProviderError(FeatureFlagError.Unauthorized("reason"))) &&
+        assertTrue(FeatureFlagError.isProviderError(FeatureFlagError.Unreachable(new Exception))) &&
         assertTrue(FeatureFlagError.isProviderError(FeatureFlagError.InvalidConfiguration("reason")))
       },
       test("non-provider errors return false") {
@@ -134,6 +147,8 @@ object FeatureFlagErrorSpec extends ZIOSpecDefault {
           ) == ErrorCode.ProviderNotReady
         ) &&
         assertTrue(FeatureFlagError.toErrorCode(FeatureFlagError.ProviderError(new Exception)) == ErrorCode.General) &&
+        assertTrue(FeatureFlagError.toErrorCode(FeatureFlagError.Unauthorized("k")) == ErrorCode.General) &&
+        assertTrue(FeatureFlagError.toErrorCode(FeatureFlagError.Unreachable(new Exception)) == ErrorCode.General) &&
         assertTrue(FeatureFlagError.toErrorCode(FeatureFlagError.InvalidConfiguration("reason")) == ErrorCode.General)
       },
       test("maps transaction errors correctly") {
@@ -141,6 +156,64 @@ object FeatureFlagErrorSpec extends ZIOSpecDefault {
         assertTrue(
           FeatureFlagError.toErrorCode(FeatureFlagError.OverrideTypeMismatch("k", "A", "B")) == ErrorCode.TypeMismatch
         )
+      }
+    ),
+    suite("classify")(
+      test("UnknownHostException is classified as Unreachable") {
+        val cause = new java.net.UnknownHostException("flags.example.com")
+        val ok = FeatureFlagError.classify(cause) match {
+          case FeatureFlagError.Unreachable(t) => t eq cause
+          case _                               => false
+        }
+        assertTrue(ok)
+      },
+      test("ConnectException is classified as Unreachable") {
+        val cause = new java.net.ConnectException("connection refused")
+        val ok = FeatureFlagError.classify(cause) match {
+          case FeatureFlagError.Unreachable(t) => t eq cause
+          case _                               => false
+        }
+        assertTrue(ok)
+      },
+      test("NoRouteToHostException is classified as Unreachable") {
+        val cause = new java.net.NoRouteToHostException("no route")
+        val ok = FeatureFlagError.classify(cause) match {
+          case _: FeatureFlagError.Unreachable => true
+          case _                               => false
+        }
+        assertTrue(ok)
+      },
+      test("RuntimeException with 401 in message is classified as Unauthorized") {
+        val cause = new RuntimeException("HTTP 401: Unauthorized")
+        val ok = FeatureFlagError.classify(cause) match {
+          case FeatureFlagError.Unauthorized(reason) => reason.contains("401")
+          case _                                     => false
+        }
+        assertTrue(ok)
+      },
+      test("RuntimeException with forbidden in message is classified as Unauthorized") {
+        val cause = new RuntimeException("Forbidden")
+        val ok = FeatureFlagError.classify(cause) match {
+          case _: FeatureFlagError.Unauthorized => true
+          case _                                => false
+        }
+        assertTrue(ok)
+      },
+      test("SocketTimeoutException falls through to ProviderError (timeout != unreachable)") {
+        val cause = new java.net.SocketTimeoutException("read timed out")
+        val ok = FeatureFlagError.classify(cause) match {
+          case FeatureFlagError.ProviderError(t) => t eq cause
+          case _                                 => false
+        }
+        assertTrue(ok)
+      },
+      test("generic RuntimeException falls through to ProviderError") {
+        val cause = new RuntimeException("something broke")
+        val ok = FeatureFlagError.classify(cause) match {
+          case FeatureFlagError.ProviderError(t) => t eq cause
+          case _                                 => false
+        }
+        assertTrue(ok)
       }
     )
   )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -261,11 +261,18 @@ The library uses `FeatureFlagError` for typed error handling:
 | `FlagNotFound` | Flag key doesn't exist in provider |
 | `TypeMismatch` | Value type doesn't match expected type |
 | `ProviderNotReady` | Provider not initialized |
+| `ProviderInitializationFailed` | Sync init returned a non-`READY` state, or `setProviderAndWait` exceeded `initTimeout` |
+| `ProviderFatal` | Provider hit an irrecoverable state (e.g. async init never produced a datafile within `initTimeout`) |
+| `Unauthorized` | Provider rejected the request (HTTP 401 / 403 or analogous SDK signal — typically a wrong SDK key) |
+| `Unreachable` | Provider could not be reached at the network layer (DNS, connection refused, no route) |
 | `TargetingKeyMissing` | Required targeting key not provided |
 | `InvalidContext` | Evaluation context is invalid |
-| `ProviderError` | Underlying provider exception |
+| `InvalidConfiguration` | Provider construction was rejected (e.g. malformed `baseUrl`, placeholder SDK key) |
+| `ProviderError` | Fallback wrapping an unclassified underlying provider exception |
 | `NestedTransactionNotAllowed` | Attempted nested transaction |
 | `OverrideTypeMismatch` | Transaction override type mismatch |
+
+`Unauthorized`, `Unreachable`, and the `ProviderError` fallback are produced by a shared classifier (`FeatureFlagError.classify`) wherever the library wraps a `Throwable` from the underlying provider. Operators can alert on `Unauthorized` (a misconfigured key) distinctly from `Unreachable` (a network outage) and the generic `ProviderError` (everything else, with the original `Throwable` preserved on `.cause`).
 
 ### Error Recovery
 
@@ -275,7 +282,12 @@ FeatureFlags.boolean("feature", false)
     case FeatureFlagError.FlagNotFound(_) =>
       ZIO.succeed(false)  // Use default
     case _: FeatureFlagError.ProviderNotReady =>
-      ZIO.succeed(false)  // Fail safe
+      ZIO.succeed(false)  // Fail safe — provider not yet ready
+    case _: FeatureFlagError.Unreachable =>
+      ZIO.succeed(false)  // Network blip — serve default rather than fail
+    case _: FeatureFlagError.Unauthorized =>
+      // Misconfigured SDK key — fail loud so operators investigate, don't paper over
+      ZIO.logError("Provider auth failed — check SDK key rotation") *> ZIO.succeed(false)
   }
 ```
 

--- a/docs/extras.md
+++ b/docs/extras.md
@@ -172,14 +172,21 @@ import zio.*
 import zio.openfeature.*
 import zio.openfeature.ofrep.OFREPProvider
 
-// Common case: point at an OFREP endpoint
-val layer = FeatureFlags.fromProvider(OFREPProvider("https://flags.example.com"))
-
-// Default endpoint (http://localhost:8016)
-val localLayer = FeatureFlags.fromProvider(OFREPProvider())
+val program = ZIO.scoped {
+  for
+    provider <- OFREPProvider.make("https://flags.example.com")
+                  .mapError(e => new RuntimeException(e.message))
+    env      <- FeatureFlags.fromProviderAsync(provider).build
+    ff        = env.get[FeatureFlags]
+    enabled  <- ff.boolean("new-checkout", default = false)
+                  .mapError(e => new RuntimeException(e.message))
+  yield enabled
+}
 ```
 
-For full configuration (auth headers, timeouts, custom executor), use `fromOptions`:
+`OFREPProvider.make(baseUrl)` parses and validates the URL before constructing — bad input fails layer build with `FeatureFlagError.InvalidConfiguration` rather than surfacing as an opaque `ProviderError(MalformedURLException)` on the first evaluation. The ZLayer convenience `OFREPProvider.layer(baseUrl)` does the same and exposes the result as `ZLayer[Any, FeatureFlagError.InvalidConfiguration, OfrepProvider]`.
+
+For full configuration (auth headers, timeouts, custom executor), use `make(options)`:
 
 ```scala
 import dev.openfeature.contrib.providers.ofrep.OfrepProviderOptions
@@ -193,10 +200,10 @@ val options = OfrepProviderOptions.builder()
   .headers(Map("Authorization" -> "Bearer my-token").asJava)
   .build()
 
-val layer = FeatureFlags.fromProvider(OFREPProvider.fromOptions(options))
+val provider = OFREPProvider.make(options)
 ```
 
-The factories return a `dev.openfeature.contrib.providers.ofrep.OfrepProvider` directly, so you can pass them to any `FeatureFlags.fromProvider*` builder without further wrapping.
+The legacy throwing factories — `OFREPProvider()`, `OFREPProvider(baseUrl)`, `OFREPProvider.fromOptions(options)` — remain available but are deprecated. They accept any string and surface configuration mistakes only at the first evaluation; prefer `make` / `layer` for validated construction.
 
 ### Configuration options
 

--- a/ofrep/src/main/scala/zio/openfeature/ofrep/OFREPProvider.scala
+++ b/ofrep/src/main/scala/zio/openfeature/ofrep/OFREPProvider.scala
@@ -1,14 +1,20 @@
 package zio.openfeature.ofrep
 
 import dev.openfeature.contrib.providers.ofrep.{OfrepProvider, OfrepProviderOptions}
+import zio._
+import zio.openfeature.FeatureFlagError
 
 /** Scala-friendly factories for the OpenFeature Java SDK's OFREP contrib provider
   * ([[dev.openfeature.contrib.providers.ofrep.OfrepProvider]]).
   *
   * OFREP (OpenFeature Remote Evaluation Protocol) is the standard HTTP protocol for vendor-neutral remote flag
-  * evaluation. The factories here just sugar over the contrib provider's static constructors; the returned value is a
-  * plain `OfrepProvider` (a `FeatureProvider`) that you pass to `FeatureFlags.fromProvider` or
+  * evaluation. The factories here sugar over the contrib provider's static constructors; the returned value is a plain
+  * `OfrepProvider` (a `FeatureProvider`) that you pass to `FeatureFlags.fromProvider` or
   * `FeatureFlags.fromProviderAsync` like any other provider.
+  *
+  * '''Recommended''': use [[make]] / [[layer]] for validated construction. The legacy throwing factories (`apply`,
+  * `fromOptions`) are kept for backwards compatibility but flagged deprecated — they accept any `baseUrl` string and
+  * surface configuration mistakes only at the first evaluation, as opaque `ProviderError(MalformedURLException)`.
   *
   * '''Experimental:''' the underlying contrib provider artifact is at version 0.0.1. The OFREP protocol itself is
   * pre-1.0; both the wire format and this Scala facade may evolve in breaking ways. Pin the dependency deliberately.
@@ -20,20 +26,106 @@ import dev.openfeature.contrib.providers.ofrep.{OfrepProvider, OfrepProviderOpti
   */
 object OFREPProvider {
 
-  /** Create an OFREP provider with the contrib provider's built-in default options (baseUrl defaults to whatever the
-    * contrib library declares — currently `http://localhost:8016`). Delegating to the contrib zero-arg constructor
-    * means we don't have to mirror its default URL here.
+  /** Validate a base URL and construct an OFREP provider. The validation rules are:
+    *   - non-empty after trim
+    *   - parses as a `java.net.URI`
+    *   - scheme is `http` or `https` (case-insensitive)
+    *   - non-empty host
+    *
+    * Any failure surfaces as `FeatureFlagError.InvalidConfiguration` so layer composition can fail at startup rather
+    * than at the first evaluation.
     */
+  def make(baseUrl: String): IO[FeatureFlagError.InvalidConfiguration, OfrepProvider] =
+    validateBaseUrl(baseUrl).flatMap { validated =>
+      ZIO
+        .attempt(
+          OfrepProvider.constructProvider(OfrepProviderOptions.builder().baseUrl(validated).build())
+        )
+        .mapError(t => FeatureFlagError.InvalidConfiguration(s"OFREP provider construction failed: ${t.getMessage}"))
+    }
+
+  /** Validate a fully-configured [[OfrepProviderOptions]] (auth headers, timeouts, executor, etc.) and construct the
+    * provider. Validates the options' `baseUrl` and rejects obvious misconfiguration up front.
+    */
+  def make(options: OfrepProviderOptions): IO[FeatureFlagError.InvalidConfiguration, OfrepProvider] =
+    for {
+      _ <- ZIO
+        .attempt(options.getBaseUrl)
+        .mapError(t =>
+          FeatureFlagError.InvalidConfiguration(s"could not read baseUrl from OfrepProviderOptions: ${t.getMessage}")
+        )
+        .flatMap {
+          case null  => ZIO.fail(FeatureFlagError.InvalidConfiguration("OfrepProviderOptions.baseUrl is null"))
+          case other => validateBaseUrl(other).unit
+        }
+      provider <- ZIO
+        .attempt(OfrepProvider.constructProvider(options))
+        .mapError(t => FeatureFlagError.InvalidConfiguration(s"OFREP provider construction failed: ${t.getMessage}"))
+    } yield provider
+
+  /** ZLayer convenience that wraps [[make(String)]]. Use as `OFREPProvider.layer("https://flags.example.com")` to wire
+    * an OFREP provider into a ZIO application; failures arrive as typed `FeatureFlagError.InvalidConfiguration` at
+    * layer build time.
+    */
+  def layer(baseUrl: String): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OfrepProvider] =
+    ZLayer.fromZIO(make(baseUrl))
+
+  /** ZLayer convenience that wraps [[make(OfrepProviderOptions)]]. */
+  def layer(options: OfrepProviderOptions): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OfrepProvider] =
+    ZLayer.fromZIO(make(options))
+
+  /** Create an OFREP provider with the contrib provider's built-in default options (baseUrl defaults to whatever the
+    * contrib library declares — currently `http://localhost:8016`).
+    *
+    * @deprecated
+    *   Use `OFREPProvider.make(...)` or `OFREPProvider.layer(...)` for validated construction.
+    */
+  @deprecated("Use OFREPProvider.make(...) or OFREPProvider.layer(...) for validated construction", "0.2.0")
   def apply(): OfrepProvider =
     OfrepProvider.constructProvider()
 
-  /** Create an OFREP provider pointed at a specific endpoint, otherwise using contrib defaults. */
+  /** Create an OFREP provider pointed at a specific endpoint, otherwise using contrib defaults.
+    *
+    * @deprecated
+    *   Use `OFREPProvider.make(baseUrl)` or `OFREPProvider.layer(baseUrl)` for validated construction.
+    */
+  @deprecated("Use OFREPProvider.make(baseUrl) or OFREPProvider.layer(baseUrl) for validated construction", "0.2.0")
   def apply(baseUrl: String): OfrepProvider =
     OfrepProvider.constructProvider(OfrepProviderOptions.builder().baseUrl(baseUrl).build())
 
-  /** Create an OFREP provider with a fully configured [[OfrepProviderOptions]] (auth headers, timeouts, executor,
-    * etc.).
+  /** Create an OFREP provider with a fully configured [[OfrepProviderOptions]].
+    *
+    * @deprecated
+    *   Use `OFREPProvider.make(options)` or `OFREPProvider.layer(options)` for validated construction.
     */
+  @deprecated("Use OFREPProvider.make(options) or OFREPProvider.layer(options) for validated construction", "0.2.0")
   def fromOptions(options: OfrepProviderOptions): OfrepProvider =
     OfrepProvider.constructProvider(options)
+
+  // Validation
+
+  private val AllowedSchemes = Set("http", "https")
+
+  private def validateBaseUrl(raw: String): IO[FeatureFlagError.InvalidConfiguration, String] = {
+    val invalid: String => FeatureFlagError.InvalidConfiguration =
+      reason => FeatureFlagError.InvalidConfiguration(reason)
+    if (raw == null) ZIO.fail(invalid("baseUrl is null"))
+    else {
+      val trimmed = raw.trim
+      if (trimmed.isEmpty) ZIO.fail(invalid("baseUrl is empty"))
+      else
+        ZIO
+          .attempt(java.net.URI.create(trimmed))
+          .mapError(t => invalid(s"malformed baseUrl '$trimmed': ${t.getMessage}"))
+          .flatMap { uri =>
+            val scheme = Option(uri.getScheme).map(_.toLowerCase).getOrElse("")
+            val host   = Option(uri.getHost).getOrElse("")
+            if (!AllowedSchemes.contains(scheme))
+              ZIO.fail(invalid(s"unsupported scheme '$scheme' in baseUrl '$trimmed' (expected http or https)"))
+            else if (host.isEmpty)
+              ZIO.fail(invalid(s"baseUrl '$trimmed' has no host"))
+            else ZIO.succeed(trimmed)
+          }
+    }
+  }
 }

--- a/ofrep/src/test/scala/zio/openfeature/ofrep/OFREPProviderIntegrationSpec.scala
+++ b/ofrep/src/test/scala/zio/openfeature/ofrep/OFREPProviderIntegrationSpec.scala
@@ -3,7 +3,9 @@ package zio.openfeature.ofrep
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import dev.openfeature.contrib.providers.ofrep.OfrepProvider
 import dev.openfeature.sdk.{ErrorCode, ImmutableContext, MutableContext, Value}
+import zio._
 import zio.test._
 
 /** End-to-end tests against a WireMock-backed OFREP server. Verifies that the OFREP contrib provider's wire calls match
@@ -27,6 +29,15 @@ object OFREPProviderIntegrationSpec extends ZIOSpecDefault {
   private def baseUrl(server: WireMockServer): String =
     s"http://localhost:${server.port()}"
 
+  /** Unsafe-run `OFREPProvider.make` so the existing test bodies can stay synchronous. The URLs are always
+    * `http://localhost:<dynamic port>`, so validation never actually fails — but exercising the validated factory keeps
+    * the spec aligned with the recommended API.
+    */
+  private def makeProvider(url: String): OfrepProvider =
+    Unsafe.unsafe { implicit u =>
+      Runtime.default.unsafe.run(OFREPProvider.make(url)).getOrThrowFiberFailure()
+    }
+
   def spec = suite("OFREP integration (WireMock)")(
     test("getBooleanEvaluation returns the server's value") {
       withMockServer { server =>
@@ -36,7 +47,7 @@ object OFREPProviderIntegrationSpec extends ZIOSpecDefault {
               okJson("""{"key":"bool-flag","value":true,"variant":"on","reason":"TARGETING_MATCH"}""")
             )
         )
-        val provider = OFREPProvider(baseUrl(server))
+        val provider = makeProvider(baseUrl(server))
         try {
           val result = provider.getBooleanEvaluation("bool-flag", java.lang.Boolean.FALSE, emptyContext)
           assertTrue(result.getValue == java.lang.Boolean.TRUE) &&
@@ -50,7 +61,7 @@ object OFREPProviderIntegrationSpec extends ZIOSpecDefault {
           post(urlEqualTo("/ofrep/v1/evaluate/flags/greeting"))
             .willReturn(okJson("""{"key":"greeting","value":"hello","reason":"STATIC"}"""))
         )
-        val provider = OFREPProvider(baseUrl(server))
+        val provider = makeProvider(baseUrl(server))
         try {
           val result = provider.getStringEvaluation("greeting", "default", emptyContext)
           assertTrue(result.getValue == "hello")
@@ -63,7 +74,7 @@ object OFREPProviderIntegrationSpec extends ZIOSpecDefault {
           post(urlEqualTo("/ofrep/v1/evaluate/flags/max-items"))
             .willReturn(okJson("""{"key":"max-items","value":42,"reason":"STATIC"}"""))
         )
-        val provider = OFREPProvider(baseUrl(server))
+        val provider = makeProvider(baseUrl(server))
         try {
           val result = provider.getIntegerEvaluation("max-items", Integer.valueOf(0), emptyContext)
           assertTrue(result.getValue == Integer.valueOf(42))
@@ -76,7 +87,7 @@ object OFREPProviderIntegrationSpec extends ZIOSpecDefault {
           post(urlEqualTo("/ofrep/v1/evaluate/flags/rate"))
             .willReturn(okJson("""{"key":"rate","value":2.5,"reason":"STATIC"}"""))
         )
-        val provider = OFREPProvider(baseUrl(server))
+        val provider = makeProvider(baseUrl(server))
         try {
           val result = provider.getDoubleEvaluation("rate", java.lang.Double.valueOf(0.0), emptyContext)
           assertTrue(result.getValue == java.lang.Double.valueOf(2.5))
@@ -91,7 +102,7 @@ object OFREPProviderIntegrationSpec extends ZIOSpecDefault {
               okJson("""{"key":"config","value":{"timeout":30,"retries":3},"reason":"STATIC"}""")
             )
         )
-        val provider = OFREPProvider(baseUrl(server))
+        val provider = makeProvider(baseUrl(server))
         try {
           val result = provider.getObjectEvaluation("config", new Value(), emptyContext)
           assertTrue(result.getValue != null) &&
@@ -110,7 +121,7 @@ object OFREPProviderIntegrationSpec extends ZIOSpecDefault {
                 .withBody("""{"errorCode":"FLAG_NOT_FOUND","errorDetails":"Flag not found"}""")
             )
         )
-        val provider = OFREPProvider(baseUrl(server))
+        val provider = makeProvider(baseUrl(server))
         try {
           val result = provider.getBooleanEvaluation("missing-flag", java.lang.Boolean.FALSE, emptyContext)
           assertTrue(result.getValue == java.lang.Boolean.FALSE) &&
@@ -129,7 +140,7 @@ object OFREPProviderIntegrationSpec extends ZIOSpecDefault {
                 .withBody("""{"errorCode":"GENERAL","errorDetails":"unauthorized"}""")
             )
         )
-        val provider = OFREPProvider(baseUrl(server))
+        val provider = makeProvider(baseUrl(server))
         try {
           val result = provider.getBooleanEvaluation("protected-flag", java.lang.Boolean.FALSE, emptyContext)
           assertTrue(result.getValue == java.lang.Boolean.FALSE) &&
@@ -146,7 +157,7 @@ object OFREPProviderIntegrationSpec extends ZIOSpecDefault {
             .withRequestBody(matchingJsonPath("$.context.plan", equalTo("premium")))
             .willReturn(okJson("""{"key":"personalised","value":true,"reason":"TARGETING_MATCH"}"""))
         )
-        val provider = OFREPProvider(baseUrl(server))
+        val provider = makeProvider(baseUrl(server))
         try {
           val ctx = new MutableContext("user-42")
           ctx.add("plan", "premium")

--- a/ofrep/src/test/scala/zio/openfeature/ofrep/OFREPProviderSpec.scala
+++ b/ofrep/src/test/scala/zio/openfeature/ofrep/OFREPProviderSpec.scala
@@ -4,7 +4,7 @@ import dev.openfeature.contrib.providers.ofrep.OfrepProvider
 import dev.openfeature.contrib.providers.ofrep.OfrepProviderOptions
 import dev.openfeature.sdk.ProviderState
 import zio._
-import zio.openfeature.FeatureFlags
+import zio.openfeature.{FeatureFlagError, FeatureFlags}
 import zio.test._
 import java.time.Duration
 
@@ -18,35 +18,148 @@ object OFREPProviderSpec extends ZIOSpecDefault {
     s
   }
 
+  @scala.annotation.nowarn("msg=deprecated")
+  private def legacyApply(): OfrepProvider = OFREPProvider()
+  @scala.annotation.nowarn("msg=deprecated")
+  private def legacyApply(baseUrl: String): OfrepProvider = OFREPProvider(baseUrl)
+  @scala.annotation.nowarn("msg=deprecated")
+  private def legacyFromOptions(o: OfrepProviderOptions): OfrepProvider = OFREPProvider.fromOptions(o)
+
   def spec = suite("OFREPProvider factories")(
-    test("apply() returns an OfrepProvider with ofrep metadata") {
-      val provider = OFREPProvider()
-      try
-        assertTrue(provider.getMetadata.getName.toLowerCase.contains("ofrep")) &&
-          assertTrue(stateOf(provider) != null)
-      finally provider.shutdown()
-    },
-    test("apply(baseUrl) returns a configured OfrepProvider") {
-      val provider = OFREPProvider("http://localhost:9999")
-      try assertTrue(provider.getMetadata.getName.toLowerCase.contains("ofrep"))
-      finally provider.shutdown()
-    },
-    test("fromOptions accepts a fully-built OfrepProviderOptions") {
-      val opts = OfrepProviderOptions
-        .builder()
-        .baseUrl("http://localhost:9999")
-        .requestTimeout(Duration.ofSeconds(5))
-        .connectTimeout(Duration.ofSeconds(5))
-        .build()
-      val provider = OFREPProvider.fromOptions(opts)
-      try assertTrue(provider.getMetadata.getName.toLowerCase.contains("ofrep"))
-      finally provider.shutdown()
-    },
-    test("returned provider integrates with FeatureFlags.fromProviderAsync (compile-time check)") {
-      // If the factory's return type isn't FeatureProvider-compatible, this won't compile.
-      val _: ZLayer[Scope, Throwable, FeatureFlags] =
-        FeatureFlags.fromProviderAsync(OFREPProvider("http://localhost:9999"))
-      assertCompletes
-    }
+    suite("legacy throwing factories (deprecated, kept for backwards compatibility)")(
+      test("apply() returns an OfrepProvider with ofrep metadata") {
+        val provider = legacyApply()
+        try
+          assertTrue(provider.getMetadata.getName.toLowerCase.contains("ofrep")) &&
+            assertTrue(stateOf(provider) != null)
+        finally provider.shutdown()
+      },
+      test("apply(baseUrl) returns a configured OfrepProvider") {
+        val provider = legacyApply("http://localhost:9999")
+        try assertTrue(provider.getMetadata.getName.toLowerCase.contains("ofrep"))
+        finally provider.shutdown()
+      },
+      test("fromOptions accepts a fully-built OfrepProviderOptions") {
+        val opts = OfrepProviderOptions
+          .builder()
+          .baseUrl("http://localhost:9999")
+          .requestTimeout(Duration.ofSeconds(5))
+          .connectTimeout(Duration.ofSeconds(5))
+          .build()
+        val provider = legacyFromOptions(opts)
+        try assertTrue(provider.getMetadata.getName.toLowerCase.contains("ofrep"))
+        finally provider.shutdown()
+      },
+      test("returned provider integrates with FeatureFlags.fromProviderAsync (compile-time check)") {
+        val _: ZLayer[Scope, Throwable, FeatureFlags] =
+          FeatureFlags.fromProviderAsync(legacyApply("http://localhost:9999"))
+        assertCompletes
+      }
+    ),
+    suite("make(baseUrl) — validated construction")(
+      test("rejects null baseUrl") {
+        for {
+          result <- OFREPProvider.make(null: String).either
+        } yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.message.toLowerCase.contains("null"))
+        )
+      },
+      test("rejects empty baseUrl") {
+        for {
+          result <- OFREPProvider.make("").either
+        } yield assertTrue(result.isLeft, result.left.exists(_.message.toLowerCase.contains("empty")))
+      },
+      test("rejects whitespace-only baseUrl") {
+        for {
+          result <- OFREPProvider.make("   ").either
+        } yield assertTrue(result.isLeft, result.left.exists(_.message.toLowerCase.contains("empty")))
+      },
+      test("rejects unsupported scheme (ftp)") {
+        for {
+          result <- OFREPProvider.make("ftp://example.com").either
+        } yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.message.toLowerCase.contains("unsupported scheme"))
+        )
+      },
+      test("rejects malformed URL") {
+        for {
+          result <- OFREPProvider.make("not a url at all").either
+        } yield assertTrue(result.isLeft)
+      },
+      test("rejects URL with no host") {
+        for {
+          result <- OFREPProvider.make("http:///path").either
+        } yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.message.toLowerCase.contains("no host"))
+        )
+      },
+      test("accepts valid http URL") {
+        for {
+          provider <- OFREPProvider.make("http://localhost:9999")
+        } yield try assertTrue(provider.getMetadata.getName.toLowerCase.contains("ofrep"))
+        finally provider.shutdown()
+      },
+      test("accepts valid https URL with path") {
+        for {
+          provider <- OFREPProvider.make("https://flags.example.com/api/ofrep")
+        } yield try assertCompletes
+        finally provider.shutdown()
+      },
+      test("accepts URL with uppercase scheme") {
+        for {
+          provider <- OFREPProvider.make("HTTPS://flags.example.com")
+        } yield try assertCompletes
+        finally provider.shutdown()
+      }
+    ),
+    suite("make(OfrepProviderOptions)")(
+      test("rejects options with bad scheme") {
+        val opts = OfrepProviderOptions.builder().baseUrl("ftp://flags.example.com").build()
+        for {
+          result <- OFREPProvider.make(opts).either
+        } yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.message.toLowerCase.contains("unsupported scheme"))
+        )
+      },
+      test("accepts options with a valid baseUrl") {
+        val opts = OfrepProviderOptions
+          .builder()
+          .baseUrl("http://localhost:9999")
+          .requestTimeout(Duration.ofSeconds(5))
+          .build()
+        for {
+          provider <- OFREPProvider.make(opts)
+        } yield try assertTrue(provider.getMetadata.getName.toLowerCase.contains("ofrep"))
+        finally provider.shutdown()
+      }
+    ),
+    suite("layer")(
+      test("layer wraps make and produces a typed error on bad input") {
+        val build = ZIO.scoped(OFREPProvider.layer("ftp://example.com").build).either
+        for {
+          result <- build
+        } yield assertTrue(
+          result.isLeft,
+          // ZLayer build wraps the typed error inside a Cause; we check the leaf type.
+          result.left.exists(_.isInstanceOf[FeatureFlagError.InvalidConfiguration])
+        )
+      },
+      test("layer accepts a valid URL and yields an OfrepProvider in the environment") {
+        val build = ZIO.scoped(
+          OFREPProvider
+            .layer("http://localhost:9999")
+            .build
+            .map(_.get[OfrepProvider])
+        )
+        for {
+          provider <- build
+        } yield try assertTrue(provider.getMetadata.getName.toLowerCase.contains("ofrep"))
+        finally provider.shutdown()
+      }
+    )
   )
 }


### PR DESCRIPTION
## Summary

Implements **#123 (typed `Unauthorized`/`Unreachable` errors)** and **#122 (OFREP construction validation)** — workstream A3 + A4 of the [1.0-readiness](https://github.com/EtaCassiopeia/zio-openfeature/milestone/1) plan.

### A4 — typed auth/network errors

- New cases in `FeatureFlagError`:
  - `Unauthorized(reason: String)` — operator-actionable signal that the remote provider rejected the request (HTTP 401/403 or analogous). Distinguishes a misconfigured SDK key from a generic provider error.
  - `Unreachable(cause: Throwable)` — network-layer failure (DNS, connection refused, no route). Distinct from a slow response (`ProviderError(TimeoutException)`) or an HTTP-level rejection.
- `FeatureFlagError.classify(t: Throwable)` — single classifier used wherever the library wraps an underlying Throwable from a provider. Recognises `UnknownHostException`, `ConnectException`, `NoRouteToHostException`, and matches common HTTP auth exception classes / messages (`401`, `403`, `Unauthorized`, `Forbidden`). Everything else falls back to `ProviderError(t)` with the cause preserved.
- All 7 `ProviderError(_)` call sites in `FeatureFlagsLive` route through `classify` now. No code path was lost — `ProviderError` remains the fallback.
- `isProviderError` and `toErrorCode` updated for the new cases.

### A3 — OFREP construction validation

- New ZIO-effectful factories on `OFREPProvider`:
  - `make(baseUrl: String): IO[FeatureFlagError.InvalidConfiguration, OfrepProvider]`
  - `make(options: OfrepProviderOptions): IO[FeatureFlagError.InvalidConfiguration, OfrepProvider]`
  - `layer(baseUrl: String): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OfrepProvider]`
  - `layer(options: OfrepProviderOptions): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OfrepProvider]`
- Validation rules: non-empty after trim, parseable URI, scheme `http`/`https`, non-empty host.
- Legacy throwing factories (`apply()`, `apply(baseUrl)`, `fromOptions`) kept for backwards compatibility but annotated `@deprecated` so callers migrate over time.
- The existing WireMock integration spec was migrated to the validated factory via a small `makeProvider` test helper, so the recommended API is also the one exercised in CI.

Closes #122
Closes #123