### PR TITLE
Add audience targeting IT spec (#149)

### DIFF
--- a/docs/it-project-setup.md
+++ b/docs/it-project-setup.md
@@ -24,6 +24,16 @@ All constants live in `optimizely-it/src/test/scala/zio/openfeature/optimizely/i
 
 Each flag has a rollout with one experiment containing one variation that captures 100% of traffic. No audience targeting; every user lands on the rolled-out variation.
 
+## `it_targeting.json` — audience-targeted decisions
+
+Audience: `Country US`, condition `country == "US"` (custom-attribute exact match).
+
+| Flag | Rule 1 (audience = US) | Rule 2 (default) |
+|---|---|---|
+| `it_audience_flag` | variation `us`, `featureEnabled=true`, `value: "us"` | variation `off`, `featureEnabled=false`, `value: "other"` |
+
+A user with attribute `country=US` matches rule 1 and gets `us`. Any other user falls through to rule 2 and gets `off`. A request with no targeting key short-circuits before reaching Optimizely with `ErrorCode.TARGETING_KEY_MISSING`.
+
 ## `it_variations.json` — variation-key fallback
 
 | Flag | Variation | `featureEnabled` | Variables |

--- a/optimizely-it/src/test/resources/datafiles/it_targeting.json
+++ b/optimizely-it/src/test/resources/datafiles/it_targeting.json
@@ -1,0 +1,103 @@
+{
+  "version": "4",
+  "accountId": "1",
+  "projectId": "1200",
+  "revision": "1",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "featureFlags": [
+    {
+      "id": "1200",
+      "key": "it_audience_flag",
+      "rolloutId": "2200",
+      "experimentIds": [],
+      "variables": [
+        {
+          "id": "5200",
+          "key": "value",
+          "type": "string",
+          "defaultValue": "other"
+        }
+      ]
+    }
+  ],
+  "rollouts": [
+    {
+      "id": "2200",
+      "experiments": [
+        {
+          "id": "3200",
+          "key": "rollout-2200-us",
+          "status": "Running",
+          "layerId": "2200",
+          "audienceIds": ["9001"],
+          "forcedVariations": {},
+          "trafficAllocation": [
+            { "entityId": "4200", "endOfRange": 10000 }
+          ],
+          "variations": [
+            {
+              "id": "4200",
+              "key": "us",
+              "featureEnabled": true,
+              "variables": [
+                { "id": "5200", "value": "us" }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "3201",
+          "key": "rollout-2200-default",
+          "status": "Running",
+          "layerId": "2200",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [
+            { "entityId": "4201", "endOfRange": 10000 }
+          ],
+          "variations": [
+            {
+              "id": "4201",
+              "key": "off",
+              "featureEnabled": false,
+              "variables": [
+                { "id": "5200", "value": "other" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "audiences": [],
+  "typedAudiences": [
+    {
+      "id": "9001",
+      "name": "Country US",
+      "conditions": [
+        "and",
+        [
+          "or",
+          [
+            "or",
+            {
+              "name": "country",
+              "type": "custom_attribute",
+              "match": "exact",
+              "value": "US"
+            }
+          ]
+        ]
+      ]
+    }
+  ],
+  "groups": [],
+  "attributes": [
+    { "id": "100", "key": "country" }
+  ],
+  "variables": [],
+  "events": []
+}

--- a/optimizely-it/src/test/scala/zio/openfeature/optimizely/it/OptimizelyTargetingSpec.scala
+++ b/optimizely-it/src/test/scala/zio/openfeature/optimizely/it/OptimizelyTargetingSpec.scala
@@ -1,0 +1,50 @@
+package zio.openfeature.optimizely.it
+
+import dev.openfeature.sdk.{ErrorCode, ImmutableContext, Reason}
+import zio._
+import zio.openfeature.optimizely.it.RealOptimizelySupport._
+import zio.test.Assertion._
+import zio.test._
+
+/** Drives the real Optimizely Java SDK against `it_targeting.json` to exercise audience-based decisions.
+  *
+  * The fixture defines `it_audience_flag` with two rollout rules: rule 1 is gated by the `Country US` audience
+  * (`country == "US"`) and serves the `us` variation; rule 2 is the unconditional default and serves the `off`
+  * variation. Tests assert that the user's attributes drive which rule fires.
+  */
+object OptimizelyTargetingSpec extends ZIOSpecDefault {
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("Optimizely audience targeting")(
+    test("user matching the US audience -> `us` variation, featureEnabled=true") {
+      withReadyProvider(TargetingSdkKey) { provider =>
+        val context   = userContext("user-us").add("country", "US")
+        val boolEval  = provider.getBooleanEvaluation(AudienceFlagKey, java.lang.Boolean.FALSE, context)
+        val valueEval = provider.getStringEvaluation(AudienceFlagKey, "fallback", context)
+        assert(boolEval.getValue)(equalTo(java.lang.Boolean.TRUE)) &&
+        assert(boolEval.getVariant)(equalTo("us")) &&
+        assert(valueEval.getValue)(equalTo("us")) &&
+        assert(valueEval.getReason)(equalTo(Reason.TARGETING_MATCH.name()))
+      }
+    },
+    test("user NOT matching the US audience -> falls through to default rule, `off` variation") {
+      withReadyProvider(TargetingSdkKey) { provider =>
+        val context   = userContext("user-fr").add("country", "FR")
+        val boolEval  = provider.getBooleanEvaluation(AudienceFlagKey, java.lang.Boolean.TRUE, context)
+        val valueEval = provider.getStringEvaluation(AudienceFlagKey, "fallback", context)
+        assert(boolEval.getValue)(equalTo(java.lang.Boolean.FALSE)) &&
+        assert(boolEval.getVariant)(equalTo("off")) &&
+        assert(valueEval.getValue)(equalTo("other"))
+      }
+    },
+    test("missing targeting key -> TARGETING_KEY_MISSING, default returned") {
+      withReadyProvider(TargetingSdkKey) { provider =>
+        val ev = provider.getBooleanEvaluation(AudienceFlagKey, java.lang.Boolean.TRUE, new ImmutableContext())
+        assert(ev.getValue)(equalTo(java.lang.Boolean.TRUE)) &&
+        assert(ev.getErrorCode)(equalTo(ErrorCode.TARGETING_KEY_MISSING)) &&
+        assert(ev.getReason)(equalTo(Reason.ERROR.name()))
+      }
+    }
+  ) @@ OptimizelyItStack.ifDockerAvailable @@ TestAspect.sequential @@ TestAspect.timeout(
+    120.seconds
+  ) @@ TestAspect.withLiveClock
+}


### PR DESCRIPTION
Closes #149. Stacked on #153.

Adds `OptimizelyTargetingSpec` plus `it_targeting.json`, exercising real Optimizely audience matching end-to-end through `ContextTransformer` and the Java SDK's decision engine.

## Fixture

`it_targeting.json` defines one feature flag (`it_audience_flag`) with a two-rule rollout:

1. **Rule 1** — gated by typed audience `Country US` (`country == "US"`). Variation `us`, `featureEnabled=true`, `value: "us"`. 100% traffic for matching users.
2. **Rule 2** — unconditional default. Variation `off`, `featureEnabled=false`, `value: "other"`. 100% traffic.

## Spec (3 tests)

- User with `country=US` → audience matches → variation `us`, `featureEnabled=true`, `value="us"`, reason `TARGETING_MATCH`.
- User with `country=FR` → audience condition evaluates false → falls through to default rule → variation `off`, `featureEnabled=false`, `value="other"`.
- Context with no targeting key → provider short-circuits with `ErrorCode.TARGETING_KEY_MISSING`, reason `ERROR`.

Optimizely's own logs in the test output confirm real audience evaluation, e.g. `Audiences for rule "1" collectively evaluated to false.` for the FR user before bucketing into the default rule.

## Docs

`docs/it-project-setup.md` gets an `it_targeting.json` section that lists the audience condition and the variation/value mapping, so the fixture stays reproducible.

## Verification

- `sbt optimizelyIt/test` — 14 tests pass (2 smoke + 9 datafile + 3 targeting), ~7s after first image pull.
- `sbt optimizelyIt/testOnly *OptimizelyTargetingSpec*` — 3 tests pass.