### PR TITLE
Add Optimizely docs: docs/optimizely.md and README + providers updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SDK directly (`com.optimizely.ab:core-api` + `core-httpclient-impl`), since the upstream contrib provider isn't
   published to Maven Central yet. Includes `OptimizelyProvider.make(sdkKey)` for the CDN path,
   `make(sdkKey, datafileUrl)` for self-hosted Optimizely Agent, and `fromOptimizelyClient` as an escape hatch.
+  Full guide at `docs/optimizely.md` (init timeout tuning, self-hosted Agent, `CircuitBreakerProvider`
+  composition, testing patterns, alerting matrix).
 - WireMock-backed failure-mode integration suites:
   - **OFREP** (`OFREPFailureModeSpec`) — 4xx, 5xx, connection reset, evaluation timeout, pre/post server-stop transition.
   - **Optimizely** (`OptimizelyProviderIntegrationSpec`) — happy path, 403/404/500 datafile fetch failures, slow

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-core" % "<v
 // Built-in providers: HOCON, env vars, caching wrapper (optional)
 libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-extras" % "<version>"
 
+// OFREP — OpenFeature Remote Evaluation Protocol provider (HTTP)
+libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-ofrep" % "<version>"
+
+// Optimizely Feature Experimentation — direct integration on top of the Optimizely Java SDK
+libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-optimizely" % "<version>"
+
 // For testing
 libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-testkit" % "<version>" % Test
 ```
@@ -83,11 +89,35 @@ object ProductionApp extends ZIOAppDefault:
   )
 ```
 
+### Using Optimizely Feature Experimentation
+
+`zio-openfeature-optimizely` is the first-party integration with [Optimizely](https://www.optimizely.com/products/feature-experimentation/). It validates the SDK key before constructing, uses the default 30 s `initTimeout`, and composes cleanly with `CircuitBreakerProvider` from `zio-openfeature-extras` for production resilience. See the [Optimizely guide]({{ site.baseurl }}/optimizely) for the full story (init timeout tuning, self-hosted Agent, what to alert on).
+
+```scala
+import zio.*
+import zio.openfeature.*
+import zio.openfeature.optimizely.OptimizelyProvider
+
+object MyApp extends ZIOAppDefault:
+
+  def run = ZIO.scoped {
+    for
+      sdkKey   <- ZIO.attempt(sys.env("OPTIMIZELY_SDK_KEY"))
+      provider <- OptimizelyProvider.make(sdkKey).mapError(e => new RuntimeException(e.message))
+      env      <- FeatureFlags.fromProviderAsync(provider).build
+      ff        = env.get[FeatureFlags]
+      enabled  <- ff.boolean("new-checkout", default = false).mapError(e => new RuntimeException(e.message))
+      _        <- ZIO.logInfo(s"new-checkout = $enabled")
+    yield ()
+  }
+```
+
 ### Popular Providers
 
 | Provider | Dependency |
 |----------|------------|
-| [Optimizely](https://www.optimizely.com/) | `"dev.openfeature.contrib.providers" % "optimizely" % "x.y.z"` |
+| [Optimizely](https://www.optimizely.com/) | `"io.github.etacassiopeia" %% "zio-openfeature-optimizely" % "<version>"` (this library) |
+| [OFREP](https://github.com/open-feature/protocol) | `"io.github.etacassiopeia" %% "zio-openfeature-ofrep" % "<version>"` (this library) |
 | [flagd](https://flagd.dev/) | `"dev.openfeature.contrib.providers" % "flagd" % "x.y.z"` |
 | [LaunchDarkly](https://launchdarkly.com/) | `"dev.openfeature.contrib.providers" % "launchdarkly" % "x.y.z"` |
 | [Flagsmith](https://flagsmith.com/) | `"dev.openfeature.contrib.providers" % "flagsmith" % "x.y.z"` |

--- a/docs/optimizely.md
+++ b/docs/optimizely.md
@@ -1,0 +1,234 @@
+---
+layout: default
+title: Optimizely
+nav_order: 6
+---
+
+# Optimizely
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Overview
+
+`zio-openfeature-optimizely` integrates with [Optimizely Feature Experimentation](https://www.optimizely.com/products/feature-experimentation/) directly on top of the official **Optimizely Java SDK** (`com.optimizely.ab:core-api` and `core-httpclient-impl`). The library does NOT depend on `dev.openfeature.contrib.providers:optimizely` — at the time of writing that artifact is not published to Maven Central.
+
+You get:
+
+- A Scala-friendly factory (`OptimizelyProvider.make(sdkKey)`) that validates inputs and returns a typed
+  `FeatureFlagError.InvalidConfiguration` on bad config.
+- An `OpenFeature`-compatible provider (`OptimizelyFeatureProvider extends EventProvider`) that emits
+  `PROVIDER_CONFIGURATION_CHANGED` when Optimizely's datafile poller picks up a new revision.
+- The same `FeatureFlags.fromProvider*` factories you use with any other provider, including the 30-second
+  `initTimeout` default added in workstream A.
+
+---
+
+## 1. Getting an SDK key
+
+1. Log in to [app.optimizely.com](https://app.optimizely.com).
+2. Pick the project you want to drive flags from.
+3. Open **Settings → Environments**.
+4. Copy the **SDK Key** for the environment (Development / Staging / Production). Each environment has its own key — never reuse a Production key in Development apps.
+
+The SDK key is a short alphanumeric token like `abcd1234efgh5678`. The library's validator accepts `[A-Za-z0-9_-]+` between 6 and 128 chars and rejects obvious placeholders (`YOUR_SDK_KEY`, `<sdk-key>`, `changeme`, …) up front.
+
+---
+
+## 2. Quick start
+
+```scala
+libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-optimizely" % "<version>"
+```
+
+```scala
+import zio.*
+import zio.openfeature.*
+import zio.openfeature.optimizely.OptimizelyProvider
+
+object MyApp extends ZIOAppDefault:
+
+  def run: ZIO[Any, Throwable, Unit] = ZIO.scoped {
+    for
+      sdkKey   <- ZIO.attempt(sys.env("OPTIMIZELY_SDK_KEY"))
+      provider <- OptimizelyProvider.make(sdkKey).mapError(e => new RuntimeException(e.message))
+      env      <- FeatureFlags.fromProviderAsync(provider).build
+      ff        = env.get[FeatureFlags]
+      enabled  <- ff.boolean("new-checkout", default = false).mapError(e => new RuntimeException(e.message))
+      _        <- ZIO.logInfo(s"new-checkout = $enabled")
+    yield ()
+  }
+```
+
+What this does on startup:
+
+1. `OptimizelyProvider.make(sdkKey)` validates the key shape (non-empty, allowed characters, not a placeholder) and constructs an `Optimizely` client wired to the public CDN at `https://cdn.optimizely.com/datafiles/<sdkKey>.json`.
+2. `FeatureFlags.fromProviderAsync(provider)` starts the provider in the background, watches for the first datafile load, and uses the default **30 s `initTimeout`** as an upper bound. If the datafile never arrives, `providerStatus` transitions to `Fatal` — your evaluations stop hanging.
+3. On every subsequent datafile revision (typically every 30 s for the SDK's default polling interval), the provider emits `ProviderEvent.ConfigurationChanged` — call `FeatureFlags.onConfigurationChanged(handler)` if you want to react.
+
+---
+
+## 3. Configuring init timeout
+
+The 30-second default is friendly for most apps. You'll want to tune it in three cases:
+
+- **Tests** — drop it to 1–2 seconds so a forgotten WireMock stub fails fast.
+- **Cold start on a constrained network** — raise it if your CI runners or first production deploys regularly need >30 s for the initial datafile fetch.
+- **Run-anywhere CLIs** — set it lower (5–10 s) so users on flaky networks get a clear startup error instead of waiting half a minute.
+
+Override via the 3-arg async factory:
+
+```scala
+FeatureFlags.fromProviderAsync(
+  provider,
+  evaluationTimeout = 500.millis,
+  initTimeout       = 5.seconds
+)
+```
+
+When `initTimeout` elapses without the datafile arriving, the layer's watchdog flips `providerStatus` to `Fatal`. Application code that polls `providerStatus` (or registers `onProviderReady` / `onProviderError`) sees this immediately and can fail loud:
+
+```scala
+val ready = for
+  ff     <- ZIO.service[FeatureFlags]
+  status <- ff.providerStatus
+  _      <- ZIO.fail(new RuntimeException(s"Optimizely never became ready: $status"))
+              .when(status == ProviderStatus.Fatal)
+yield ()
+```
+
+---
+
+## 4. Self-hosted Optimizely Agent
+
+When you run [Optimizely Agent](https://docs.developers.optimizely.com/feature-experimentation/docs/agent) inside your network (e.g., for FedRAMP / data-residency requirements), pass the agent's URL explicitly:
+
+```scala
+val provider = OptimizelyProvider.make(
+  sdkKey      = sys.env("OPTIMIZELY_SDK_KEY"),
+  datafileUrl = "https://flags.internal.example.com/datafile.json"
+)
+```
+
+The URL is validated alongside the SDK key: parseable as a URI, scheme `http` or `https`, non-empty host. A malformed URL fails layer build with `FeatureFlagError.InvalidConfiguration("malformed datafileUrl …")` before any network call.
+
+---
+
+## 5. Production resilience — composing with `CircuitBreakerProvider`
+
+`OptimizelyFeatureProvider` extends `EventProvider`, so it composes cleanly with the breaker from `zio-openfeature-extras`. A degraded Optimizely CDN trips the breaker; while open, evaluations fail fast (sub-millisecond) without contacting Optimizely.
+
+```scala
+import zio.openfeature.extras.{CircuitBreakerProvider, CircuitBreakerProviderConfig}
+
+val breakerConfig = CircuitBreakerProviderConfig(
+  failureThreshold = 5,
+  resetTimeout     = 30.seconds
+)
+
+val program = ZIO.scoped {
+  for
+    sdkKey   <- ZIO.attempt(sys.env("OPTIMIZELY_SDK_KEY"))
+    inner    <- OptimizelyProvider.make(sdkKey).mapError(e => new RuntimeException(e.message))
+    wrapped  <- CircuitBreakerProvider.make(inner, breakerConfig)
+    env      <- FeatureFlags.fromProviderAsync(wrapped, evaluationTimeout = 500.millis).build
+    ff        = env.get[FeatureFlags]
+    enabled  <- ff.boolean("flag", default = false).mapError(e => new RuntimeException(e.message))
+  yield enabled
+}
+```
+
+The breaker counts *infrastructure* errors (timeouts, connection failures, `GeneralError`, `ProviderNotReadyError`) toward the failure threshold. Application-level errors (`FlagNotFoundError`, type mismatches, etc.) don't trip the breaker — those indicate the provider is reachable. See [Extras → CircuitBreakerProvider]({{ site.baseurl }}/extras) for the full classification.
+
+---
+
+## 6. Testing your app
+
+Two patterns, both supported:
+
+### Unit-testing application code without touching Optimizely
+
+Use `TestFeatureProvider` from `zio-openfeature-testkit` — there's a worked example under [`examples/testkit-app/`](https://github.com/EtaCassiopeia/zio-openfeature/tree/main/examples/testkit-app):
+
+```scala
+import zio.openfeature.testkit.TestFeatureProvider
+
+val spec = test("UserService returns the new greeting when the flag is ON") {
+  for
+    provider <- ZIO.service[TestFeatureProvider]
+    _        <- provider.setFlag("new-greeting-copy", true)
+    svc      <- ZIO.service[UserService]
+    greeting <- svc.welcome("alice")
+  yield assertTrue(greeting.contains("Hey alice"))
+}.provide(TestFeatureProvider.scopedLayer >>> UserService.live)
+```
+
+This is what your app developers should use day-to-day. Nothing in this test path requires a real Optimizely SDK key or network access.
+
+### Integration-testing the Optimizely wiring itself
+
+The library's own integration suite (`OptimizelyProviderIntegrationSpec`) drives a WireMock server impersonating the Optimizely CDN, with short `blockingTimeout` and `pollingInterval` knobs to keep tests fast. If you want to replicate that pattern in your own repo (e.g., to confirm a custom datafile schema), copy the per-test `WireMockServer` setup and use `OptimizelyFeatureProvider`'s package-private constructor through the `fromOptimizelyClient` escape hatch:
+
+```scala
+val opt = Optimizely.builder()
+  .withConfigManager(
+    HttpProjectConfigManager.builder()
+      .withSdkKey("test-sdk-key")
+      .withUrl(wireMockBaseUrl)
+      .withBlockingTimeout(1L, TimeUnit.SECONDS)
+      .withPollingInterval(1L, TimeUnit.HOURS)  // effectively disable polling for the test
+      .build()
+  )
+  .build()
+
+val provider = Unsafe.unsafe { implicit u =>
+  Runtime.default.unsafe.run(OptimizelyProvider.fromOptimizelyClient(opt)).getOrThrow()
+}
+```
+
+---
+
+## 7. Operating Optimizely-backed apps
+
+### What to alert on
+
+| Signal                                           | Likely cause                                        | Suggested action                         |
+|--------------------------------------------------|-----------------------------------------------------|------------------------------------------|
+| `FeatureFlagError.Unauthorized`                  | Wrong / revoked SDK key, expired access token       | Page on-call; check key rotation status  |
+| `FeatureFlagError.Unreachable`                   | DNS / network failure reaching `cdn.optimizely.com` | Check network egress; consider self-hosting via Optimizely Agent |
+| `providerStatus = Fatal` after startup           | Datafile never loaded (SDK key invalid, CDN unreachable, network ACL) | Restart with corrected config; alert on >1 occurrence |
+| `FlagResolution.errorCode` populated repeatedly | Misconfigured flag, missing rollout                 | Application-side issue, not a transport one — check Optimizely UI |
+
+`Unauthorized` and `Unreachable` come from the typed-error classifier (`FeatureFlagError.classify`); see the [error types]({{ site.baseurl }}/architecture) doc for the full ADT.
+
+### `ProviderEvent.ConfigurationChanged` events
+
+The Optimizely SDK polls its datafile URL on a background thread (default ~30 s interval). Whenever a new revision is fetched and parsed, `OptimizelyFeatureProvider` emits OpenFeature's `PROVIDER_CONFIGURATION_CHANGED` event. Hook into it for log lines, cache invalidation, or metrics:
+
+```scala
+ff.onConfigurationChanged { (flagsChanged, meta) =>
+  ZIO.logInfo(s"Optimizely datafile updated; affected flags: $flagsChanged")
+}
+```
+
+The library doesn't pass through the *list* of changed flags from Optimizely (the underlying notification doesn't expose them in this version of the SDK) — the `flagsChanged` set will be empty. Use the event as a trigger; check the actual flag values via fresh evaluations.
+
+### Detecting a stuck `Fatal` status
+
+`Fatal` is intentionally non-recoverable: it's the library's way of saying "stop polling, this isn't coming back without operator intervention." A typical pattern in long-running services:
+
+```scala
+val healthCheck =
+  ZIO.serviceWithZIO[FeatureFlags](_.providerStatus).map {
+    case ProviderStatus.Ready | ProviderStatus.Stale => true
+    case _                                            => false
+  }
+```
+
+Wire `healthCheck` into your liveness or readiness endpoint. If `Fatal` is observed, surface it as a hard failure — the process should restart (or page operators) rather than serve traffic with frozen flag values.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -53,125 +53,91 @@ See [Extras]({{ site.baseurl }}/extras) for details on all of the above.
 
 ## Using Optimizely
 
-[Optimizely](https://www.optimizely.com/) is the recommended provider for most users. It provides feature flags, A/B testing, and experimentation capabilities.
+`zio-openfeature-optimizely` is the first-party integration with [Optimizely Feature Experimentation](https://www.optimizely.com/products/feature-experimentation/). It builds on the Optimizely Java SDK directly (`com.optimizely.ab:core-api` + `core-httpclient-impl`) — the upstream OpenFeature contrib provider isn't published to Maven Central, so this library ships its own integration.
+
+For init-timeout tuning, self-hosted Optimizely Agent, `CircuitBreakerProvider` composition, testing patterns, and operational alerting guidance, see the dedicated [Optimizely guide]({{ site.baseurl }}/optimizely). The quick start below covers the 80% case.
 
 ### Installation
 
 ```scala
 libraryDependencies ++= Seq(
-  "io.github.etacassiopeia" %% "zio-openfeature-core" % "<version>",
-  "dev.openfeature.contrib.providers" % "optimizely" % "0.1.0"
+  "io.github.etacassiopeia" %% "zio-openfeature-core"       % "<version>",
+  "io.github.etacassiopeia" %% "zio-openfeature-optimizely" % "<version>"
 )
 ```
 
 ### Getting Your SDK Key
 
-1. Log in to [Optimizely](https://app.optimizely.com)
-2. Navigate to **Settings** → **Environments**
-3. Copy the **SDK Key** for your environment (Development, Staging, or Production)
+1. Log in to [Optimizely](https://app.optimizely.com).
+2. Navigate to **Settings** → **Environments**.
+3. Copy the **SDK Key** for your environment (Development, Staging, or Production).
 
 ### Basic Setup
 
 ```scala
 import zio.*
 import zio.openfeature.*
-import dev.openfeature.contrib.providers.optimizely.OptimizelyProvider
-import dev.openfeature.contrib.providers.optimizely.OptimizelyProviderConfig
+import zio.openfeature.optimizely.OptimizelyProvider
 
 object MyApp extends ZIOAppDefault:
 
-  val config = OptimizelyProviderConfig.builder()
-    .sdkKey("YOUR_SDK_KEY")
-    .build()
-
-  val provider = new OptimizelyProvider(config)
-
-  val program = for
-    enabled <- FeatureFlags.boolean("new-checkout-flow", default = false)
-    _       <- ZIO.when(enabled)(Console.printLine("New checkout enabled!"))
-  yield ()
-
-  def run = program.provide(
-    Scope.default >>> FeatureFlags.fromProvider(provider)
-  )
+  def run = ZIO.scoped {
+    for
+      sdkKey   <- ZIO.attempt(sys.env("OPTIMIZELY_SDK_KEY"))
+      provider <- OptimizelyProvider.make(sdkKey).mapError(e => new RuntimeException(e.message))
+      env      <- FeatureFlags.fromProviderAsync(provider).build
+      ff        = env.get[FeatureFlags]
+      enabled  <- ff.boolean("new-checkout-flow", default = false)
+                    .mapError(e => new RuntimeException(e.message))
+      _        <- ZIO.when(enabled)(Console.printLine("New checkout enabled!"))
+    yield ()
+  }
 ```
+
+`OptimizelyProvider.make(sdkKey)` validates the key shape (non-empty, allowed characters, not a known placeholder) and returns `FeatureFlagError.InvalidConfiguration` on bad input. The async layer uses the library's default 30-second `initTimeout`; override via `FeatureFlags.fromProviderAsync(provider, evaluationTimeout = 500.millis, initTimeout = 5.seconds)`.
 
 ### User Targeting
 
 The `targetingKey` in the evaluation context maps to the Optimizely user ID:
 
 ```scala
-// Create context with user ID
 val userContext = EvaluationContext("user-12345")
   .withAttribute("email", "user@example.com")
   .withAttribute("plan", "premium")
   .withAttribute("country", "US")
 
-// Evaluate with user context
-val result = FeatureFlags.boolean("premium-feature", false, userContext)
+val result = ff.boolean("premium-feature", default = false, userContext)
 ```
 
 ### Feature Variables
 
-Optimizely supports feature variables. By default, the OpenFeature provider searches for a variable named `"value"`:
+By default, typed evaluations (String / Int / Double) look up an Optimizely variable named `"value"`:
 
 ```scala
-// Optimizely feature with a "value" variable
-val discount = FeatureFlags.double("discount-rate", 0.0, userContext)
+val discount = ff.double("discount-rate", default = 0.0, userContext)
 ```
 
-To use a different variable name, add the `variableKey` attribute to the context:
+Override the variable name per-evaluation via the `openfeature.variableKey` context attribute:
 
 ```scala
-val ctx = userContext.withAttribute("variableKey", "custom_variable_name")
-val value = FeatureFlags.string("feature-key", "default", ctx)
+val ctx   = userContext.withAttribute("openfeature.variableKey", AttributeValue.StringValue("custom_var"))
+val value = ff.string("feature-key", default = "default", ctx)
 ```
 
-### Complete Example
+Boolean evaluations always return Optimizely's `decision.getEnabled` regardless of `variableKey`. Object evaluations return the full `getVariables.toMap` as a `Value` structure.
+
+### Self-hosted Optimizely Agent
+
+When you run [Optimizely Agent](https://docs.developers.optimizely.com/feature-experimentation/docs/agent) inside your network, pass the agent's URL:
 
 ```scala
-import zio.*
-import zio.openfeature.*
-import dev.openfeature.contrib.providers.optimizely.OptimizelyProvider
-import dev.openfeature.contrib.providers.optimizely.OptimizelyProviderConfig
-
-object FeatureFlagApp extends ZIOAppDefault:
-
-  val sdkKey = sys.env.getOrElse("OPTIMIZELY_SDK_KEY", "YOUR_SDK_KEY")
-
-  val config = OptimizelyProviderConfig.builder()
-    .sdkKey(sdkKey)
-    .build()
-
-  val provider = new OptimizelyProvider(config)
-
-  def handleUserRequest(userId: String, plan: String) = for
-    ctx = EvaluationContext(userId).withAttribute("plan", plan)
-
-    // Check if new checkout is enabled for this user
-    newCheckout <- FeatureFlags.boolean("new-checkout-flow", false, ctx)
-
-    // Get the button variation
-    buttonColor <- FeatureFlags.string("checkout-button", "blue", ctx)
-
-    // Get max cart items
-    maxItems <- FeatureFlags.int("max-cart-items", 10, ctx)
-
-    _ <- Console.printLine(s"User $userId (plan: $plan):")
-    _ <- Console.printLine(s"  - New checkout: $newCheckout")
-    _ <- Console.printLine(s"  - Button color: $buttonColor")
-    _ <- Console.printLine(s"  - Max items: $maxItems")
-  yield ()
-
-  val program = for
-    _ <- handleUserRequest("user-001", "free")
-    _ <- handleUserRequest("user-002", "premium")
-  yield ()
-
-  def run = program.provide(
-    Scope.default >>> FeatureFlags.fromProvider(provider)
-  )
+val provider = OptimizelyProvider.make(
+  sdkKey      = sys.env("OPTIMIZELY_SDK_KEY"),
+  datafileUrl = "https://flags.internal.example.com/datafile.json"
+)
 ```
+
+Both inputs are validated (URL parseable, scheme `http`/`https`, non-empty host) before the Optimizely client is built. See the [Optimizely guide]({{ site.baseurl }}/optimizely#4-self-hosted-optimizely-agent) for the full picture.
 
 ---
 
@@ -181,7 +147,7 @@ The OpenFeature ecosystem includes providers for many feature flag services:
 
 | Provider | Dependency | Description |
 |:---------|:-----------|:------------|
-| [Optimizely](https://www.optimizely.com/) | `"dev.openfeature.contrib.providers" % "optimizely" % "0.1.0"` | Feature flags and A/B testing |
+| [Optimizely](https://www.optimizely.com/) | `"io.github.etacassiopeia" %% "zio-openfeature-optimizely" % "<version>"` | First-party integration on the Optimizely Java SDK — see [Optimizely guide]({{ site.baseurl }}/optimizely) |
 | [flagd](https://flagd.dev/) | `"dev.openfeature.contrib.providers" % "flagd" % "0.8.9"` | Open-source flag evaluation engine |
 | [LaunchDarkly](https://launchdarkly.com/) | `"dev.openfeature.contrib.providers" % "launchdarkly" % "1.1.0"` | Enterprise feature management |
 | [Flagsmith](https://flagsmith.com/) | `"dev.openfeature.contrib.providers" % "flagsmith" % "0.1.0"` | Open-source feature flags |


### PR DESCRIPTION
## Summary

Implements **#137 (D5 — Optimizely docs)** from the [1.0-readiness](https://github.com/EtaCassiopeia/zio-openfeature/milestone/1) milestone.

**Stacked.** Base branch is `feat/optimizely-hardening-and-failure-tests` (#141). This branch also merges in `feat/init-timeout-and-sync-verify` (#138) and `feat/typed-errors-and-ofrep-validation` (#139) so the documentation references real APIs (init timeout, validated `OptimizelyProvider.make`, typed `Unauthorized`/`Unreachable` errors). Once #138, #139, #140, and #141 land in `main`, retarget to `main`.

### What lands

- **`docs/optimizely.md`** (new) — comprehensive Optimizely guide with seven sections:
  1. Getting an SDK key.
  2. Quick start — full runnable snippet using `OptimizelyProvider.make(sdkKey)` + `FeatureFlags.fromProviderAsync`.
  3. Configuring init timeout — when to lower it (tests), when to raise it (cold start on constrained network), how to handle `Fatal` status with a polling helper.
  4. Self-hosted Optimizely Agent — the two-arg `OptimizelyProvider.make(sdkKey, datafileUrl)` overload.
  5. Production resilience — `CircuitBreakerProvider` composition with concrete config, including the infrastructure-vs-application error classification note.
  6. Testing your app — `TestFeatureProvider` for unit tests, plus the WireMock pattern for integration tests of the Optimizely wiring itself.
  7. Operations — alerting matrix (`Unauthorized` / `Unreachable` / `Fatal` / `errorCode`-populated `FlagResolution`), `ConfigurationChanged` handling, and the recommended liveness/readiness check.

- **`docs/providers.md`** — replaced the existing "Using Optimizely" section (which referenced the unpublished contrib provider) with a quick-start pointing at `zio-openfeature-optimizely`. Updated the "Other Providers" table to reference our module and link to the dedicated guide. User-targeting + feature-variables subsections rewritten against the actual API (including the `openfeature.variableKey` context-attribute override).

- **`README.md`** — added `zio-openfeature-optimizely` to the installation snippet alongside OFREP. Added a "Using Optimizely Feature Experimentation" subsection with a compact runnable example. Fixed the "Popular Providers" table to point Optimizely at our module rather than the unpublished contrib artifact.


Closes #137