### PR TITLE
Document sync vs async + fallback strategy trade-offs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   production patterns (init timeout + circuit breaker composition; testing app code against `TestFeatureProvider`).
 - Top-level `NOTICE` file with attributions for OpenFeature SDK, OFREP contrib, Optimizely SDK, ZIO, ZIO Cache,
   Typesafe Config, and WireMock.
+- `docs/providers.md`: new "Choosing a strategy — sync vs async, with vs without fallback" section with a decision
+  matrix, watchdog semantics under each cell, the cold-start "all defaults" gap, recovery semantics under `Fatal`,
+  and `initTimeout` tuning guidance.
+- `docs/optimizely.md` §7: expanded healthcheck guidance for readiness gating. New §8 "Choosing a topology" with
+  three named patterns (Optimizely-only async with watchdog, Optimizely-only sync with fail-fast boot, Optimizely
+  + `EnvVarProvider` hybrid for critical flags) and a decision table indexed by workload type.
 
 ### Changed
 

--- a/docs/optimizely.md
+++ b/docs/optimizely.md
@@ -219,16 +219,105 @@ ff.onConfigurationChanged { (flagsChanged, meta) =>
 
 The library doesn't pass through the *list* of changed flags from Optimizely (the underlying notification doesn't expose them in this version of the SDK) — the `flagsChanged` set will be empty. Use the event as a trigger; check the actual flag values via fresh evaluations.
 
-### Detecting a stuck `Fatal` status
+### Detecting `Fatal` status from a healthcheck
 
-`Fatal` is intentionally non-recoverable: it's the library's way of saying "stop polling, this isn't coming back without operator intervention." A typical pattern in long-running services:
+After `initTimeout` elapses with the provider still un-ready, the async watchdog flips status to `Fatal`. This is recoverable (a later `PROVIDER_READY` event transitions `Fatal → Ready`), but during the gap every evaluation fails — so don't route traffic to the pod. The standard pattern:
 
 ```scala
-val healthCheck =
+val readinessCheck: URIO[FeatureFlags, Boolean] =
   ZIO.serviceWithZIO[FeatureFlags](_.providerStatus).map {
     case ProviderStatus.Ready | ProviderStatus.Stale => true
     case _                                            => false
   }
 ```
 
-Wire `healthCheck` into your liveness or readiness endpoint. If `Fatal` is observed, surface it as a hard failure — the process should restart (or page operators) rather than serve traffic with frozen flag values.
+Wire `readinessCheck` into your readiness endpoint. Kubernetes / ECS / Nomad won't direct traffic to the pod until `Ready`. The cold-start window — and any post-`Fatal` recovery window — becomes invisible to users. Without this, your app advertises healthy while every flag silently returns its OF default.
+
+---
+
+## 8. Choosing a topology
+
+The patterns below differ in **when defaults are served** and **whether the app refuses to start on a misconfiguration**. See [Providers → Choosing a strategy]({{ site.baseurl }}/providers#choosing-a-strategy--sync-vs-async-with-vs-without-fallback) for the full decision matrix; the Optimizely-specific guidance is below.
+
+### Pattern A — Optimizely-only with the async watchdog (default)
+
+Highest availability after boot, but during the cold-start window every flag returns its OF default until Optimizely's first datafile arrives. Use this when:
+
+- Most of your flags are non-correctness-bearing (UI variations, feature gates, experiments).
+- You wire `providerStatus` into your readiness check (so the cold-start defaults don't reach users).
+- You can tolerate a 30-second window where new pods are not-routed.
+
+```scala
+ZIO.scoped {
+  for
+    provider <- OptimizelyProvider.make(sys.env("OPTIMIZELY_SDK_KEY"))
+    env      <- FeatureFlags.fromProviderAsync(provider, evaluationTimeout = 500.millis).build
+    // initTimeout uses the library default (30 s); override via the 3-arg overload
+  yield env.get[FeatureFlags]
+}
+```
+
+### Pattern B — Optimizely-only with fail-fast boot
+
+Boot blocks until Optimizely is `READY` or `initTimeout` elapses; on failure the layer build throws and the orchestrator restarts the pod. Use this when:
+
+- Some of your flags gate correctness (financial logic, fraud checks, billing rules).
+- "All flags default" is unsafe even for a few seconds.
+- You'd rather fail loud at boot than serve traffic in a degraded state.
+
+```scala
+ZIO.scoped {
+  for
+    provider <- OptimizelyProvider.make(sys.env("OPTIMIZELY_SDK_KEY"))
+    env      <- FeatureFlags.fromProvider(
+                  provider,
+                  evaluationTimeout = 500.millis,
+                  initTimeout       = 15.seconds   // tight — fail fast on misconfig
+                ).build
+  yield env.get[FeatureFlags]
+}
+```
+
+If Optimizely doesn't reach `READY` in 15 s, the layer build fails with `TimeoutException` or `IllegalStateException`. Your pod doesn't go live; the orchestrator restarts it. There's no half-initialised state and no window of all-defaults.
+
+### Pattern C — Optimizely + `EnvVarProvider` for critical flags only
+
+Hybrid: Optimizely serves the bulk of flags; a small `EnvVarProvider` is the second provider in a `MultiProvider`, holding only the flags whose default-value matters under outage. Use this when:
+
+- A small subset of flags is correctness-bearing; the rest is fine to default during an outage.
+- You want the highest availability (multi-provider is always `Ready` via EnvVar) without sacrificing safety on the critical few.
+
+```scala
+import zio.openfeature.extras.EnvVarProvider
+import dev.openfeature.sdk.multiprovider.FirstSuccessfulStrategy
+
+val critical = Map(
+  "FF_MAINTENANCE_MODE"    -> "false",
+  "FF_FRAUD_CHECK_ENABLED" -> "true"
+)
+
+ZIO.scoped {
+  for
+    optimizely <- OptimizelyProvider.make(sys.env("OPTIMIZELY_SDK_KEY"))
+    envProvider = EnvVarProvider.withLookup(critical.get)
+    env        <- FeatureFlags.fromMultiProviderAsync(
+                    List(optimizely, envProvider),
+                    new FirstSuccessfulStrategy()
+                  ).build
+  yield env.get[FeatureFlags]
+}
+```
+
+`FirstSuccessfulStrategy` tries Optimizely first; if it fails or is unready, falls through to `EnvVarProvider`. Because `EnvVarProvider` is instantly `Ready`, the `MultiProvider`'s aggregate state is `Ready` immediately and the 30-second watchdog never fires — meaning Optimizely-specific failures are no longer visible at the `FeatureFlags` layer. If you want to alert on Optimizely-side problems anyway, poll the underlying client's `isValid` from a side healthcheck or hook into `onProviderError`.
+
+### Picking between A, B, and C
+
+| Question | Pattern A (Optimizely, async) | Pattern B (Optimizely, sync) | Pattern C (Optimizely + EnvVar) |
+|---|---|---|---|
+| Can the app start while Optimizely is down? | yes, but readiness blocks until `Ready` | no — boot fails | yes, always |
+| What happens during a 60-second Optimizely outage at runtime? | flags return OF defaults until recovery | n/a (app refuses to start) | flags served from EnvVar where defined; OF defaults otherwise |
+| Operational visibility on Optimizely failures | high — `providerStatus` reports `Fatal` | very high — boot fails loudly | low — `MultiProvider` masks it; needs separate monitoring |
+| Right for correctness-critical workloads | only if you wire readiness | **yes — preferred** | yes for the EnvVar-covered flags only |
+| Right for experiments / UI gates / dashboards | **yes — preferred** | overkill | overkill |
+
+If in doubt: start with B for any service handling money or user-trust decisions; start with A for everything else; pull in C only when a specific outage exposed a flag whose default was wrong.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -501,6 +501,66 @@ program.provide(Scope.default >>> FeatureFlags.fromProviderAsync(provider))
 
 ---
 
+## Choosing a strategy — sync vs async, with vs without fallback
+
+Provider construction has two orthogonal dimensions: **how long the layer build blocks** (sync vs async) and **what serves requests when the remote provider is sick** (single provider vs multi-provider fallback). The right combination depends on whether your application can tolerate flag defaults during an outage.
+
+### Decision matrix
+
+| | Single remote provider, no fallback | Remote + `EnvVarProvider` fallback (multi-provider) |
+|---|---|---|
+| **Sync (`fromProvider`)** | App refuses to boot if remote is sick. Operator gets a clear error; orchestrator restarts the pod. Best for correctness-critical workloads (financial, billing) where serving defaults is dangerous. | App refuses to boot only if every provider in the list fails. With `EnvVarProvider` as the last entry, it always boots — but Optimizely failures are then *invisible* unless you also monitor `providerStatus`. Rarely the right pick. |
+| **Async (`fromProviderAsync`)** | App boots immediately. Status starts `NotReady`; transitions to `Ready` if the remote initialises, or `Fatal` after the `initTimeout` watchdog if it doesn't. Every flag evaluation during the gap returns its OF default. Wire `providerStatus` into your readiness check so the pod isn't routed traffic until ready. | App boots immediately and is *always* `Ready` — `FirstSuccessfulStrategy` + an always-ready local provider means the watchdog never fires. Highest availability, but remote failures are silent at the `FeatureFlags` layer. Good for dashboards, feature gates, A/B traffic; risky for correctness-bearing flags. |
+
+### How the `initTimeout` watchdog interacts with each cell
+
+The 30-second default applies to both `fromProvider` and `fromProviderAsync`. Its effect differs:
+
+- **Sync**: bounds the *blocking* call. If `setProviderAndWait` (the underlying Java SDK call) doesn't return within `initTimeout`, the layer build fails with a `TimeoutException`. After it returns successfully, the library reads the provider's `getState()` — anything other than `READY`/`STALE` fails the build with `IllegalStateException`. Translation: in sync mode, `initTimeout` is a hard ceiling on cold-start latency and the layer never lands in a half-initialised state.
+- **Async**: a daemon fiber forked into the layer's `Scope` sleeps `initTimeout` then atomically transitions `NotReady`/`Error` → `Fatal`. The transition isn't terminal — if `PROVIDER_READY` fires later (e.g. network came back), status flips `Fatal → Ready` and evaluations resume. Translation: in async mode, `initTimeout` is the **bounded uncertainty window** at boot; after it elapses you have a reliable signal you can act on.
+
+### The "all defaults" gap
+
+In every async configuration without a same-process fallback, there is a window between layer construction and `Ready` during which every flag evaluation fails with `ProviderNotReady` and your application's `.catchAll`/`.catchSome` returns the OF default value. The window is bounded above by `initTimeout` (after which `Fatal` makes the failure explicit), but it's still a real window. Two ways to handle it:
+
+1. **Gate traffic on readiness.** Expose `ff.providerStatus` to your liveness/readiness endpoint:
+
+   ```scala
+   val readinessCheck: URIO[FeatureFlags, Boolean] =
+     ZIO.serviceWithZIO[FeatureFlags](_.providerStatus).map {
+       case ProviderStatus.Ready | ProviderStatus.Stale => true
+       case _                                            => false
+     }
+   ```
+
+   Kubernetes / ECS / your orchestrator won't route traffic to the pod until this returns `true`. The cold-start window becomes invisible to users.
+
+2. **Keep an `EnvVarProvider` for the flags whose default-value *correctness matters*.** Most apps have a small set of "kill-switch" flags (maintenance mode, fraud-check enabled) where serving an OF default is unsafe. Put those in env vars; let the remote provider serve everything else.
+
+   ```scala
+   val critical = Map("FF_MAINTENANCE_MODE" -> "false", "FF_FRAUD_CHECK_ENABLED" -> "true")
+   val envProvider = EnvVarProvider.withLookup(critical.get)
+   val providers   = List(optimizelyProvider, envProvider)
+   FeatureFlags.fromMultiProviderAsync(providers, FirstSuccessfulStrategy())
+   ```
+
+   The cost of a `MultiProvider` lookup is microseconds; the benefit is that your critical flags have a deterministic value even when the remote is down.
+
+### Recovery semantics under `Fatal`
+
+`Fatal` is a "stop waiting, take operator action" signal — not a tombstone. If the watchdog fires it at t = 30 s but Optimizely's poller succeeds at t = 90 s, the event bridge fires `PROVIDER_READY` and status transitions `Fatal → Ready`. Long-running pods recover naturally; you don't need to restart them to resume normal evaluation.
+
+Healthchecks that gate on `Ready`/`Stale` will see the pod un-route during the `Fatal` window and re-route after recovery, which is usually what you want.
+
+### Tuning `initTimeout`
+
+- Production cold start from a healthy network typically completes in seconds, not tens of seconds. **Lower the timeout** (10–15 s) when you want a tight feedback loop on misconfigurations.
+- CI / local dev / staging across flaky networks may need the default 30 s or more.
+- For sync mode, set `initTimeout` to your acceptable boot delay. Boot fails if exceeded — that's the point.
+- For async mode, set it to "how long am I willing to wait before declaring an outage." Independent of boot delay since boot is non-blocking.
+
+---
+
 ## Provider Registry
 
 For applications that need multiple providers across different domains (e.g., billing, auth, analytics), `FeatureFlagRegistry` provides a centralized service that manages domain-scoped providers with automatic fallback to a default.


### PR DESCRIPTION
## Summary

Captures the resilience-strategy guidance that came out of the post-merge analysis of how the new `initTimeout` watchdog and the existing `MultiProvider` patterns interact for production workloads. Two doc files updated, no code changes.

### What lands

**`docs/providers.md` — new "Choosing a strategy — sync vs async, with vs without fallback" section.** Sits after the existing "Async Variants" section, before "Provider Registry". Contains:

- Decision matrix mapping the four combinations of `{sync, async} × {fallback, no fallback}` to who they're right for.
- Watchdog semantics in each cell — sync uses `initTimeout` as a hard ceiling on cold-start latency; async uses it as a bounded uncertainty window.
- The cold-start "all defaults" gap explained, plus the two mitigations: (1) gate traffic on `providerStatus` from the readiness endpoint, (2) keep `EnvVarProvider` for only the flags whose default-value correctness matters.
- Recovery semantics under `Fatal`: it's a "stop waiting, take operator action" signal, not a tombstone — a later `PROVIDER_READY` event transitions `Fatal → Ready`.
- Tuning guidance for `initTimeout` (production cold-start vs CI vs sync-mode-is-the-boot-deadline).

**`docs/optimizely.md` — expanded operational guidance.**
- §7 (Detecting `Fatal`): rewritten with the readiness-check pattern explicit; clarifies that `Fatal` is recoverable so don't treat it as permanent.
- §8 (new) "Choosing a topology": three named patterns specific to Optimizely-backed apps — Pattern A (Optimizely-only async + readiness gate), Pattern B (Optimizely-only sync, fail-fast boot for correctness-critical workloads), Pattern C (Optimizely + `EnvVarProvider` for the small set of flags where defaults are unsafe). Each pattern has a runnable snippet using `OptimizelyProvider.make`, a fit-for-purpose rationale, and the trade-offs it accepts.
- Decision table to pick between A / B / C indexed by workload questions (can the app start while Optimizely is down? what happens during a runtime outage? right for correctness-critical workloads?).

**`CHANGELOG.md`** — `[Unreleased]` entries pointing at the new sections.

### Why this is worth the change

Without this guidance, users picking a topology have to derive these trade-offs themselves. The full chain — `fromProviderAsync` defaults, the 30 s watchdog, `MultiProvider` + `FirstSuccessfulStrategy`'s "Ready if any sub-provider is Ready" semantics, the recovery path under `Fatal` — is implicit in the codebase but not visible at any single doc location. The new sections make the implicit decisions explicit and give operators a fit-for-purpose pattern to pick from rather than a "here are the knobs, good luck" set of APIs.
