### PR TITLE
Bump GitHub Actions to Node-24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,20 @@ on:
   pull_request:
     branches: [main]
 
+# Force any JavaScript action still bundled with Node 20 to run on Node 24. Belt-and-suspenders for the few
+# actions (sbt/setup-sbt@v1, …) that haven't bumped majors yet. Node 24 becomes the runner default on
+# 2026-06-02 and Node 20 is removed entirely on 2026-09-16 — see #164.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # Format check runs once; format errors are platform-independent so there's no value in re-running per matrix cell.
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -35,9 +41,9 @@ jobs:
         java-version: ['17', '21']
         scala-version: ['2.13.16', '3.3.4']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
@@ -55,9 +61,9 @@ jobs:
   mima:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -72,9 +78,9 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -5,14 +5,18 @@ on:
     - cron: '0 8 * * 1' # every Monday at 8am UTC
   workflow_dispatch:
 
+# Force any JavaScript action still bundled with Node 20 to run on Node 24. See #164 / ci.yml note.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   dependency-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -27,7 +31,7 @@ jobs:
           while read jar; do cp "$jar" build/deps/ 2>/dev/null; done < /tmp/dep-jars.txt
 
       - name: Cache NVD database
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.dependency-check
           key: nvd-db-${{ github.run_id }}
@@ -56,7 +60,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dependency-check-report
           path: build/reports/

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -4,14 +4,18 @@ on:
   push:
     branches: [main]
 
+# Force any JavaScript action still bundled with Node 20 to run on Node 24. See #164 / ci.yml note.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   dependency-submission:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,15 +17,19 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+# Force any JavaScript action still bundled with Node 20 to run on Node 24. See #164 / ci.yml note.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
@@ -34,7 +38,7 @@ jobs:
           destination: ./_site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
   deploy:
     environment:
@@ -45,4 +49,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,20 @@ on:
 permissions:
   contents: write
 
+# Force any JavaScript action still bundled with Node 20 to run on Node 24. See #164 / ci.yml note.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -38,6 +42,6 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true


### PR DESCRIPTION
Closes #164.

Migrates every workflow off Node 20-only action versions before:

- **2026-06-02** — Node 24 becomes the runner default
- **2026-09-16** — Node 20 is removed entirely

## Version bumps

| Action | Before | After | Notes |
|---|---|---|---|
| \`actions/checkout\` | \`@v4\` | \`@v6\` | Node 24 starting v5+ |
| \`actions/setup-java\` | \`@v4\` | \`@v5\` | Node 24 starting v5 |
| \`actions/cache\` | \`@v4\` | \`@v5\` | Node 24 starting v5 |
| \`actions/upload-artifact\` | \`@v4\` | \`@v7\` | Node 24 starting v5+ |
| \`actions/configure-pages\` | \`@v4\` | \`@v6\` | Node 24 starting v5+ |
| \`actions/upload-pages-artifact\` | \`@v3\` | \`@v5\` | Node 24 starting v4+ |
| \`actions/deploy-pages\` | \`@v4\` | \`@v5\` | Node 24 starting v5 |
| \`softprops/action-gh-release\` | \`@v2\` | \`@v3\` | Node 24 starting v3 |

Three actions don't have a new major yet so they stay where they are:

- \`sbt/setup-sbt@v1\` (latest \`v1.1.23\`)
- \`scalacenter/sbt-dependency-submission@v3\` (latest \`v3.2.1\`)
- \`actions/jekyll-build-pages@v1\` (latest \`v1.0.13\`)

## Belt-and-suspenders

Workflow-level \`env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: \"true\"\` added to all 5 workflows. This forces any remaining Node-20-bundled action to run on Node 24 immediately, ahead of the 2026-06-02 default flip. Once Node 24 becomes the default, the env var is a no-op; keeping it documented ties the change to the deprecation calendar.

## Workflows touched

- \`.github/workflows/ci.yml\` (format + build-matrix + mima + examples)
- \`.github/workflows/release.yml\` (Maven Central publish + GitHub Release)
- \`.github/workflows/docs.yml\` (GitHub Pages deploy)
- \`.github/workflows/dependency-check.yml\` (weekly OWASP scan)
- \`.github/workflows/dependency-submission.yml\` (Dependabot supply chain)

## Verification

This PR's own CI run is the verification — it exercises ci.yml across the same JDK 17/21 × Scala 2.13.16/3.3.4 matrix. release.yml only triggers on \`v*\` tags, but the action versions there mirror what ci.yml proves.