### PR TITLE
Fix flaky FeatureFlagRegistrySpec / ProviderHotSwapSpec: guard async PROVIDER_READY race after failed setProvider

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -31,6 +31,21 @@ final private[openfeature] class FeatureFlagsLive(
   evaluationTimeout: Option[Duration] = None
 ) extends FeatureFlags {
 
+  // Records when a `setProvider` swap last failed. Used by the async PROVIDER_READY bridge to decide whether an
+  // incoming Ready event is a real recovery signal or a stale event left over from a previous attach that's racing
+  // against the explicit Error transition set by the failed swap. See `setProvider` and `readyHandler` below.
+  //
+  // Initialised to `0L` (epoch). `currentTimeMillis() - 0L` will always be far beyond `FailedSwapGuardMillis`, so the
+  // guard never trips before the first failed swap. (Using `Long.MinValue` instead would overflow the subtraction and
+  // wrap negative, causing the guard to trip incorrectly and block legitimate Error → Ready recoveries.)
+  private val recentSwapFailureAt = new java.util.concurrent.atomic.AtomicLong(0L)
+
+  // How long after a failed swap an async PROVIDER_READY event should be ignored as a likely stale signal. Real
+  // recovery scenarios (provider was in Error for an extended period and genuinely transitions back to Ready)
+  // happen on a much longer timescale than this; the race window we're closing is the SDK's emitter executor
+  // dispatching a queued event that pre-dates our explicit Error.
+  private val FailedSwapGuardMillis: Long = 500L
+
   // Bridge Java SDK provider events to ZIO event system
   private[openfeature] def startEventBridge: ZIO[Scope, Nothing, Unit] = {
     // Read provider name dynamically so events after a provider swap use the new name
@@ -67,7 +82,19 @@ final private[openfeature] class FeatureFlagsLive(
       val readyHandler: java.util.function.Consumer[EventDetails] = details => {
         val em = extractEventMetadata(details)
         runHandler(runtime, "PROVIDER_READY")(
-          state.statusRef.set(ProviderStatus.Ready) *>
+          // Transition statusRef only from states where PROVIDER_READY is meaningful. The `Error => Ready` arrow is
+          // valid per the OpenFeature spec (recovery from a recoverable error) but is guarded by
+          // `FailedSwapGuardMillis`: if the most recent statusRef write was a failed-swap Error within that window,
+          // a Ready event arriving now is almost certainly a stale signal queued on the SDK's emitter executor before
+          // the swap, not a genuine recovery. Real recoveries happen on timescales much longer than the guard.
+          state.statusRef.update {
+            case ProviderStatus.NotReady => ProviderStatus.Ready
+            case ProviderStatus.Stale    => ProviderStatus.Ready
+            case ProviderStatus.Error =>
+              val sinceFailure = java.lang.System.currentTimeMillis() - recentSwapFailureAt.get()
+              if (sinceFailure >= FailedSwapGuardMillis) ProviderStatus.Ready else ProviderStatus.Error
+            case other => other
+          } *>
             state.eventHub.publish(ProviderEvent.Ready(currentMetadata(runtime), em)).unit
         )
         onReady.foreach(_.countDown())
@@ -816,8 +843,11 @@ final private[openfeature] class FeatureFlagsLive(
           case None    => ZIO.attemptBlocking(api.setProviderAndWait(newProvider))
         }).mapError(e => FeatureFlagError.ProviderInitializationFailed(e))
           .tapError(_ =>
-            // Rollback refs and set Error status so the instance is in a diagnosable state
-            providerRef.set(oldProvider) *>
+            // Rollback refs and set Error status so the instance is in a diagnosable state. Stamp
+            // `recentSwapFailureAt` BEFORE the statusRef write so the async PROVIDER_READY handler sees a fresh
+            // failure timestamp and skips overwriting Error within the guard window.
+            ZIO.succeed(recentSwapFailureAt.set(java.lang.System.currentTimeMillis())) *>
+              providerRef.set(oldProvider) *>
               providerNameRef.set(oldName) *>
               state.statusRef.set(ProviderStatus.Error)
           )


### PR DESCRIPTION
## Root cause

`FeatureFlagsLive.setProvider` synchronously transitions `statusRef` to `Error` in its `tapError` block when the new provider's `initialize()` throws. In parallel, the event bridge's async `readyHandler` (a Java `Consumer<EventDetails>` dispatched on the OpenFeature SDK's emitter executor) unconditionally writes `statusRef.set(Ready)` for any incoming `PROVIDER_READY` event.

A `PROVIDER_READY` event queued on the SDK's emitter executor before the swap began — for example from the previous provider's initial `setProviderAndWait` — can fire *after* the synchronous `tapError` has set `Error`, overwriting the failure state back to `Ready`. Reproduced on CI runs of `FeatureFlagRegistrySpec.failed setProvider does not update providers map` (line 194: `status == ProviderStatus.Error`) — fails when the stale Ready wins the race, passes when the Error transition arrives last. Same race affects assertions in `ProviderHotSwapSpec`.

## Fix

Track the wall-clock time of the most recent failed swap on an `AtomicLong` (`recentSwapFailureAt`). In `setProvider`'s `tapError`, stamp this *before* setting `statusRef` to `Error`. In `readyHandler`, change the unconditional `statusRef.set(Ready)` to a conditional `statusRef.update`:

```scala
state.statusRef.update {
  case ProviderStatus.NotReady => ProviderStatus.Ready
  case ProviderStatus.Stale    => ProviderStatus.Ready
  case ProviderStatus.Error =>
    val sinceFailure = System.currentTimeMillis() - recentSwapFailureAt.get()
    if (sinceFailure >= FailedSwapGuardMillis) ProviderStatus.Ready else ProviderStatus.Error
  case other => other
}
```

`NotReady → Ready` (initial) and `Stale → Ready` (degradation recovery) are untouched. `Error → Ready` remains valid per the OpenFeature spec (a real recoverable error transitioning back) — but is gated by a 500 ms window after the latest failed swap. Real recoveries happen on a much longer timescale than that window; the race we're closing is the emitter executor dispatching a queued event that pre-dates the explicit failed-swap Error.

## Initial-value gotcha

First implementation initialised `recentSwapFailureAt` to `Long.MinValue`. The subtraction `currentTimeMillis() - Long.MinValue` overflows the Long range and wraps negative — which then fails the `>= 500L` check, so the guard tripped before any failed swap had ever happened, breaking the legitimate `[B2 / case 6] async provider recovers ERROR -> READY` test. Initialising to `0L` (epoch) means `current - 0` is always a large positive value, the guard never trips before the first failed swap, and real recoveries work as before. Documented in a comment so the next person doesn't change it back.

## Verification

- `sbt 'core/testOnly *FeatureFlagRegistrySpec*'` ran **30/30 times** locally without a flake.
- Full repo: 710 tests pass (370 core + 30 OFREP + 99 testkit + 171 extras + 40 optimizely).
- `[B2 / case 6] async provider recovers ERROR -> READY and evaluations succeed` (the recovery test) still passes — confirms `Error → Ready` async recovery isn't broken by the guard.
- `ProviderHotSwapSpec` (which has similar `status == ProviderStatus.Error` assertions after a failed swap) still passes.

## Scope

Only `FeatureFlagsLive.scala` changes. Confined to the event-bridge `readyHandler` and `setProvider`'s `tapError` block. No public API changes, no transitive effect on the OFREP / Optimizely / extras modules.