### PR TITLE
Add auth and transport failure IT spec (#150)

### DIFF
--- a/optimizely-it/src/test/scala/zio/openfeature/optimizely/FastFailProviderHarness.scala
+++ b/optimizely-it/src/test/scala/zio/openfeature/optimizely/FastFailProviderHarness.scala
@@ -1,0 +1,45 @@
+package zio.openfeature.optimizely
+
+import com.optimizely.ab.Optimizely
+import com.optimizely.ab.config.HttpProjectConfigManager
+
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+/** Test-only helper that lives in `zio.openfeature.optimizely` so it can construct an `OptimizelyFeatureProvider`
+  * directly via the package-private constructor with a custom blocking timeout — needed for the auth/transport-failure
+  * IT spec, where toxic-induced latencies have to exceed the SDK's `getConfig` blocking timeout for `isValid` to
+  * actually report false before our outer init-wait fires.
+  *
+  * Not part of the public API; built by the `optimizely-it` test sources only.
+  */
+object FastFailProviderHarness {
+
+  /** Build an Optimizely client pointed at `datafileUrl` with a short blocking timeout so transport-fault tests fail
+    * fast instead of being absorbed by the SDK's default 10-second wait.
+    */
+  def buildFastFailClient(
+    sdkKey: String,
+    datafileUrl: String,
+    blockingTimeout: Duration = Duration.ofMillis(300),
+    pollingInterval: Duration = Duration.ofSeconds(3600)
+  ): Optimizely = {
+    val mgr = HttpProjectConfigManager
+      .builder()
+      .withSdkKey(sdkKey)
+      .withUrl(datafileUrl)
+      .withBlockingTimeout(blockingTimeout.toMillis, TimeUnit.MILLISECONDS)
+      .withPollingInterval(pollingInterval.toSeconds, TimeUnit.SECONDS)
+      .build()
+    Optimizely.builder().withConfigManager(mgr).build()
+  }
+
+  /** Build a provider directly via the package-private constructor with the specified `initWait` and
+    * `closeOnShutdown=true`. Use with `buildFastFailClient` for failure-mode tests.
+    */
+  def newProvider(
+    client: Optimizely,
+    initWait: Duration
+  ): OptimizelyFeatureProvider =
+    new OptimizelyFeatureProvider(client, initWait, closeOnShutdown = true)
+}

--- a/optimizely-it/src/test/scala/zio/openfeature/optimizely/it/OptimizelyAuthFailureSpec.scala
+++ b/optimizely-it/src/test/scala/zio/openfeature/optimizely/it/OptimizelyAuthFailureSpec.scala
@@ -1,0 +1,92 @@
+package zio.openfeature.optimizely.it
+
+import dev.openfeature.sdk.{ImmutableContext, ProviderState}
+import eu.rekawek.toxiproxy.model.ToxicDirection
+import zio._
+import zio.openfeature.optimizely.FastFailProviderHarness
+import zio.openfeature.optimizely.it.RealOptimizelySupport._
+import zio.test.Assertion._
+import zio.test._
+
+import java.time.Duration
+
+/** Drives the real Optimizely Java SDK at the real Toxiproxy-fronted nginx, injecting network-level faults to verify
+  * the provider surfaces them as init failures rather than silent fallbacks.
+  *
+  * Synthesized HTTP status codes (401 / 403 / 500) are explicitly NOT covered here — those belong to
+  * `OptimizelyProviderIntegrationSpec` (WireMock), which is fast, in-process, and runs on every PR. This suite covers
+  * transport-layer faults that need a real TCP proxy in the path.
+  *
+  * The provider is built via [[FastFailProviderHarness]] with a short SDK `blockingTimeout`, otherwise
+  * `optimizely.isValid()` (which the provider calls during `initialize`) absorbs the injected latency within its own
+  * default 10-second wait and the outer `initWait` never wins the race.
+  */
+object OptimizelyAuthFailureSpec extends ZIOSpecDefault {
+
+  private val ShortInitWait: Duration = Duration.ofMillis(500)
+  private val ShortBlocking: Duration = Duration.ofMillis(300)
+
+  @scala.annotation.nowarn("msg=deprecated")
+  private def stateOf(p: zio.openfeature.optimizely.OptimizelyFeatureProvider): ProviderState = p.getState
+
+  private def withFastFailProvider[A](
+    sdkKey: String,
+    initWait: Duration = ShortInitWait,
+    blockingTimeout: Duration = ShortBlocking
+  )(body: zio.openfeature.optimizely.OptimizelyFeatureProvider => A): A = {
+    val client =
+      FastFailProviderHarness.buildFastFailClient(sdkKey, OptimizelyItStack.datafileUrl(sdkKey), blockingTimeout)
+    val provider = FastFailProviderHarness.newProvider(client, initWait)
+    try body(provider)
+    finally provider.shutdown()
+  }
+
+  private def tryInit(provider: zio.openfeature.optimizely.OptimizelyFeatureProvider): Either[Throwable, Unit] =
+    try { provider.initialize(new ImmutableContext()); Right(()) }
+    catch { case t: Throwable => Left(t) }
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("Optimizely auth / transport failures")(
+    test("unknown SDK key (nginx 404) -> init fails, state not READY") {
+      // The filename `it_not_present.json` doesn't exist under datafiles/, so nginx returns a real 404.
+      withFastFailProvider("it_not_present") { provider =>
+        val outcome = tryInit(provider)
+        val state   = stateOf(provider)
+        assert(outcome.isLeft)(isTrue) &&
+        assert(state)(not(equalTo(ProviderState.READY)))
+      }
+    },
+    test("latency toxic past initWait -> init throws, state not READY") {
+      OptimizelyItStack.withToxic(_.toxics().latency("slow", ToxicDirection.DOWNSTREAM, 5000)) {
+        withFastFailProvider(BasicSdkKey) { provider =>
+          val outcome = tryInit(provider)
+          val state   = stateOf(provider)
+          assert(outcome.isLeft)(isTrue) &&
+          assert(state)(not(equalTo(ProviderState.READY)))
+        }
+      }
+    },
+    test("RESET_PEER toxic -> init throws, state not READY") {
+      OptimizelyItStack.withToxic(_.toxics().resetPeer("reset", ToxicDirection.DOWNSTREAM, 0)) {
+        withFastFailProvider(BasicSdkKey) { provider =>
+          val outcome = tryInit(provider)
+          val state   = stateOf(provider)
+          assert(outcome.isLeft)(isTrue) &&
+          assert(state)(not(equalTo(ProviderState.READY)))
+        }
+      }
+    },
+    test("proxy disabled (connection refused) -> init throws, state not READY") {
+      val handle = OptimizelyItStack.disableProxy()
+      try
+        withFastFailProvider(BasicSdkKey) { provider =>
+          val outcome = tryInit(provider)
+          val state   = stateOf(provider)
+          assert(outcome.isLeft)(isTrue) &&
+          assert(state)(not(equalTo(ProviderState.READY)))
+        }
+      finally handle.close()
+    }
+  ) @@ OptimizelyItStack.ifDockerAvailable @@ TestAspect.sequential @@ TestAspect.timeout(
+    120.seconds
+  ) @@ TestAspect.withLiveClock
+}


### PR DESCRIPTION
Closes #150. Stacked on #154.

Adds `OptimizelyAuthFailureSpec`, which drives the real Optimizely Java SDK against Toxiproxy and asserts the provider surfaces network-level faults as `initialize()` failures.

## Why this exists alongside the WireMock spec

Synthesized HTTP status codes (401 / 403 / 500) stay with `OptimizelyProviderIntegrationSpec` — in-process, fast, runs on every PR. This new spec covers transport-layer faults that need a real TCP proxy in the path.

## Scenarios (4 tests)

| Fault | Mechanism | Assertion |
|---|---|---|
| Unknown SDK key | filename absent on nginx mount → real 404 | init fails, state not `READY` |
| Latency past `initWait` | Toxiproxy `latency` toxic (5s) on DOWNSTREAM | init throws, state not `READY` |
| Connection reset | Toxiproxy `RESET_PEER` toxic | init throws, state not `READY` |
| Connection refused | `OptimizelyItStack.disableProxy()` | init throws, state not `READY` |

## New helper: `FastFailProviderHarness`

The first run revealed a subtle ordering issue: `OptimizelyFeatureProvider.initialize` calls `optimizely.isValid()`, which (under the hood) blocks up to the SDK's default 10-second `blockingTimeout` waiting for a datafile. With a 5-second latency toxic, `isValid` absorbs the latency within its own wait and reports `true` before our outer `initWait` ever fires — making the provider reach `READY` despite the injected fault.

The fix is to drop the SDK's `blockingTimeout` below the toxic's effect. `OptimizelyProvider.make` doesn't expose `blockingTimeout` (and shouldn't — typical production callers should just use the default), so the spec builds its client via a new test-only helper at `optimizely-it/src/test/scala/zio/openfeature/optimizely/FastFailProviderHarness.scala`. The file lives in `package zio.openfeature.optimizely` so it can call the package-private `OptimizelyFeatureProvider` constructor directly, just like `OptimizelyProviderIntegrationSpec` does. Scala 3's `private[optimizely]` permits this cross-module same-package access.

## Verification

- `sbt optimizelyIt/testOnly *OptimizelyAuthFailureSpec*` — 4 tests pass.
- `sbt optimizelyIt/test` — full suite: 18 tests pass (2 smoke + 9 datafile + 3 targeting + 4 auth), ~10s after cached image pulls.

Optimizely's own logs in the test output confirm real fault surfacing, e.g. `Timeout exceeded waiting for ProjectConfig to be set, returning null.` for the connection-refused case.

## Follow-up

- #151 — datafile churn spec