### PR TITLE
Fix provider hook duplication and add ZIO API-level hooks

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
@@ -17,6 +17,9 @@ trait FeatureFlagRegistry {
 
   /** Get or create the default (no-domain) client. */
   def defaultClient: UIO[FeatureFlags]
+
+  /** Register a ZIO API-level hook on all existing and future domain clients. */
+  def addZioApiHook(hook: FeatureHook): UIO[Unit]
 }
 
 object FeatureFlagRegistry {
@@ -33,16 +36,29 @@ object FeatureFlagRegistry {
   def defaultClient: ZIO[FeatureFlagRegistry, Nothing, FeatureFlags] =
     ZIO.serviceWithZIO(_.defaultClient)
 
+  def addZioApiHook(hook: FeatureHook): ZIO[FeatureFlagRegistry, Nothing, Unit] =
+    ZIO.serviceWithZIO(_.addZioApiHook(hook))
+
   def fromProvider(defaultProvider: OFFeatureProvider): ZLayer[Scope, Throwable, FeatureFlagRegistry] =
     ZLayer.scoped {
       for {
-        api        <- ZIO.succeed(OpenFeatureAPIFactory.create())
-        scope      <- ZIO.service[Scope]
-        clients    <- Ref.make(Map.empty[String, FeatureFlags])
-        providers  <- Ref.make(Map.empty[String, OFFeatureProvider])
-        defaultRef <- Ref.make(Option.empty[FeatureFlags])
-        lock       <- Semaphore.make(1)
-        registry = new FeatureFlagRegistryLive(defaultProvider, api, scope, clients, providers, defaultRef, lock)
+        api            <- ZIO.succeed(OpenFeatureAPIFactory.create())
+        scope          <- ZIO.service[Scope]
+        clients        <- Ref.make(Map.empty[String, FeatureFlags])
+        providers      <- Ref.make(Map.empty[String, OFFeatureProvider])
+        defaultRef     <- Ref.make(Option.empty[FeatureFlags])
+        lock           <- Semaphore.make(1)
+        zioApiHooksRef <- Ref.make(List.empty[FeatureHook])
+        registry = new FeatureFlagRegistryLive(
+          defaultProvider,
+          api,
+          scope,
+          clients,
+          providers,
+          defaultRef,
+          lock,
+          zioApiHooksRef
+        )
         _ <- ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore)
       } yield registry
     }
@@ -55,7 +71,8 @@ final private class FeatureFlagRegistryLive(
   clients: Ref[Map[String, FeatureFlags]],
   providers: Ref[Map[String, OFFeatureProvider]],
   defaultRef: Ref[Option[FeatureFlags]],
-  lock: Semaphore
+  lock: Semaphore,
+  zioApiHooksRef: Ref[List[FeatureHook]]
 ) extends FeatureFlagRegistry {
 
   override def getClient(domain: String): UIO[FeatureFlags] =
@@ -86,6 +103,16 @@ final private class FeatureFlagRegistryLive(
       }
     }
 
+  override def addZioApiHook(hook: FeatureHook): UIO[Unit] =
+    lock.withPermit {
+      for {
+        _               <- zioApiHooksRef.update(_ :+ hook)
+        existingClients <- clients.get.map(_.values.toList)
+        defaultC        <- defaultRef.get
+        _               <- ZIO.foreachDiscard(existingClients ++ defaultC.toList)(_.addZioApiHook(hook))
+      } yield ()
+    }
+
   private def createDomainClient(domain: String): UIO[FeatureFlags] =
     for {
       pm <- providers.get
@@ -103,7 +130,9 @@ final private class FeatureFlagRegistryLive(
           )
         )
         .orDie
-      _ <- clients.update(_ + (domain -> client))
+      apiHooks <- zioApiHooksRef.get
+      _        <- client.addZioApiHooks(apiHooks)
+      _        <- clients.update(_ + (domain -> client))
     } yield client
 
   private def createDefaultClient: UIO[FeatureFlags] =
@@ -121,6 +150,8 @@ final private class FeatureFlagRegistryLive(
           )
         )
         .orDie
-      _ <- defaultRef.set(Some(client))
+      apiHooks <- zioApiHooksRef.get
+      _        <- client.addZioApiHooks(apiHooks)
+      _        <- defaultRef.set(Some(client))
     } yield client
 }

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -160,6 +160,12 @@ trait FeatureFlags {
   def clearHooks: UIO[Unit]
   def hooks: UIO[List[FeatureHook]]
 
+  /** Register a ZIO API-level hook (spec §4.4.1 level 1). Runs before client-level hooks on every evaluation. */
+  def addZioApiHook(hook: FeatureHook): UIO[Unit]
+  def addZioApiHooks(hooks: List[FeatureHook]): UIO[Unit]
+  def clearZioApiHooks: UIO[Unit]
+  def zioApiHooks: UIO[List[FeatureHook]]
+
   /** Add an API-level hook that applies to all clients sharing this instance's OpenFeatureAPI. */
   def addApiHook(hook: dev.openfeature.sdk.Hook[_]): UIO[Unit]
 
@@ -371,6 +377,18 @@ object FeatureFlags {
 
   def hooks: ZIO[FeatureFlags, Nothing, List[FeatureHook]] =
     ZIO.serviceWithZIO(_.hooks)
+
+  def addZioApiHook(hook: FeatureHook): ZIO[FeatureFlags, Nothing, Unit] =
+    ZIO.serviceWithZIO(_.addZioApiHook(hook))
+
+  def addZioApiHooks(hooks: List[FeatureHook]): ZIO[FeatureFlags, Nothing, Unit] =
+    ZIO.serviceWithZIO(_.addZioApiHooks(hooks))
+
+  def clearZioApiHooks: ZIO[FeatureFlags, Nothing, Unit] =
+    ZIO.serviceWithZIO(_.clearZioApiHooks)
+
+  def zioApiHooks: ZIO[FeatureFlags, Nothing, List[FeatureHook]] =
+    ZIO.serviceWithZIO(_.zioApiHooks)
 
   // API-level Hooks (per OpenFeature spec 4.4.1)
 

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -179,10 +179,11 @@ final private[openfeature] class FeatureFlagsLive(
     initialHints: HookHints = HookHints.empty
   ): IO[FeatureFlagError, FlagResolution[A]] =
     for {
+      apiHooks     <- state.zioApiHooksRef.get
       currentHooks <- state.hooksRef.get
-      provHooks    <- getProviderHooks
       pName        <- providerNameRef.get
-      allHooks   = currentHooks ++ extraHooks ++ provHooks
+      // Order per spec §4.4.1: API -> Client -> Invocation. Provider hooks run inside the Java SDK call.
+      allHooks   = apiHooks ++ currentHooks ++ extraHooks
       metadata   = ProviderMetadata(pName)
       clientMeta = ClientMetadata(domain, version)
       hookCtx = HookContext(
@@ -715,6 +716,18 @@ final private[openfeature] class FeatureFlagsLive(
 
   override def hooks: UIO[List[FeatureHook]] =
     state.hooksRef.get
+
+  override def addZioApiHook(hook: FeatureHook): UIO[Unit] =
+    state.zioApiHooksRef.update(_ :+ hook)
+
+  override def addZioApiHooks(hooks: List[FeatureHook]): UIO[Unit] =
+    state.zioApiHooksRef.update(_ ++ hooks)
+
+  override def clearZioApiHooks: UIO[Unit] =
+    state.zioApiHooksRef.set(List.empty)
+
+  override def zioApiHooks: UIO[List[FeatureHook]] =
+    state.zioApiHooksRef.get
 
   override def addApiHook(hook: dev.openfeature.sdk.Hook[_]): UIO[Unit] =
     ZIO.succeed(api.addHooks(hook))

--- a/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
+++ b/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
@@ -8,6 +8,7 @@ final case class FeatureFlagsState(
   clientContextRef: Ref[EvaluationContext],
   fiberContextRef: FiberRef[EvaluationContext],
   transactionRef: FiberRef[Option[TransactionState]],
+  zioApiHooksRef: Ref[List[FeatureHook]],
   hooksRef: Ref[List[FeatureHook]],
   eventHub: Hub[ProviderEvent],
   statusRef: Ref[ProviderStatus],
@@ -21,6 +22,7 @@ object FeatureFlagsState {
       clientCtxRef   <- Ref.make(EvaluationContext.empty)
       fiberCtxRef    <- FiberRef.make(EvaluationContext.empty)
       transactionRef <- FiberRef.make[Option[TransactionState]](None)
+      zioApiHooksRef <- Ref.make(List.empty[FeatureHook])
       hooksRef       <- Ref.make(List.empty[FeatureHook])
       // Bounded; subscribers reconcile via current state on next evaluation, so dropping intermediate events is safe.
       eventHub  <- Hub.dropping[ProviderEvent](256)
@@ -31,6 +33,7 @@ object FeatureFlagsState {
       clientCtxRef,
       fiberCtxRef,
       transactionRef,
+      zioApiHooksRef,
       hooksRef,
       eventHub,
       statusRef,

--- a/core/src/test/scala/zio/openfeature/ProviderHookDuplicationSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderHookDuplicationSpec.scala
@@ -1,0 +1,117 @@
+package zio.openfeature
+
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  HookContext => JavaHookContext,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderState
+}
+import zio._
+import zio.test._
+import java.util.concurrent.atomic.AtomicInteger
+
+object ProviderHookDuplicationSpec extends ZIOSpecDefault {
+
+  private class ProviderWithCountingHook(name: String, value: Boolean, counter: AtomicInteger) extends EventProvider {
+
+    private val providerHook = new dev.openfeature.sdk.Hook[java.lang.Boolean] {
+      override def before(
+        ctx: JavaHookContext[java.lang.Boolean],
+        hints: java.util.Map[String, AnyRef]
+      ): java.util.Optional[OFEvaluationContext] = {
+        counter.incrementAndGet()
+        java.util.Optional.empty()
+      }
+    }
+
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { override def getName: String = name }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+
+    override def getProviderHooks(): java.util.List[dev.openfeature.sdk.Hook[_]] =
+      java.util.Collections.singletonList(providerHook)
+
+    override def getBooleanEvaluation(
+      key: String,
+      defaultValue: java.lang.Boolean,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Boolean] =
+      ProviderEvaluation.builder[java.lang.Boolean]().value(value).reason("STATIC").build()
+
+    override def getStringEvaluation(
+      key: String,
+      defaultValue: String,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[String] =
+      ProviderEvaluation.builder[String]().value(defaultValue).reason("STATIC").build()
+
+    override def getIntegerEvaluation(
+      key: String,
+      defaultValue: java.lang.Integer,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Integer] =
+      ProviderEvaluation.builder[java.lang.Integer]().value(defaultValue).reason("STATIC").build()
+
+    override def getDoubleEvaluation(
+      key: String,
+      defaultValue: java.lang.Double,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Double] =
+      ProviderEvaluation.builder[java.lang.Double]().value(defaultValue).reason("STATIC").build()
+
+    override def getObjectEvaluation(
+      key: String,
+      defaultValue: dev.openfeature.sdk.Value,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[dev.openfeature.sdk.Value] =
+      ProviderEvaluation.builder[dev.openfeature.sdk.Value]().value(defaultValue).reason("STATIC").build()
+  }
+
+  def spec = suite("Provider hook duplication")(
+    test("provider hook runs exactly once per evaluation (not duplicated by ZIO pipeline)") {
+      ZIO.scoped {
+        val counter = new AtomicInteger(0)
+        val domain  = s"prov-hook-${java.util.UUID.randomUUID()}"
+        val api     = OpenFeatureAPIFactory.create()
+        for {
+          ff <- FeatureFlags.build(
+            new ProviderWithCountingHook("p", value = true, counter),
+            domain = Some(domain),
+            version = None,
+            initialHooks = Nil,
+            statusRef = None,
+            addShutdownFinalizer = false,
+            apiOverride = Some(api)
+          )
+          _ <- ff.boolean("flag", default = false).provideEnvironment(ZEnvironment(ff))
+        } yield assertTrue(counter.get() == 1)
+      }
+    },
+    test("provider hook count stays at 1 across multiple evaluations") {
+      ZIO.scoped {
+        val counter = new AtomicInteger(0)
+        val domain  = s"prov-hook-multi-${java.util.UUID.randomUUID()}"
+        val api     = OpenFeatureAPIFactory.create()
+        for {
+          ff <- FeatureFlags.build(
+            new ProviderWithCountingHook("p", value = true, counter),
+            domain = Some(domain),
+            version = None,
+            initialHooks = Nil,
+            statusRef = None,
+            addShutdownFinalizer = false,
+            apiOverride = Some(api)
+          )
+          _ <- ff.boolean("flag", default = false).provideEnvironment(ZEnvironment(ff))
+          _ <- ff.boolean("flag", default = false).provideEnvironment(ZEnvironment(ff))
+          _ <- ff.boolean("flag", default = false).provideEnvironment(ZEnvironment(ff))
+        } yield assertTrue(counter.get() == 3)
+      }
+    }
+  )
+}

--- a/core/src/test/scala/zio/openfeature/ZioApiHookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ZioApiHookSpec.scala
@@ -1,0 +1,191 @@
+package zio.openfeature
+
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderState
+}
+import zio._
+import zio.test._
+
+object ZioApiHookSpec extends ZIOSpecDefault {
+
+  private class SimpleBooleanProvider(name: String, value: Boolean) extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { override def getName: String = name }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+
+    override def getBooleanEvaluation(
+      key: String,
+      defaultValue: java.lang.Boolean,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Boolean] =
+      ProviderEvaluation.builder[java.lang.Boolean]().value(value).reason("STATIC").build()
+
+    override def getStringEvaluation(
+      key: String,
+      defaultValue: String,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[String] =
+      ProviderEvaluation.builder[String]().value(defaultValue).reason("STATIC").build()
+
+    override def getIntegerEvaluation(
+      key: String,
+      defaultValue: java.lang.Integer,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Integer] =
+      ProviderEvaluation.builder[java.lang.Integer]().value(defaultValue).reason("STATIC").build()
+
+    override def getDoubleEvaluation(
+      key: String,
+      defaultValue: java.lang.Double,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Double] =
+      ProviderEvaluation.builder[java.lang.Double]().value(defaultValue).reason("STATIC").build()
+
+    override def getObjectEvaluation(
+      key: String,
+      defaultValue: dev.openfeature.sdk.Value,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[dev.openfeature.sdk.Value] =
+      ProviderEvaluation.builder[dev.openfeature.sdk.Value]().value(defaultValue).reason("STATIC").build()
+  }
+
+  private def buildIsolated(provider: EventProvider): ZIO[Scope, Throwable, FeatureFlags] = {
+    val api    = OpenFeatureAPIFactory.create()
+    val domain = s"zio-api-hook-${java.util.UUID.randomUUID()}"
+    FeatureFlags.build(
+      provider,
+      domain = Some(domain),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = false,
+      apiOverride = Some(api)
+    )
+  }
+
+  private def recordingHook(label: String, log: Ref[List[String]]): FeatureHook =
+    new FeatureHook {
+      override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+        log.update(_ :+ label).as(None)
+
+      override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+        log.update(_ :+ s"$label-after")
+    }
+
+  def spec = suite("ZIO API-level hooks")(
+    suite("ordering")(
+      test("API hook runs before client hook in before-phase (spec §4.4.1: api -> client)") {
+        ZIO.scoped {
+          for {
+            log    <- Ref.make(List.empty[String])
+            ff     <- buildIsolated(new SimpleBooleanProvider("p", true))
+            _      <- ff.addZioApiHook(recordingHook("api", log))
+            _      <- ff.addHook(recordingHook("client", log))
+            _      <- ff.boolean("flag", default = false).provideEnvironment(ZEnvironment(ff))
+            events <- log.get
+          } yield assertTrue(events.take(2) == List("api", "client"))
+        }
+      },
+      test("after-phase runs in reverse order (client-after before api-after)") {
+        ZIO.scoped {
+          for {
+            log    <- Ref.make(List.empty[String])
+            ff     <- buildIsolated(new SimpleBooleanProvider("p", true))
+            _      <- ff.addZioApiHook(recordingHook("api", log))
+            _      <- ff.addHook(recordingHook("client", log))
+            _      <- ff.boolean("flag", default = false).provideEnvironment(ZEnvironment(ff))
+            events <- log.get
+          } yield assertTrue(events == List("api", "client", "client-after", "api-after"))
+        }
+      }
+    ),
+    suite("management")(
+      test("addZioApiHooks adds multiple hooks") {
+        ZIO.scoped {
+          for {
+            log    <- Ref.make(List.empty[String])
+            ff     <- buildIsolated(new SimpleBooleanProvider("p", true))
+            _      <- ff.addZioApiHooks(List(recordingHook("a1", log), recordingHook("a2", log)))
+            _      <- ff.boolean("flag", default = false).provideEnvironment(ZEnvironment(ff))
+            events <- log.get
+          } yield assertTrue(events.take(2) == List("a1", "a2"))
+        }
+      },
+      test("clearZioApiHooks removes all API-level hooks") {
+        ZIO.scoped {
+          for {
+            log    <- Ref.make(List.empty[String])
+            ff     <- buildIsolated(new SimpleBooleanProvider("p", true))
+            _      <- ff.addZioApiHook(recordingHook("api", log))
+            _      <- ff.clearZioApiHooks
+            _      <- ff.boolean("flag", default = false).provideEnvironment(ZEnvironment(ff))
+            events <- log.get
+          } yield assertTrue(events.isEmpty)
+        }
+      },
+      test("clearZioApiHooks does not affect client-level hooks") {
+        ZIO.scoped {
+          for {
+            log    <- Ref.make(List.empty[String])
+            ff     <- buildIsolated(new SimpleBooleanProvider("p", true))
+            _      <- ff.addZioApiHook(recordingHook("api", log))
+            _      <- ff.addHook(recordingHook("client", log))
+            _      <- ff.clearZioApiHooks
+            _      <- ff.boolean("flag", default = false).provideEnvironment(ZEnvironment(ff))
+            events <- log.get
+          } yield assertTrue(events.take(1) == List("client"))
+        }
+      },
+      test("zioApiHooks returns the registered hooks") {
+        ZIO.scoped {
+          for {
+            log <- Ref.make(List.empty[String])
+            ff  <- buildIsolated(new SimpleBooleanProvider("p", true))
+            hook = recordingHook("api", log)
+            _    <- ff.addZioApiHook(hook)
+            list <- ff.zioApiHooks
+          } yield assertTrue(list.length == 1)
+        }
+      }
+    ),
+    suite("FeatureFlagRegistry propagation")(
+      test("addZioApiHook propagates to clients created after the call") {
+        ZIO.scoped {
+          for {
+            log <- Ref.make(List.empty[String])
+            registry <- FeatureFlagRegistry
+              .fromProvider(new SimpleBooleanProvider("p", true))
+              .build
+              .map(_.get[FeatureFlagRegistry])
+            _      <- registry.addZioApiHook(recordingHook("api", log))
+            client <- registry.getClient(s"dom-${java.util.UUID.randomUUID()}")
+            _      <- client.boolean("flag", default = false).provideEnvironment(ZEnvironment(client))
+            events <- log.get
+          } yield assertTrue(events.contains("api"))
+        }
+      },
+      test("addZioApiHook propagates to already-existing clients") {
+        ZIO.scoped {
+          for {
+            log <- Ref.make(List.empty[String])
+            registry <- FeatureFlagRegistry
+              .fromProvider(new SimpleBooleanProvider("p", true))
+              .build
+              .map(_.get[FeatureFlagRegistry])
+            client <- registry.getClient(s"dom-${java.util.UUID.randomUUID()}")
+            _      <- registry.addZioApiHook(recordingHook("api", log))
+            _      <- client.boolean("flag", default = false).provideEnvironment(ZEnvironment(client))
+            events <- log.get
+          } yield assertTrue(events.contains("api"))
+        }
+      }
+    )
+  )
+}


### PR DESCRIPTION
## Summary

- **Fixes #167 (bug):** Remove `provHooks` from the ZIO hook pipeline in `runWithHooks`. Provider hooks are already executed internally by the Java SDK's `client.getXxxDetails()` call — including them in `allHooks` caused every provider hook to fire twice per evaluation.
- **Closes #166 (enhancement):** Add ZIO API-level hook registration (`addZioApiHook`, `addZioApiHooks`, `clearZioApiHooks`, `zioApiHooks`) on `FeatureFlags` and `FeatureFlagRegistry`. API hooks run before client-level hooks per spec §4.4.1 (API → Client → Invocation). The registry propagates API hooks to all existing and future domain clients.
- **#168:** `dev.openfeature.contrib.providers:ofrep` is still at `0.0.1` on Maven Central — no bump available.

## Changes

| File | What changed |
|------|-------------|
| `internal/FeatureFlagsState.scala` | Add `zioApiHooksRef: Ref[List[FeatureHook]]` |
| `FeatureFlags.scala` | Add trait methods + companion accessors for ZIO API hooks |
| `FeatureFlagsLive.scala` | Remove `provHooks` from pipeline; implement new methods |
| `FeatureFlagRegistry.scala` | Add `addZioApiHook` to trait/companion; propagate via registry |
| `ProviderHookDuplicationSpec.scala` | New: asserts provider hook fires exactly once per evaluation |
| `ZioApiHookSpec.scala` | New: covers ordering, management, and registry propagation |

## Test plan

- [ ] `sbt compile` — passes
- [ ] `sbt scalafmtCheckAll` — passes
- [ ] `sbt test` — 385 core tests + all module tests pass