### PR TITLE
Add real-datafile decisions IT spec (#148)

### DIFF
--- a/docs/it-project-setup.md
+++ b/docs/it-project-setup.md
@@ -1,0 +1,51 @@
+# `optimizely-it` test-project setup
+
+The `optimizely-it` module's tests run against committed Optimizely v4 datafiles under `optimizely-it/src/test/resources/datafiles/`. Those fixtures are currently **hand-crafted to match the v4 schema** — they're real bytes consumed by the real Optimizely Java SDK, but they were not produced by Optimizely's serializer.
+
+This document is the source of truth for what those datafiles describe so you can:
+
+1. Understand what each spec asserts.
+2. Regenerate the fixtures from a real Optimizely free-tier project (recommended for the strongest "no fakes" coverage — see [Regenerating from a real project](#regenerating-from-a-real-project) below).
+3. Add new flags / audiences / variables and keep the constants in `RealOptimizelySupport.scala` aligned with them.
+
+## Constants
+
+All constants live in `optimizely-it/src/test/scala/zio/openfeature/optimizely/it/RealOptimizelySupport.scala`. Don't rename anything there without updating both the JSON fixtures and this doc.
+
+## `it_basic.json` — five flags, all rolled out 100%
+
+| Flag | Variation | `featureEnabled` | Variables |
+|---|---|---|---|
+| `it_bool_flag` | `on` | true | — |
+| `it_string_flag` | `on` | true | `value: "rolled-out"` (string) |
+| `it_int_flag` | `on` | true | `value: 42` (integer) |
+| `it_double_flag` | `on` | true | `value: 3.14` (double) |
+| `it_object_flag` | `on` | true | `name: "alice"` (string), `level: 7` (integer) |
+
+Each flag has a rollout with one experiment containing one variation that captures 100% of traffic. No audience targeting; every user lands on the rolled-out variation.
+
+## `it_variations.json` — variation-key fallback
+
+| Flag | Variation | `featureEnabled` | Variables |
+|---|---|---|---|
+| `it_variation_flag` | `treatment_a` | true | — |
+
+Used to verify that when a flag has no `value` variable, `getStringEvaluation` falls back to `decision.getVariationKey` (so the test asserts `"treatment_a"`).
+
+## Regenerating from a real project
+
+If you'd rather have Optimizely's serializer produce the JSON (so the fixtures match exactly what a production deployment receives), set up a free-tier project in the Optimizely dashboard and recreate the flags above:
+
+1. Create a new project under your Optimizely Feature Experimentation account (the free tier is fine).
+2. Create the seven flags listed in the [Constants](#constants) section. Match the keys, variable names, types, and default values exactly.
+3. For each rollout: set traffic to 100% and configure the variation values to match the tables above.
+4. (When implementing the targeting spec in #149) create the `country == "US"` audience and the `it_audience_flag` flag.
+5. Dump the datafile for each "SDK key" used by the tests. The SDK keys in the fixtures (`it_basic`, `it_targeting`, `it_variations`, …) are also the filenames nginx serves — you'll need a real Optimizely SDK key per file. The simplest path is to create one Optimizely project per fixture and use that project's SDK key.
+
+   ```bash
+   curl https://cdn.optimizely.com/datafiles/<your-sdk-key-for-it_basic>.json > optimizely-it/src/test/resources/datafiles/it_basic.json
+   ```
+
+6. Run `sbt optimizelyIt/test` to confirm the regenerated fixtures still produce the expected decisions.
+
+If you do this, please remove this note and replace it with a pointer to the Optimizely project(s) used.

--- a/optimizely-it/src/test/resources/datafiles/it_basic.json
+++ b/optimizely-it/src/test/resources/datafiles/it_basic.json
@@ -1,0 +1,218 @@
+{
+  "version": "4",
+  "accountId": "1",
+  "projectId": "1000",
+  "revision": "1",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "featureFlags": [
+    {
+      "id": "1001",
+      "key": "it_bool_flag",
+      "rolloutId": "2001",
+      "experimentIds": [],
+      "variables": []
+    },
+    {
+      "id": "1002",
+      "key": "it_string_flag",
+      "rolloutId": "2002",
+      "experimentIds": [],
+      "variables": [
+        {
+          "id": "5002",
+          "key": "value",
+          "type": "string",
+          "defaultValue": "default"
+        }
+      ]
+    },
+    {
+      "id": "1003",
+      "key": "it_int_flag",
+      "rolloutId": "2003",
+      "experimentIds": [],
+      "variables": [
+        {
+          "id": "5003",
+          "key": "value",
+          "type": "integer",
+          "defaultValue": "0"
+        }
+      ]
+    },
+    {
+      "id": "1004",
+      "key": "it_double_flag",
+      "rolloutId": "2004",
+      "experimentIds": [],
+      "variables": [
+        {
+          "id": "5004",
+          "key": "value",
+          "type": "double",
+          "defaultValue": "0.0"
+        }
+      ]
+    },
+    {
+      "id": "1005",
+      "key": "it_object_flag",
+      "rolloutId": "2005",
+      "experimentIds": [],
+      "variables": [
+        {
+          "id": "5005",
+          "key": "name",
+          "type": "string",
+          "defaultValue": "unknown"
+        },
+        {
+          "id": "5006",
+          "key": "level",
+          "type": "integer",
+          "defaultValue": "0"
+        }
+      ]
+    }
+  ],
+  "rollouts": [
+    {
+      "id": "2001",
+      "experiments": [
+        {
+          "id": "3001",
+          "key": "rollout-2001",
+          "status": "Running",
+          "layerId": "2001",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [
+            { "entityId": "4001", "endOfRange": 10000 }
+          ],
+          "variations": [
+            {
+              "id": "4001",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2002",
+      "experiments": [
+        {
+          "id": "3002",
+          "key": "rollout-2002",
+          "status": "Running",
+          "layerId": "2002",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [
+            { "entityId": "4002", "endOfRange": 10000 }
+          ],
+          "variations": [
+            {
+              "id": "4002",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [
+                { "id": "5002", "value": "rolled-out" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2003",
+      "experiments": [
+        {
+          "id": "3003",
+          "key": "rollout-2003",
+          "status": "Running",
+          "layerId": "2003",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [
+            { "entityId": "4003", "endOfRange": 10000 }
+          ],
+          "variations": [
+            {
+              "id": "4003",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [
+                { "id": "5003", "value": "42" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2004",
+      "experiments": [
+        {
+          "id": "3004",
+          "key": "rollout-2004",
+          "status": "Running",
+          "layerId": "2004",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [
+            { "entityId": "4004", "endOfRange": 10000 }
+          ],
+          "variations": [
+            {
+              "id": "4004",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [
+                { "id": "5004", "value": "3.14" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2005",
+      "experiments": [
+        {
+          "id": "3005",
+          "key": "rollout-2005",
+          "status": "Running",
+          "layerId": "2005",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [
+            { "entityId": "4005", "endOfRange": 10000 }
+          ],
+          "variations": [
+            {
+              "id": "4005",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [
+                { "id": "5005", "value": "alice" },
+                { "id": "5006", "value": "7" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "audiences": [],
+  "typedAudiences": [],
+  "groups": [],
+  "attributes": [],
+  "variables": [],
+  "events": []
+}

--- a/optimizely-it/src/test/resources/datafiles/it_variations.json
+++ b/optimizely-it/src/test/resources/datafiles/it_variations.json
@@ -1,0 +1,51 @@
+{
+  "version": "4",
+  "accountId": "1",
+  "projectId": "1100",
+  "revision": "1",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "featureFlags": [
+    {
+      "id": "1101",
+      "key": "it_variation_flag",
+      "rolloutId": "2101",
+      "experimentIds": [],
+      "variables": []
+    }
+  ],
+  "rollouts": [
+    {
+      "id": "2101",
+      "experiments": [
+        {
+          "id": "3101",
+          "key": "rollout-2101",
+          "status": "Running",
+          "layerId": "2101",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [
+            { "entityId": "4101", "endOfRange": 10000 }
+          ],
+          "variations": [
+            {
+              "id": "4101",
+              "key": "treatment_a",
+              "featureEnabled": true,
+              "variables": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "audiences": [],
+  "typedAudiences": [],
+  "groups": [],
+  "attributes": [],
+  "variables": [],
+  "events": []
+}

--- a/optimizely-it/src/test/scala/zio/openfeature/optimizely/it/OptimizelyRealDatafileSpec.scala
+++ b/optimizely-it/src/test/scala/zio/openfeature/optimizely/it/OptimizelyRealDatafileSpec.scala
@@ -1,0 +1,99 @@
+package zio.openfeature.optimizely.it
+
+import dev.openfeature.sdk.{ErrorCode, ProviderState, Reason, Value}
+import zio._
+import zio.openfeature.optimizely.it.RealOptimizelySupport._
+import zio.test.Assertion._
+import zio.test._
+
+/** Drives the real Optimizely Java SDK against a docker-compose'd nginx + Toxiproxy stack serving a committed datafile.
+  * Covers the boolean / string / int / double / object decision paths, the unknown-flag and variable-type-mismatch
+  * branches, and variation-key fallback when a flag has no `"value"` variable.
+  *
+  * Fixture: `optimizely-it/src/test/resources/datafiles/it_basic.json` (5 flags, all rolled out 100%) and
+  * `it_variations.json` (1 flag with no variables, used for variation-key access).
+  *
+  * Sequential and live-clock for the same reasons as `OptimizelyProviderIntegrationSpec` — the Optimizely SDK keeps
+  * order-sensitive state on its internal executor and these tests need wall-clock for the datafile init wait.
+  */
+object OptimizelyRealDatafileSpec extends ZIOSpecDefault {
+
+  private val TargetingKey = "it-user-1"
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("Optimizely real-datafile decisions")(
+    test("initialize against committed datafile -> READY") {
+      withReadyProvider(BasicSdkKey) { provider =>
+        @scala.annotation.nowarn("msg=deprecated")
+        val state = provider.getState
+        assert(state)(equalTo(ProviderState.READY))
+      }
+    },
+    test("boolean evaluation returns the rolled-out variation's featureEnabled") {
+      withReadyProvider(BasicSdkKey) { provider =>
+        val ev = provider.getBooleanEvaluation(BoolFlagKey, java.lang.Boolean.FALSE, userContext(TargetingKey))
+        assert(ev.getValue)(equalTo(java.lang.Boolean.valueOf(BoolFlagExpectedEnabled))) &&
+        assert(ev.getVariant)(equalTo(BoolFlagExpectedVariant)) &&
+        assert(ev.getReason)(equalTo(Reason.TARGETING_MATCH.name())) &&
+        assert(ev.getErrorCode)(isNull)
+      }
+    },
+    test("string evaluation returns the variation's `value` variable") {
+      withReadyProvider(BasicSdkKey) { provider =>
+        val ev = provider.getStringEvaluation(StringFlagKey, "default", userContext(TargetingKey))
+        assert(ev.getValue)(equalTo(StringFlagExpectedValue)) &&
+        assert(ev.getReason)(equalTo(Reason.TARGETING_MATCH.name())) &&
+        assert(ev.getErrorCode)(isNull)
+      }
+    },
+    test("integer evaluation returns the variation's typed `value` variable") {
+      withReadyProvider(BasicSdkKey) { provider =>
+        val ev = provider.getIntegerEvaluation(IntFlagKey, java.lang.Integer.valueOf(-1), userContext(TargetingKey))
+        assert(ev.getValue)(equalTo(java.lang.Integer.valueOf(IntFlagExpectedValue))) &&
+        assert(ev.getReason)(equalTo(Reason.TARGETING_MATCH.name()))
+      }
+    },
+    test("double evaluation returns the variation's typed `value` variable") {
+      withReadyProvider(BasicSdkKey) { provider =>
+        val ev = provider.getDoubleEvaluation(DoubleFlagKey, java.lang.Double.valueOf(-1.0), userContext(TargetingKey))
+        assert(ev.getValue)(equalTo(java.lang.Double.valueOf(DoubleFlagExpectedValue))) &&
+        assert(ev.getReason)(equalTo(Reason.TARGETING_MATCH.name()))
+      }
+    },
+    test("object evaluation returns a Structure with all variation variables") {
+      withReadyProvider(BasicSdkKey) { provider =>
+        val ev        = provider.getObjectEvaluation(ObjectFlagKey, new Value(), userContext(TargetingKey))
+        val structure = ev.getValue.asStructure()
+        assert(structure.getValue("name").asString())(equalTo(ObjectFlagExpectedName)) &&
+        assert(structure.getValue("level").asInteger().intValue())(equalTo(ObjectFlagExpectedLevel)) &&
+        assert(ev.getReason)(equalTo(Reason.TARGETING_MATCH.name()))
+      }
+    },
+    test("unknown flag key -> FLAG_NOT_FOUND, default returned") {
+      withReadyProvider(BasicSdkKey) { provider =>
+        val ev = provider.getBooleanEvaluation(UnknownFlagKey, java.lang.Boolean.TRUE, userContext(TargetingKey))
+        assert(ev.getValue)(equalTo(java.lang.Boolean.TRUE)) &&
+        assert(ev.getErrorCode)(equalTo(ErrorCode.FLAG_NOT_FOUND)) &&
+        assert(ev.getReason)(equalTo(Reason.ERROR.name()))
+      }
+    },
+    test("type mismatch (string flag queried as integer) -> default with reason DEFAULT") {
+      withReadyProvider(BasicSdkKey) { provider =>
+        val default = java.lang.Integer.valueOf(99)
+        val ev      = provider.getIntegerEvaluation(StringFlagKey, default, userContext(TargetingKey))
+        assert(ev.getValue)(equalTo(default)) &&
+        assert(ev.getReason)(equalTo(Reason.DEFAULT.name())) &&
+        assert(ev.getErrorCode)(isNull)
+      }
+    },
+    test("variation-key fallback when the flag has no `value` variable") {
+      withReadyProvider(VariationsSdkKey) { provider =>
+        val ev = provider.getStringEvaluation(VariationFlagKey, "fallback", userContext(TargetingKey))
+        assert(ev.getValue)(equalTo(VariationFlagExpectedKey)) &&
+        assert(ev.getVariant)(equalTo(VariationFlagExpectedKey)) &&
+        assert(ev.getReason)(equalTo(Reason.TARGETING_MATCH.name()))
+      }
+    }
+  ) @@ OptimizelyItStack.ifDockerAvailable @@ TestAspect.sequential @@ TestAspect.timeout(
+    120.seconds
+  ) @@ TestAspect.withLiveClock
+}

--- a/optimizely-it/src/test/scala/zio/openfeature/optimizely/it/RealOptimizelySupport.scala
+++ b/optimizely-it/src/test/scala/zio/openfeature/optimizely/it/RealOptimizelySupport.scala
@@ -1,17 +1,19 @@
 package zio.openfeature.optimizely.it
 
-import zio.{Runtime, Unsafe}
+import dev.openfeature.sdk.{ImmutableContext, MutableContext}
 import zio.openfeature.optimizely.{OptimizelyFeatureProvider, OptimizelyProvider}
+import zio.{Runtime, Unsafe}
 
 import java.time.Duration
 
 /** Single source of truth for the flag-key / variable / variation constants that the IT specs assert against. Any
   * change here must be matched in the committed datafiles under `src/test/resources/datafiles/` AND in
-  * `docs/it-project-setup.md` so a contributor can regenerate the fixtures from a fresh Optimizely project.
+  * `docs/it-project-setup.md` so the fixtures stay reproducible from a real Optimizely free-tier project.
   */
 object RealOptimizelySupport {
 
-  // SDK keys — synthetic filenames served by nginx, not real Optimizely keys.
+  // SDK keys — filenames served by nginx, also passed to the Optimizely Java SDK as "the" SDK key. They have to
+  // satisfy OptimizelyProvider's shape validation: [A-Za-z0-9_-]+, length 6..128.
 
   val BasicSdkKey: String      = "it_basic"
   val V2SdkKey: String         = "it_basic_v2"
@@ -19,8 +21,7 @@ object RealOptimizelySupport {
   val VariationsSdkKey: String = "it_variations"
   val MalformedSdkKey: String  = "it_malformed"
 
-  // Flag keys, variable names, and expected variation values for `it_basic.json`. Filled in by the real-datafile-spec
-  // PR; declared here so the foundation can compile.
+  // Flag keys defined by the committed datafiles.
 
   val BoolFlagKey: String      = "it_bool_flag"
   val StringFlagKey: String    = "it_string_flag"
@@ -31,7 +32,33 @@ object RealOptimizelySupport {
   val AudienceFlagKey: String  = "it_audience_flag"
   val UnknownFlagKey: String   = "it_does_not_exist"
 
+  // Expected values served by `it_basic.json` and `it_variations.json` when a flag is fully rolled out.
+
+  val BoolFlagExpectedEnabled: Boolean = true
+  val BoolFlagExpectedVariant: String  = "on"
+  val StringFlagExpectedValue: String  = "rolled-out"
+  val IntFlagExpectedValue: Int        = 42
+  val DoubleFlagExpectedValue: Double  = 3.14
+  val ObjectFlagExpectedName: String   = "alice"
+  val ObjectFlagExpectedLevel: Int     = 7
+  val VariationFlagExpectedKey: String = "treatment_a"
+
   val DefaultInitWait: Duration = Duration.ofSeconds(5)
+
+  /** Build a `MutableContext` whose targeting key is set, so Optimizely's bucketing has a userId to hash. Without one
+    * the provider short-circuits with TARGETING_KEY_MISSING and the decision engine is never exercised.
+    */
+  def userContext(targetingKey: String): MutableContext = new MutableContext(targetingKey)
+
+  /** Build a provider, drive it to `READY` via `initialize`, run `body`, and shutdown on every path. */
+  def withReadyProvider[A](
+    sdkKey: String,
+    initWait: Duration = DefaultInitWait
+  )(body: OptimizelyFeatureProvider => A): A =
+    withProvider(sdkKey, initWait) { provider =>
+      provider.initialize(new ImmutableContext())
+      body(provider)
+    }
 
   /** Synchronously build a provider against the live stack and run `body` against it, ensuring shutdown.
     *
@@ -50,7 +77,7 @@ object RealOptimizelySupport {
 
   /** Try to initialize the provider, returning the exception (if any). */
   def tryInit(provider: OptimizelyFeatureProvider): Either[Throwable, Unit] =
-    try { provider.initialize(new dev.openfeature.sdk.ImmutableContext()); Right(()) }
+    try { provider.initialize(new ImmutableContext()); Right(()) }
     catch { case t: Throwable => Left(t) }
 
   private def buildProvider(sdkKey: String, initWait: Duration): OptimizelyFeatureProvider = {


### PR DESCRIPTION
Closes #148. Stacked on #152.

Adds `OptimizelyRealDatafileSpec` plus the two hand-crafted Optimizely v4 datafile fixtures it drives.

## Per #148

- `it_basic.json` — five rolled-out-100% flags (`it_bool_flag`, `it_string_flag`, `it_int_flag`, `it_double_flag`, `it_object_flag`). Each has the variable layout the spec asserts on; the object flag has two variables (`name`, `level`) so the Structure path is exercised.
- `it_variations.json` — one flag with no variables, used for variation-key fallback.
- `OptimizelyRealDatafileSpec` (9 tests, all gated behind `ifDockerAvailable @@ sequential @@ withLiveClock`):
  - init → `READY`
  - boolean → `true` / variant `on` / reason TARGETING_MATCH
  - string / int / double — typed `value` variable round-trips
  - object — Structure with both variables
  - unknown flag → FLAG_NOT_FOUND, default returned, reason ERROR
  - type mismatch (string flag queried as integer) → default, reason DEFAULT
  - variation-key fallback (no `value` variable) → variation key returned
- `RealOptimizelySupport` extended with `withReadyProvider`, `userContext`, and the expected-value constants the spec asserts on.
- `docs/it-project-setup.md` — describes what each fixture encodes plus a checklist for regenerating from a real Optimizely free-tier project (option chosen later if the hand-crafted fixtures aren't authentic enough).

## Verification

- `sbt optimizelyIt/test` with Docker running: stack comes up, all 11 tests (2 foundation smoke + 9 new) pass, stack tears down cleanly (~6s after cached image pulls).
- Optimizely SDK logs confirm real decision-engine activity, including bucketing into rollout experiments and emitting `JsonParseException` on the type-mismatch case (which the provider correctly catches and surfaces as the DEFAULT reason).

## Hand-crafted fixture note

These datafiles are valid Optimizely v4 JSON — the real Java SDK consumes them, runs its real decision engine on them — but the JSON was written by hand, not produced by Optimizely's serializer. The same caveats apply as in the plan's option 2: less authentic, but unblocks all four specs without needing an Optimizely project. `docs/it-project-setup.md` describes how to swap to dumped real datafiles later.

## Follow-ups

- #149 — audience targeting spec
- #150 — auth / transport failure spec
- #151 — datafile churn spec