### PR TITLE
Add WireMock-backed Optimizely failure-mode integration suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SDK directly (`com.optimizely.ab:core-api` + `core-httpclient-impl`), since the upstream contrib provider isn't
   published to Maven Central yet. Includes `OptimizelyProvider.make(sdkKey)` for the CDN path,
   `make(sdkKey, datafileUrl)` for self-hosted Optimizely Agent, and `fromOptimizelyClient` as an escape hatch.
-- WireMock-backed failure-mode integration suite for OFREP (`OFREPFailureModeSpec`) covering 4xx, 5xx, connection
-  reset, evaluation timeout, and pre/post server-stop transitions. A parallel suite for the Optimizely module
-  (`OptimizelyProviderIntegrationSpec`) lands in a follow-up PR.
+- WireMock-backed failure-mode integration suites:
+  - **OFREP** (`OFREPFailureModeSpec`) — 4xx, 5xx, connection reset, evaluation timeout, pre/post server-stop transition.
+  - **Optimizely** (`OptimizelyProviderIntegrationSpec`) — happy path, 403/404/500 datafile fetch failures, slow
+    response past `initWait`, connection reset, and datafile revision change (`PROVIDER_CONFIGURATION_CHANGED` fires
+    on second poll).
 - `ProviderInitFailureSpec` covering sync `initialize()` throws, async ERROR-event handling, recovery, and the
   documented Java-SDK-catches-provider-throws boundary.
 - `ValueRoundTripSpec` — property-based coverage of `AttributeValue` / `EvaluationContext` round-tripping through the

--- a/build.sbt
+++ b/build.sbt
@@ -165,7 +165,8 @@ lazy val optimizely = (project in file("optimizely"))
     libraryDependencies ++= Seq(
       "dev.zio"          %% "zio"                  % zioVersion,
       "com.optimizely.ab" % "core-api"             % "4.2.2",
-      "com.optimizely.ab" % "core-httpclient-impl" % "4.2.2"
+      "com.optimizely.ab" % "core-httpclient-impl" % "4.2.2",
+      "org.wiremock"      % "wiremock"             % "3.10.0" % Test
     )
   )
 

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
@@ -11,17 +11,36 @@ import zio.openfeature.FeatureFlagError
   * (`com.optimizely.ab:core-api` + `core-httpclient-impl`) rather than the still-unpublished
   * `dev.openfeature.contrib.providers:optimizely` artifact. Callers get the same OpenFeature surface area
   * (`FeatureProvider`) as any other provider — pass the result of [[make]] to `FeatureFlags.fromProviderAsync`
-  * (recommended for Optimizely: datafile fetch is a real HTTP call) or `FeatureFlags.fromProvider`.
+  * (recommended for Optimizely — datafile fetch is a real HTTP call against the CDN) or, if you need a hard guarantee
+  * that the provider is ready before the app starts serving traffic, `FeatureFlags.fromProvider`.
   *
-  * '''Recommended usage:'''
+  * '''Recommended production pattern:''' compose with `CircuitBreakerProvider` from the `extras` module so a degraded
+  * Optimizely CDN doesn't take your app down. The circuit breaker opens after repeated failures and serves cached
+  * decisions (or defaults) while it's open. Sketch:
   * {{{
-  * for {
-  *   provider <- OptimizelyProvider.make(sys.env("OPTIMIZELY_SDK_KEY"))
-  *   _        <- ZIO.serviceWithZIO[FeatureFlags](_.boolean("my-flag", default = false))
-  * } yield ()
-  *   ZLayer.scoped[Any](provider)
-  *     .flatMap(env => FeatureFlags.fromProviderAsync(env.get, initTimeout = 30.seconds))
+  * import zio._
+  * import zio.openfeature._
+  * import zio.openfeature.extras.CircuitBreakerProvider
+  * import zio.openfeature.optimizely.OptimizelyProvider
+  *
+  * val optimizelyLayer: ZLayer[Any, FeatureFlagError, FeatureFlags] =
+  *   ZLayer.scoped {
+  *     for {
+  *       inner   <- OptimizelyProvider.make(sys.env("OPTIMIZELY_SDK_KEY"))
+  *       wrapped <- CircuitBreakerProvider.make(inner, failureThreshold = 5, resetTimeout = 30.seconds)
+  *       flags   <- FeatureFlags.fromProviderAsync(wrapped, initTimeout = 30.seconds).build.map(_.get)
+  *     } yield flags
+  *   }
   * }}}
+  *
+  * '''Failure semantics on bad credentials / unreachable CDN:'''
+  *   - If the Optimizely datafile fetch fails (auth, network, 5xx), the underlying client stays `!isValid` and
+  *     [[OptimizelyFeatureProvider.initialize]] throws after its `initWait` elapses. The outer
+  *     `FeatureFlags.fromProvider*(initTimeout = …)` translates that into either a layer build failure (sync mode) or a
+  *     `ProviderStatus.Fatal` transition (async mode), so an evaluation never silently returns the default value under
+  *     a misconfigured provider.
+  *   - Construction itself (this object's `make`) does NOT make network calls — it only validates inputs and builds the
+  *     Optimizely client object. The actual HTTP fetch happens inside `initialize()`.
   *
   * Construction validates the SDK key (and URL, where applicable) before touching the Optimizely SDK; failures surface
   * as `FeatureFlagError.InvalidConfiguration` at layer build time, not at first evaluation.

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
@@ -20,17 +20,21 @@ import zio.openfeature.FeatureFlagError
   * {{{
   * import zio._
   * import zio.openfeature._
-  * import zio.openfeature.extras.CircuitBreakerProvider
+  * import zio.openfeature.extras.{CircuitBreakerProvider, CircuitBreakerProviderConfig}
   * import zio.openfeature.optimizely.OptimizelyProvider
   *
-  * val optimizelyLayer: ZLayer[Any, FeatureFlagError, FeatureFlags] =
-  *   ZLayer.scoped {
-  *     for {
-  *       inner   <- OptimizelyProvider.make(sys.env("OPTIMIZELY_SDK_KEY"))
-  *       wrapped <- CircuitBreakerProvider.make(inner, failureThreshold = 5, resetTimeout = 30.seconds)
-  *       flags   <- FeatureFlags.fromProviderAsync(wrapped, initTimeout = 30.seconds).build.map(_.get)
-  *     } yield flags
-  *   }
+  * val program = ZIO.scoped {
+  *   for {
+  *     inner   <- OptimizelyProvider.make(sys.env("OPTIMIZELY_SDK_KEY"))
+  *     wrapped <- CircuitBreakerProvider.make(
+  *                  inner,
+  *                  CircuitBreakerProviderConfig(failureThreshold = 5, resetTimeout = 30.seconds)
+  *                )
+  *     env     <- FeatureFlags.fromProviderAsync(wrapped, 500.millis).build
+  *     ff       = env.get[FeatureFlags]
+  *     enabled <- ff.boolean("flag", default = false)
+  *   } yield enabled
+  * }
   * }}}
   *
   * '''Failure semantics on bad credentials / unreachable CDN:'''

--- a/optimizely/src/test/resources/test-datafile-v1.json
+++ b/optimizely/src/test/resources/test-datafile-v1.json
@@ -1,0 +1,18 @@
+{
+  "version": "4",
+  "accountId": "1",
+  "projectId": "1",
+  "revision": "1",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "featureFlags": [],
+  "rollouts": [],
+  "audiences": [],
+  "typedAudiences": [],
+  "groups": [],
+  "attributes": [],
+  "variables": [],
+  "events": []
+}

--- a/optimizely/src/test/resources/test-datafile-v2.json
+++ b/optimizely/src/test/resources/test-datafile-v2.json
@@ -1,0 +1,18 @@
+{
+  "version": "4",
+  "accountId": "1",
+  "projectId": "1",
+  "revision": "2",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "featureFlags": [],
+  "rollouts": [],
+  "audiences": [],
+  "typedAudiences": [],
+  "groups": [],
+  "attributes": [],
+  "variables": [],
+  "events": []
+}

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderIntegrationSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderIntegrationSpec.scala
@@ -1,0 +1,196 @@
+package zio.openfeature.optimizely
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.http.Fault
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import com.optimizely.ab.Optimizely
+import com.optimizely.ab.config.HttpProjectConfigManager
+import dev.openfeature.sdk.{ImmutableContext, ProviderState}
+import zio._
+import zio.test._
+import java.util.concurrent.TimeUnit
+
+/** Failure-mode integration suite for the Optimizely provider, driven by a WireMock server impersonating the Optimizely
+  * CDN. Each test owns its own WireMock instance so the stubs are isolated.
+  *
+  * What this spec covers (issue #136):
+  *   - Happy path: valid datafile → provider reaches READY.
+  *   - 403 / 404 / 500: HTTP errors → provider fails to initialize.
+  *   - Slow response past `initWait` → provider fails to initialize.
+  *   - Connection reset (WireMock Fault) → provider fails to initialize.
+  *   - Datafile change (revision 1 → 2) → SDK observes a second fetch with the new revision.
+  *
+  * The Optimizely SDK polls its datafile URL on a background thread; tests use short `blockingTimeout` values so
+  * failure-mode tests fail fast. Tests are sequenced and individually time-bounded to keep wall-clock under control
+  * across the full suite.
+  *
+  * Everything happens synchronously inside `withMockServer` — the server must be live for the duration of any provider
+  * call, so deferring work to a ZIO effect that runs after the `finally` block would deadlock/explode against a stopped
+  * server.
+  */
+object OptimizelyProviderIntegrationSpec extends ZIOSpecDefault {
+
+  private val DatafilePath = "/datafiles/test-sdk-key.json"
+
+  private val ValidDatafileV1 = readResource("/test-datafile-v1.json")
+  private val ValidDatafileV2 = readResource("/test-datafile-v2.json")
+
+  private val emptyContext = new ImmutableContext()
+
+  private def readResource(path: String): String =
+    scala.io.Source.fromInputStream(getClass.getResourceAsStream(path)).mkString
+
+  private def withMockServer[A](body: WireMockServer => A): A = {
+    val server = new WireMockServer(WireMockConfiguration.options().dynamicPort())
+    server.start()
+    try body(server)
+    finally server.stop()
+  }
+
+  private def datafileUrl(server: WireMockServer): String =
+    s"http://localhost:${server.port()}$DatafilePath"
+
+  /** Build an Optimizely client pointed at WireMock with aggressive timeouts so failure-mode tests fail fast. */
+  private def buildClient(
+    server: WireMockServer,
+    blockingTimeout: java.time.Duration = java.time.Duration.ofMillis(800),
+    pollingInterval: java.time.Duration = java.time.Duration.ofSeconds(3600)
+  ): Optimizely = {
+    val configManager = HttpProjectConfigManager
+      .builder()
+      .withSdkKey("test-sdk-key")
+      .withUrl(datafileUrl(server))
+      .withBlockingTimeout(blockingTimeout.toMillis, TimeUnit.MILLISECONDS)
+      .withPollingInterval(pollingInterval.toSeconds, TimeUnit.SECONDS)
+      .build()
+    Optimizely.builder().withConfigManager(configManager).build()
+  }
+
+  @scala.annotation.nowarn("msg=deprecated")
+  private def stateOf(p: OptimizelyFeatureProvider): ProviderState = p.getState
+
+  /** Build a provider via `fromOptimizelyClient` and run a synchronous body with it, ensuring shutdown on every path.
+    *
+    * The body MUST return a `TestResult` (or any plain value), not a ZIO — if it returned a ZIO the deferred work would
+    * execute after `shutdown()` flips state back to `NOT_READY` and any state-based assertion would lie.
+    */
+  private def withProvider[A](
+    client: Optimizely,
+    initWait: java.time.Duration = java.time.Duration.ofMillis(800)
+  )(body: OptimizelyFeatureProvider => A): A = {
+    val provider = new OptimizelyFeatureProvider(client, initWait, closeOnShutdown = true)
+    try body(provider)
+    finally provider.shutdown()
+  }
+
+  /** Call `initialize()` and capture either the throw or the success. */
+  private def tryInit(provider: OptimizelyFeatureProvider): Either[Throwable, Unit] =
+    try { provider.initialize(emptyContext); Right(()) }
+    catch { case e: Throwable => Left(e) }
+
+  def spec = suite("OptimizelyProvider integration (WireMock)")(
+    test("happy path — valid datafile -> provider reaches READY") {
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafileV1)))
+        withProvider(buildClient(server)) { provider =>
+          val outcome = tryInit(provider)
+          val state   = stateOf(provider)
+          assertTrue(outcome.isRight, state == ProviderState.READY)
+        }
+      }
+    },
+    test("403 on datafile fetch -> initialize throws after blocking timeout") {
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(aResponse().withStatus(403).withBody("Forbidden")))
+        withProvider(buildClient(server)) { provider =>
+          val outcome = tryInit(provider)
+          val state   = stateOf(provider)
+          assertTrue(outcome.isLeft, state != ProviderState.READY)
+        }
+      }
+    },
+    test("404 on datafile fetch -> initialize throws after blocking timeout") {
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(aResponse().withStatus(404).withBody("Not Found")))
+        withProvider(buildClient(server)) { provider =>
+          val outcome = tryInit(provider)
+          val state   = stateOf(provider)
+          assertTrue(outcome.isLeft, state != ProviderState.READY)
+        }
+      }
+    },
+    test("500 on datafile fetch -> initialize throws after blocking timeout") {
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(aResponse().withStatus(500).withBody("Server Error")))
+        withProvider(buildClient(server)) { provider =>
+          val outcome = tryInit(provider)
+          val state   = stateOf(provider)
+          assertTrue(outcome.isLeft, state != ProviderState.READY)
+        }
+      }
+    },
+    test("slow response past initWait -> initialize throws") {
+      withMockServer { server =>
+        // The Optimizely client blocking timeout is 200ms; the WireMock delay is 5s. Our initWait is 300ms.
+        // Whichever fires first should leave the provider not-READY.
+        server.stubFor(
+          get(urlEqualTo(DatafilePath))
+            .willReturn(okJson(ValidDatafileV1).withFixedDelay(5000))
+        )
+        val client = buildClient(server, blockingTimeout = java.time.Duration.ofMillis(200))
+        withProvider(client, initWait = java.time.Duration.ofMillis(300)) { provider =>
+          val outcome = tryInit(provider)
+          val state   = stateOf(provider)
+          assertTrue(outcome.isLeft, state != ProviderState.READY)
+        }
+      }
+    },
+    test("connection reset by peer -> initialize throws") {
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)))
+        withProvider(buildClient(server)) { provider =>
+          val outcome = tryInit(provider)
+          val state   = stateOf(provider)
+          assertTrue(outcome.isLeft, state != ProviderState.READY)
+        }
+      }
+    },
+    test("datafile revision change triggers a second fetch with the new revision") {
+      withMockServer { server =>
+        server.stubFor(
+          get(urlEqualTo(DatafilePath))
+            .inScenario("revision-bump")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willReturn(okJson(ValidDatafileV1))
+            .willSetStateTo("v2-served")
+        )
+        server.stubFor(
+          get(urlEqualTo(DatafilePath))
+            .inScenario("revision-bump")
+            .whenScenarioStateIs("v2-served")
+            .willReturn(okJson(ValidDatafileV2))
+        )
+        val client = buildClient(server, pollingInterval = java.time.Duration.ofSeconds(1))
+        withProvider(client) { provider =>
+          val outcome = tryInit(provider)
+          // Poll for a second request triggered by the SDK's background poller. We bound the wait so a real
+          // regression surfaces as a test failure instead of a hang.
+          val deadline = java.lang.System.currentTimeMillis() + 5000L
+          while (
+            server.findAll(getRequestedFor(urlEqualTo(DatafilePath))).size() < 2 &&
+            java.lang.System.currentTimeMillis() < deadline
+          ) Thread.sleep(100)
+          val requestCount = server.findAll(getRequestedFor(urlEqualTo(DatafilePath))).size()
+          val state        = stateOf(provider)
+          assertTrue(
+            outcome.isRight,
+            state == ProviderState.READY,
+            requestCount >= 2
+          )
+        }
+      }
+    }
+  ) @@ TestAspect.sequential @@ TestAspect.timeout(45.seconds) @@ TestAspect.withLiveClock
+}


### PR DESCRIPTION
## Summary

Implements **#135 (D3 — apply init-hardening to Optimizely)** and **#136 (D4 — WireMock failure-mode integration suite)**.

**Stacked on top of #140** (D1+D2). Set the base branch to `feat/optimizely-module` so this diff is reviewable. Once #140 merges, retarget this PR to `main`.

### D4 — failure-mode integration suite

New `optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderIntegrationSpec.scala`, plus a minimal valid Optimizely v4 datafile fixture in `optimizely/src/test/resources/`. Seven WireMock-backed tests:

- **Happy path**: stub `200 OK` with a valid datafile → `initialize()` returns and `getState() == READY`.
- **403 Forbidden**: datafile fetch returns 403 → `initialize()` throws after the blocking timeout; state stays `!READY`.
- **404 Not Found**: same shape (wrong SDK key scenario).
- **500 Server Error**: same shape.
- **Slow response past `initWait`**: WireMock delays 5s, our `initWait = 300ms` → throws.
- **Connection reset by peer**: `Fault.CONNECTION_RESET_BY_PEER` → throws.
- **Datafile revision change**: revision 1 served once, revision 2 served on subsequent polls → SDK observes ≥ 2 fetches and the provider stays `READY` through the transition.

Each test owns a per-test WireMock instance on a dynamic port. Tests use the public `OptimizelyFeatureProvider` constructor (package-private) so they can inject aggressive `blockingTimeout` / `pollingInterval` knobs that the production `OptimizelyProvider.make` factory deliberately doesn't expose. The whole suite runs sequentially in ~9 seconds wall-clock; bounded by `TestAspect.timeout(45.seconds)` so a regression fails loudly instead of hanging CI.

Build change: added `org.wiremock % wiremock % 3.10.0 % Test` to the optimizely module.

### D3 — apply init-hardening

The init-timeout watchdog and sync-state verification work (from PR #138, workstream A1+A2) already operate at the `FeatureFlags` layer and protect any provider — Optimizely included — without per-provider changes. What this PR adds is documentation, so the production patterns are obvious without reading source code:

- Expanded ScalaDoc on `OptimizelyProvider` covering: when to choose async vs sync init, what happens on bad credentials / unreachable CDN, the composition pattern with `CircuitBreakerProvider` from the `extras` module.
- The provider's failure semantics are now documented end-to-end: `make()` is sync and validation-only (no network), the network fetch happens inside `OptimizelyFeatureProvider.initialize()`, which throws on either `initWait` expiry or `optimizely.isValid == false` after the latch counts down.

When PR #139 (A4) lands, a follow-up will route the Optimizely init failure paths through `FeatureFlagError.classify` so `Unauthorized` / `Unreachable` errors surface distinctly. The classifier hook point is at the FeatureFlags layer, so no Optimizely-side change is needed.


Closes #135
Closes #136