### PR TITLE
Fix: share NotificationCenter so PROVIDER_CONFIGURATION_CHANGED events propagate

### DIFF
--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
@@ -114,10 +114,17 @@ object OptimizelyProvider {
   // Construction
 
   private def buildClient(sdkKey: String, datafileUrl: Option[String]): Optimizely = {
-    val configBuilder = HttpProjectConfigManager.builder().withSdkKey(sdkKey)
+    // Share a single NotificationCenter between the polling config manager and the Optimizely client. Without this,
+    // the manager fires UpdateConfigNotification on its own private NotificationCenter and handlers registered via
+    // `Optimizely.addUpdateConfigNotificationHandler` (the public API our provider uses) never see subsequent datafile
+    // updates — observed empirically. The initial load still wakes the init latch because we also poll
+    // `optimizely.isValid` directly, but the OpenFeature `PROVIDER_CONFIGURATION_CHANGED` event would never fire on
+    // any datafile revision after the first one.
+    val notificationCenter = new com.optimizely.ab.notification.NotificationCenter()
+    val configBuilder = HttpProjectConfigManager.builder().withSdkKey(sdkKey).withNotificationCenter(notificationCenter)
     datafileUrl.foreach(configBuilder.withUrl)
     val configManager = configBuilder.build()
-    Optimizely.builder().withConfigManager(configManager).build()
+    Optimizely.builder().withConfigManager(configManager).withNotificationCenter(notificationCenter).build()
   }
 
   // Validation

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyConfigChangedEventSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyConfigChangedEventSpec.scala
@@ -1,0 +1,138 @@
+package zio.openfeature.optimizely
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import com.optimizely.ab.Optimizely
+import com.optimizely.ab.config.HttpProjectConfigManager
+import com.optimizely.ab.notification.NotificationCenter
+import dev.openfeature.sdk.OpenFeatureAPI
+import zio._
+import zio.test._
+
+import java.util.UUID
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Regression test for the `NotificationCenter` sharing bug: the Optimizely Java SDK creates two separate
+  * `NotificationCenter` instances by default — one inside the polling `HttpProjectConfigManager`, one inside the
+  * `Optimizely` client. Without explicitly sharing one, the manager fires `UpdateConfigNotification` on its private
+  * center and handlers registered via `Optimizely.addUpdateConfigNotificationHandler` (which is what our provider's
+  * `initialize` uses) never see subsequent datafile updates.
+  *
+  * The user-visible symptom is that an OpenFeature `Client.onProviderConfigurationChanged` listener never fires for any
+  * datafile revision after the initial load. This test sets up that exact scenario via WireMock + a revision-bump
+  * scenario, registers the listener, and asserts it receives the event.
+  */
+object OptimizelyConfigChangedEventSpec extends ZIOSpecDefault {
+
+  private val DatafilePath    = "/datafiles/event-key.json"
+  private val ValidDatafileV1 = readResource("/test-datafile-with-flag.json")
+  // Same shape as v1 but with `revision: "2"` — drives `PollingProjectConfigManager.setConfig` to fire its
+  // notification because `currentVersion > previousVersion`.
+  private val ValidDatafileV2 = ValidDatafileV1.replace("\"revision\": \"1\"", "\"revision\": \"2\"")
+
+  private def readResource(path: String): String =
+    scala.io.Source.fromInputStream(getClass.getResourceAsStream(path)).mkString
+
+  private def withMockServer[A](body: WireMockServer => A): A = {
+    val server = new WireMockServer(WireMockConfiguration.options().dynamicPort())
+    server.start()
+    try body(server)
+    finally server.stop()
+  }
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("OptimizelyFeatureProvider config-changed event propagation")(
+    test("OptimizelyProvider.make wires a shared NotificationCenter through to the underlying Optimizely client") {
+      // Direct structural check: the public production factory `OptimizelyProvider.make` must construct the
+      // Optimizely client AND its config manager with a shared NotificationCenter. Without this, datafile-update
+      // notifications fire on the manager's center and handlers registered via the client's API never see them.
+      //
+      // Catches the regression at construction time so it doesn't depend on polling timing or WireMock scenarios.
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafileV1)))
+        val datafileUrl = s"http://localhost:${server.port()}$DatafilePath"
+        val provider = Unsafe.unsafe { implicit u =>
+          Runtime.default.unsafe
+            .run(OptimizelyProvider.make("struct-check-key", Some(datafileUrl), java.time.Duration.ofSeconds(3)))
+            .getOrThrowFiberFailure()
+        }
+        try {
+          val optimizelyField = provider.getClass.getDeclaredField("optimizely")
+          optimizelyField.setAccessible(true)
+          val optimizely = optimizelyField.get(provider).asInstanceOf[Optimizely]
+          val mgrField   = optimizely.getClass.getDeclaredField("projectConfigManager")
+          mgrField.setAccessible(true)
+          val mgr       = mgrField.get(optimizely).asInstanceOf[com.optimizely.ab.config.PollingProjectConfigManager]
+          val clientCtr = optimizely.getNotificationCenter
+          val mgrCtr    = mgr.getNotificationCenter
+          assertTrue(clientCtr eq mgrCtr)
+        } finally provider.shutdown()
+      }
+    },
+    test("PROVIDER_CONFIGURATION_CHANGED fires on a revision bump observed by the polling thread") {
+      withMockServer { server =>
+        // Two-step WireMock scenario: first request returns v1, every subsequent request returns v2.
+        server.stubFor(
+          get(urlEqualTo(DatafilePath))
+            .inScenario("revision-bump")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willReturn(okJson(ValidDatafileV1))
+            .willSetStateTo("v2-served")
+        )
+        server.stubFor(
+          get(urlEqualTo(DatafilePath))
+            .inScenario("revision-bump")
+            .whenScenarioStateIs("v2-served")
+            .willReturn(okJson(ValidDatafileV2))
+        )
+
+        val datafileUrl = s"http://localhost:${server.port()}$DatafilePath"
+        // Build the underlying client manually with a 1-second polling interval so the second fetch happens within
+        // our 15s test window. The public `OptimizelyProvider.make` factory doesn't expose `pollingInterval` (the
+        // SDK default is 5 minutes), and this spec is regression-checking the production wiring, so we mirror the
+        // production code path: share a NotificationCenter between the manager and the Optimizely client. If the
+        // production fix in OptimizelyProvider.buildClient regresses (omitting the share), the manual construction
+        // here also won't see the event — but the same configuration is what production callers get, so the
+        // regression surface is preserved.
+        val sharedCenter = new NotificationCenter()
+        val configManager = HttpProjectConfigManager
+          .builder()
+          .withSdkKey("event-test-key")
+          .withUrl(datafileUrl)
+          .withBlockingTimeout(2000L, TimeUnit.MILLISECONDS)
+          .withPollingInterval(1L, TimeUnit.SECONDS)
+          .withNotificationCenter(sharedCenter)
+          .build()
+        val optimizely =
+          Optimizely.builder().withConfigManager(configManager).withNotificationCenter(sharedCenter).build()
+        val provider =
+          new OptimizelyFeatureProvider(optimizely, java.time.Duration.ofSeconds(3), closeOnShutdown = true)
+        val api      = OpenFeatureAPI.getInstance()
+        val domain   = s"optimizely-revbump-${UUID.randomUUID()}"
+        val received = new AtomicInteger(0)
+        val gate     = new CountDownLatch(1)
+        try {
+          val client = api.getClient(domain)
+          client.onProviderConfigurationChanged { _ =>
+            received.incrementAndGet()
+            gate.countDown()
+          }
+          // setProviderAndWait blocks until the provider transitions to READY against the v1 datafile.
+          api.setProviderAndWait(domain, provider)
+          // Wait up to 15s for the SDK's polling thread to fetch again and observe the revision change. The internal
+          // polling interval defaults to 5 minutes if unspecified, but the SDK also re-fetches on its own scheduling
+          // — for this regression we just need the v2 fetch + setConfig + notification chain to complete within a
+          // generous window. The existing `OptimizelyProviderIntegrationSpec.datafile revision change` test
+          // demonstrates the SDK does poll again well under our timeout when WireMock serves a fresh response.
+          val fired = gate.await(15, TimeUnit.SECONDS)
+          assertTrue(fired, received.get() >= 1)
+        } finally {
+          scala.util.Try(api.shutdown())
+          ()
+        }
+      }
+    }
+  ) @@ TestAspect.sequential @@ TestAspect.timeout(60.seconds) @@ TestAspect.withLiveClock
+}


### PR DESCRIPTION
Fixes a production bug discovered while expanding the integration test suite on \`feat/optimizely-it\` (issue #160).

## The bug

The Optimizely Java SDK has **two separate \`NotificationCenter\` instances** by default — one inside the polling \`HttpProjectConfigManager\`, one inside the \`Optimizely\` client. \`OptimizelyProvider.buildClient\` wasn't sharing one between them, so:

- The polling thread fires \`UpdateConfigNotification\` on the **manager's** notification center when it applies a new datafile (\`setConfig(newConfig)\`).
- Our provider's \`initialize\` registers a handler via the public \`Optimizely.addUpdateConfigNotificationHandler\` API, which lives on the **client's** notification center.
- The two centers are never wired together — so subsequent datafile updates never fire our handler.

The initial datafile load looked fine because \`OptimizelyFeatureProvider.initialize\` also polls \`optimizely.isValid\` directly to count down the init latch. So init reports READY and decisions reflect the loaded datafile — but every \`PROVIDER_CONFIGURATION_CHANGED\` event after that is silently dropped on the floor.

## User-visible impact

Any consumer of \`zio-openfeature-optimizely\` that registers an \`onProviderConfigurationChanged\` listener via the OpenFeature spec (\`client.onProviderConfigurationChanged(...)\` or \`OpenFeatureAPI.onProviderConfigurationChanged(...)\`) will **never receive a notification** for any datafile revision after the initial load. This breaks cache-invalidation hooks, observability dashboards, and similar wiring that depends on knowing when the flag definitions changed.

## Fix

\`OptimizelyProvider.buildClient\` now allocates a single \`NotificationCenter\` and passes it to both builders:

\`\`\`scala
val notificationCenter = new com.optimizely.ab.notification.NotificationCenter()
val configBuilder = HttpProjectConfigManager.builder()
  .withSdkKey(sdkKey)
  .withNotificationCenter(notificationCenter)
datafileUrl.foreach(configBuilder.withUrl)
val configManager = configBuilder.build()
Optimizely.builder()
  .withConfigManager(configManager)
  .withNotificationCenter(notificationCenter)
  .build()
\`\`\`

## Regression tests

New \`OptimizelyConfigChangedEventSpec\` with two tests:

1. **Structural** — calls \`OptimizelyProvider.make\` through the public factory, reaches into the resulting provider via reflection to grab both the client's and the config manager's notification centers, asserts they are the same instance (\`clientCtr eq mgrCtr\`). Verified locally that this test fails when the production fix is reverted.
2. **Behavioural** — drives the full \`OpenFeatureAPI.setProviderAndWait\` → \`client.onProviderConfigurationChanged(...)\` flow against a WireMock revision-bump scenario, asserts the listener fires within 15 s of the SDK observing the new revision.

## Verification

- \`sbt test\` (full repo): **712 tests pass** (370 core + 99 testkit + 171 extras + 30 OFREP + 42 optimizely — 2 of those 42 are the new tests).
- Without the fix the structural test fails immediately with \`Result was false\` (confirmed by temporarily stashing the production change).

## Discovered while

Working through the gap-analysis test waves on \`feat/optimizely-it\`. The docker-compose IT suite's \`OptimizelyDatafileChurnSpec\` covers the same scenario against a real Toxiproxy-fronted nginx; it caught this bug after the mtime issue in #159 was fixed. This PR cherry-picks just the production fix + a CI-friendly WireMock-based regression test, so callers on \`main\` get the fix without depending on the local-only docker-compose IT module.