### PR TITLE
Add property-based round-trip spec and concurrency spec

### DIFF
--- a/core/src/test/scala/zio/openfeature/ValueRoundTripSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ValueRoundTripSpec.scala
@@ -1,0 +1,174 @@
+package zio.openfeature
+
+import zio._
+import zio.openfeature.internal.ContextConverter
+import zio.test._
+
+/** Property-based coverage of value round-tripping through the OpenFeature Java SDK boundary (workstream B3).
+  *
+  * The cross-boundary conversion is intentionally lossy because the Java SDK normalises every numeric to a single
+  * `Double` type, so `IntValue` and `LongValue` are mediated through `Double` and may come back as a different concrete
+  * `AttributeValue` case. The properties below pin the contract callers actually rely on — that the value round-trips
+  * as observed through the typed accessors (`asBoolean`, `asString`, `asLong`, `asDouble`, etc.).
+  *
+  * If a property finds a counterexample, fix the converter (or the property), then add a non-property regression test
+  * pinning the exact case so it never resurfaces.
+  */
+object ValueRoundTripSpec extends ZIOSpecDefault {
+
+  private def roundTrip(attr: AttributeValue): AttributeValue = {
+    val ctx     = EvaluationContext(None, Map("k" -> attr))
+    val javaCtx = ContextConverter.toOpenFeature(ctx)
+    val backCtx = ContextConverter.fromOpenFeature(javaCtx)
+    backCtx.attributes("k")
+  }
+
+  /** Doubles that round-trip predictably: skip NaN (NaN != NaN), skip ±Infinity (Java SDK normalises these), and skip
+    * whole-number doubles (they come back as `IntValue` / `LongValue`, not `DoubleValue`).
+    */
+  private val finiteFractionalDouble: Gen[Any, Double] =
+    Gen.double(-1e10, 1e10).filter(d => !d.isWhole && !d.isNaN && !d.isInfinity)
+
+  /** Longs that round-trip exactly through `Double`. Doubles have 53 bits of mantissa, so any Long in `[Long.MinValue,
+    * 2^53)` is representable exactly. Outside that window we'd lose precision. We also bound below at a value the
+    * converter actually maps back as `LongValue` rather than `IntValue` (above Int.MaxValue).
+    */
+  private val largeLong: Gen[Any, Long] =
+    Gen.long(Int.MaxValue.toLong + 1L, (1L << 53) - 1L)
+
+  /** Strings the converter accepts losslessly. Non-empty so the Java SDK's empty-string treatment isn't asserted here
+    * (a corner case orthogonal to the round-trip property).
+    */
+  private val nonEmptyString: Gen[Any, String] =
+    Gen.string1(Gen.unicodeChar)
+
+  def spec = suite("ValueRoundTripSpec")(
+    test("BoolValue round-trips exactly") {
+      check(Gen.boolean) { b =>
+        roundTrip(AttributeValue.BoolValue(b)) match {
+          case AttributeValue.BoolValue(v) => assertTrue(v == b)
+          case other                       => assertTrue(false: Boolean) ?? s"expected BoolValue, got $other"
+        }
+      }
+    },
+    test("StringValue round-trips for non-empty unicode strings") {
+      check(nonEmptyString) { s =>
+        roundTrip(AttributeValue.StringValue(s)) match {
+          case AttributeValue.StringValue(v) => assertTrue(v == s)
+          case other                         => assertTrue(false: Boolean) ?? s"expected StringValue, got $other"
+        }
+      }
+    },
+    test("IntValue round-trips exactly") {
+      check(Gen.int) { i =>
+        // Int always fits in Double's mantissa (53 bits), and our converter maps small whole numbers back to IntValue.
+        roundTrip(AttributeValue.IntValue(i)) match {
+          case AttributeValue.IntValue(v) => assertTrue(v == i)
+          case other                      => assertTrue(false: Boolean) ?? s"expected IntValue, got $other"
+        }
+      }
+    },
+    test("LongValue (large enough to be distinct from Int) round-trips as LongValue") {
+      check(largeLong) { l =>
+        roundTrip(AttributeValue.LongValue(l)) match {
+          case AttributeValue.LongValue(v) => assertTrue(v == l)
+          case other                       => assertTrue(false: Boolean) ?? s"expected LongValue($l), got $other"
+        }
+      }
+    },
+    test("DoubleValue (finite, fractional) round-trips exactly") {
+      check(finiteFractionalDouble) { d =>
+        roundTrip(AttributeValue.DoubleValue(d)) match {
+          case AttributeValue.DoubleValue(v) => assertTrue(v == d)
+          case other                         => assertTrue(false: Boolean) ?? s"expected DoubleValue, got $other"
+        }
+      }
+    },
+    test("DoubleValue NaN survives as a NaN double (not necessarily equal-by-==)") {
+      // NaN is its own equivalence class — only `isNaN` is reliable.
+      val r = roundTrip(AttributeValue.DoubleValue(Double.NaN))
+      val isNaN = r match {
+        case AttributeValue.DoubleValue(v) => v.isNaN
+        case _                             => false
+      }
+      assertTrue(isNaN)
+    },
+    test("LongValue(Long.MaxValue) lands as DoubleValue (documents the converter's strict-upper-bound)") {
+      // `valueToAttribute` rejects values >= Long.MaxValue.toDouble because the conversion saturates at that point.
+      // We don't assert exact equality on the resulting Double — the point is that no information is silently lost as
+      // an out-of-range Long; the caller sees a Double they can detect and handle.
+      val r = roundTrip(AttributeValue.LongValue(Long.MaxValue))
+      val isDouble = r match {
+        case _: AttributeValue.DoubleValue => true
+        case _                             => false
+      }
+      assertTrue(isDouble)
+    },
+    test("Nested struct round-trip preserves leaf values via their getters") {
+      val structGen: Gen[Any, AttributeValue.StructValue] = for {
+        b <- Gen.boolean
+        s <- nonEmptyString
+        i <- Gen.int
+        d <- finiteFractionalDouble
+      } yield AttributeValue.StructValue(
+        Map(
+          "bool"   -> AttributeValue.BoolValue(b),
+          "string" -> AttributeValue.StringValue(s),
+          "int"    -> AttributeValue.IntValue(i),
+          "double" -> AttributeValue.DoubleValue(d)
+        )
+      )
+      check(structGen) { struct =>
+        roundTrip(struct) match {
+          case AttributeValue.StructValue(fields) =>
+            assertTrue(
+              fields("bool").asBoolean.contains(struct.fields("bool").asBoolean.get),
+              fields("string").asString.contains(struct.fields("string").asString.get),
+              fields("int").asInt.contains(struct.fields("int").asInt.get),
+              fields("double").asDouble.contains(struct.fields("double").asDouble.get)
+            )
+          case other =>
+            assertTrue(false: Boolean) ?? s"expected StructValue, got $other"
+        }
+      }
+    },
+    test("ListValue round-trip preserves the leaf values") {
+      val listGen: Gen[Any, AttributeValue.ListValue] =
+        Gen.listOfBounded(0, 8)(Gen.int.map(AttributeValue.IntValue.apply)).map(AttributeValue.ListValue.apply)
+      check(listGen) { list =>
+        roundTrip(list) match {
+          case AttributeValue.ListValue(items) =>
+            val expected = list.values.flatMap(_.asInt)
+            val actual   = items.flatMap(_.asInt)
+            assertTrue(actual == expected)
+          case other =>
+            assertTrue(false: Boolean) ?? s"expected ListValue, got $other"
+        }
+      }
+    },
+    test("EvaluationContext with targetingKey + mixed attributes round-trips") {
+      val ctxGen: Gen[Any, EvaluationContext] = for {
+        tk <- Gen.option(nonEmptyString)
+        b  <- Gen.boolean
+        s  <- nonEmptyString
+        i  <- Gen.int
+      } yield EvaluationContext(
+        targetingKey = tk,
+        attributes = Map(
+          "bool"   -> AttributeValue.BoolValue(b),
+          "string" -> AttributeValue.StringValue(s),
+          "int"    -> AttributeValue.IntValue(i)
+        )
+      )
+      check(ctxGen) { ctx =>
+        val rt = ContextConverter.fromOpenFeature(ContextConverter.toOpenFeature(ctx))
+        assertTrue(
+          rt.targetingKey == ctx.targetingKey,
+          rt.attributes("bool").asBoolean == ctx.attributes("bool").asBoolean,
+          rt.attributes("string").asString == ctx.attributes("string").asString,
+          rt.attributes("int").asInt == ctx.attributes("int").asInt
+        )
+      }
+    }
+  ) @@ TestAspect.samples(200)
+}

--- a/docs/context.md
+++ b/docs/context.md
@@ -346,5 +346,17 @@ ZIO OpenFeature contexts are automatically converted to OpenFeature SDK `Evaluat
 2. Converts all attributes to OpenFeature `Value` types
 3. Preserves nested structures and lists
 
-This conversion happens internally - you work only with ZIO OpenFeature's `EvaluationContext` type.
+This conversion happens internally — you work only with ZIO OpenFeature's `EvaluationContext` type.
+
+### Numeric conversion is mediated through `Double`
+
+The OpenFeature Java SDK has only one numeric `Value` type (`Double`), so `IntValue` and `LongValue` are mediated through `Double` on the way out and decoded back to the smallest fitting case on the way in. Practical consequences:
+
+- `BoolValue` and `StringValue` round-trip exactly.
+- `IntValue(n)` round-trips as `IntValue(n)` (always fits in `Double`'s 53-bit mantissa).
+- `LongValue(n)` with `n` in the `Int` range comes back as `IntValue(n)` — same numeric value, different concrete case. `LongValue(n)` outside the `Int` range but in `[Int.MaxValue + 1, 2^53)` round-trips as `LongValue`. `LongValue(Long.MaxValue)` comes back as `DoubleValue` because the conversion would otherwise saturate.
+- `DoubleValue(n)` with a fractional component round-trips as `DoubleValue`. Whole-number doubles in the `Long`/`Int` range come back as `LongValue` / `IntValue`.
+- `DoubleValue(Double.NaN)` survives as a NaN double (verify via `.isNaN`, not `==`).
+
+If you need to preserve the exact numeric case across the boundary, read values via the typed accessors (`asInt`, `asLong`, `asDouble`) rather than pattern-matching on the concrete `AttributeValue` subtype. The property-based round-trip spec (`ValueRoundTripSpec`) pins this contract.
 

--- a/testkit/src/test/scala/zio/openfeature/testkit/ConcurrentEvaluationSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/ConcurrentEvaluationSpec.scala
@@ -1,0 +1,92 @@
+package zio.openfeature.testkit
+
+import zio._
+import zio.openfeature._
+import zio.test._
+import zio.test.TestAspect.{timeout, withLiveClock}
+
+/** Concurrency stress for the core `FeatureFlags` evaluation path (workstream B4).
+  *
+  * Fans out N parallel fibers, each performing M sequential evaluations, while a separate fiber flips the underlying
+  * provider's status `READY → ERROR → READY` mid-burst. Proves:
+  *
+  *   - No defects escape (`ZIO.Cause.Die`): the evaluation path classifies every error as a typed `FeatureFlagError`.
+  *   - Every result is either a flag value (status `READY`) or `ProviderNotReady` (during the `ERROR` window).
+  *   - Final `providerStatus` matches what the test driver last set.
+  *   - All fibers complete within the bounded test timeout (no deadlock).
+  *
+  * This spec lives in `testkit` rather than `core` because `TestFeatureProvider.setStatus` is the cleanest API to drive
+  * the status transitions; `core` doesn't depend on `testkit`. The behaviour under test is core's evaluation path, so
+  * the spec exercises the public `FeatureFlags` service the same way any application would.
+  *
+  * Sized to keep wall-clock under control (~2 seconds with `TestAspect.withLiveClock`).
+  */
+object ConcurrentEvaluationSpec extends ZIOSpecDefault {
+
+  private val FiberCount     = 200
+  private val EvalsPerFiber  = 10
+  private val InitialDelay   = 50.millis
+  private val ErrorWindow    = 50.millis
+  private val EvaluationFlag = "concurrent-flag"
+
+  // We classify each evaluation outcome into one of three buckets so the final assertion can confirm the only seen
+  // failure shape was `ProviderNotReady` — anything else (e.g., a Defect or an unrelated FeatureFlagError) would mean
+  // the evaluation pipeline has a concurrency bug.
+  sealed private trait Outcome
+  private object Outcome {
+    case object Ok                                   extends Outcome
+    case object NotReady                             extends Outcome
+    final case class Unexpected(e: FeatureFlagError) extends Outcome
+  }
+
+  private def runOne(ff: FeatureFlags): UIO[Outcome] =
+    ff.boolean(EvaluationFlag, default = false).either.map {
+      case Right(_)                                   => Outcome.Ok
+      case Left(_: FeatureFlagError.ProviderNotReady) => Outcome.NotReady
+      case Left(FeatureFlagError.ProviderFatal)       => Outcome.NotReady
+      case Left(other)                                => Outcome.Unexpected(other)
+    }
+
+  def spec = suite("ConcurrentEvaluationSpec")(
+    test(s"$FiberCount fibers x $EvalsPerFiber evaluations survive a READY -> ERROR -> READY transition") {
+      for {
+        ff       <- ZIO.service[FeatureFlags]
+        provider <- ZIO.service[TestFeatureProvider]
+        _        <- provider.setFlag(EvaluationFlag, true)
+
+        // Background fiber drives the provider through the failure window. Forked into the test scope; lives or dies
+        // with the test. The first sleep means evaluations start cleanly in READY before we toggle.
+        statusDriver <- (
+          ZIO.sleep(InitialDelay) *>
+            provider.setStatus(ProviderStatus.Error) *>
+            ZIO.sleep(ErrorWindow) *>
+            provider.setStatus(ProviderStatus.Ready)
+        ).fork
+
+        // Fan out evaluations. Each fiber records its own outcomes; we aggregate across all of them at the end.
+        outcomes <- ZIO.foreachPar(1 to FiberCount) { _ =>
+          ZIO.foreach(1 to EvalsPerFiber)(_ => runOne(ff))
+        }
+        _ <- statusDriver.join
+
+        flat       = outcomes.toList.flatten
+        oks        = flat.count(_ == Outcome.Ok)
+        notReady   = flat.count(_ == Outcome.NotReady)
+        unexpected = flat.collect { case Outcome.Unexpected(e) => e }
+
+        finalStatus <- ff.providerStatus
+        // notReady is informational only — the burst can race the status driver on a fast machine and complete the
+        // full 2000 evaluations before the ERROR window opens. The deterministic failure-path coverage lives in
+        // ProviderInitFailureSpec; this spec proves the concurrency invariants below.
+        _ <- ZIO.logInfo(
+          s"Concurrent burst summary: ok=$oks, notReady=$notReady, unexpected=${unexpected.size}"
+        )
+      } yield assertTrue(
+        flat.size == FiberCount * EvalsPerFiber,
+        unexpected.isEmpty,
+        oks > 0,
+        finalStatus == ProviderStatus.Ready
+      )
+    } @@ withLiveClock @@ timeout(20.seconds)
+  ).provide(TestFeatureProvider.scopedLayer)
+}


### PR DESCRIPTION
## Summary

Implements **#126 (B3 — property-based `ValueRoundTripSpec`)** and **#127 (B4 — concurrency spec)** from the [1.0-readiness](https://github.com/EtaCassiopeia/zio-openfeature/milestone/1) milestone. Independent of the other open PRs — branches off `main`.

### B3 — `ValueRoundTripSpec`

Property-based coverage in `core/src/test/scala/zio/openfeature/ValueRoundTripSpec.scala`, 10 properties at 200 samples each (via `TestAspect.samples(200)`).

The interesting finding: **the cross-boundary conversion is intentionally lossy** because the OpenFeature Java SDK normalises every numeric to a single `Double` type, so `IntValue` and `LongValue` are mediated through `Double` and may come back as a different concrete `AttributeValue` case. The properties pin the actual contract callers depend on rather than asserting a (false) exactness:

- `BoolValue`, non-empty unicode `StringValue`, and `IntValue` round-trip exactly.
- `LongValue` round-trips as `LongValue` only when the value is large enough to be distinct from `Int` AND ≤ `2^53 - 1` (Double mantissa limit). Smaller values come back as `IntValue`.
- `DoubleValue` round-trips for finite, fractional doubles; whole-number doubles convert to `IntValue` / `LongValue` on the way back.
- `DoubleValue(Double.NaN)` survives as a NaN double (not equal-by-`==`, but `isNaN` holds).
- `LongValue(Long.MaxValue)` lands as `DoubleValue` — pinned via a dedicated test that documents the converter's `Long.MaxValue.toDouble` saturation-avoidance.
- Nested `StructValue` / `ListValue` preserve leaf values via their typed accessors.
- `EvaluationContext.targetingKey` + mixed attributes round-trips cleanly.

If a future converter change breaks any of these, the property test surfaces a counterexample.

### B4 — `ConcurrentEvaluationSpec`

200 fibers × 10 evaluations each (= 2000 concurrent ops) against `TestFeatureProvider`, with a background fiber driving `ProviderStatus.Ready → Error → Ready` mid-burst. Lives in `testkit/src/test/scala/zio/openfeature/testkit/` rather than `core/` (the issue suggested `core`) — using `TestFeatureProvider.setStatus` is the cleanest API for driving the transition and `core` doesn't depend on `testkit`. The behaviour under test is core's evaluation path, exercised the same way an app would.

Assertions:
- Total result count equals `FiberCount × EvalsPerFiber` (no leaked / dropped evaluations).
- No `Unexpected` outcomes (anything other than `ProviderNotReady` is treated as a concurrency bug).
- At least one successful evaluation observed.
- Final `providerStatus == Ready`.
- Bounded by `TestAspect.timeout(20.seconds)` so a deadlock surfaces as a test failure.

`notReady` count is logged for visibility but not asserted — the burst can race the status driver on a fast machine and complete before the ERROR window opens, which would make the test flaky on Scala 2.13's marginally faster scheduling. Deterministic failure-path coverage already lives in `ProviderInitFailureSpec` (B2, #142).


Closes #126
Closes #127