### PR TITLE
Pass post-before context to after/error/finally hook stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hook stages observe the context modified by before hooks.** The `after`, `error`, and `finallyAfter` stages
+  previously received the pre-`before` evaluation context, so hooks logging or tagging by context saw different
+  attributes than the evaluation actually used (spec §4.3.5–4.3.8). (#178)
+
 ## [0.9.1] — 2026-06-04
 
 ### Fixed

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -211,18 +211,21 @@ final private[openfeature] class FeatureFlagsLive(
     for {
       beforeResult <- composedHook.before(hookCtx, initialHints)
       (effectiveCtx, hints) = beforeResult match {
-        case Some((hookCtx, h)) => (hookCtx, h)
-        case None               => (context, initialHints)
+        case Some((modifiedCtx, h)) => (modifiedCtx, h)
+        case None                   => (context, initialHints)
       }
+      // Per spec §4.3.5-4.3.8, after/error/finally stages must observe the evaluation
+      // context as modified by the before hooks, not the original one.
+      stageCtx = hookCtx.copy(evaluationContext = effectiveCtx)
       resultRef <- Ref.make[Option[FlagResolution[_]]](None)
       result <- evaluate(effectiveCtx)
         .tap(res => resultRef.set(Some(res)))
         .tapBoth(
-          err => composedHook.error(hookCtx, err, hints),
-          res => composedHook.after(hookCtx, res, hints)
+          err => composedHook.error(stageCtx, err, hints),
+          res => composedHook.after(stageCtx, res, hints)
         )
         .ensuring(
-          resultRef.get.flatMap(details => composedHook.finallyAfter(hookCtx, details, hints)).ignore
+          resultRef.get.flatMap(details => composedHook.finallyAfter(stageCtx, details, hints)).ignore
         )
     } yield result
   }

--- a/core/src/test/scala/zio/openfeature/HookStageContextSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookStageContextSpec.scala
@@ -1,0 +1,131 @@
+package zio.openfeature
+
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderState
+}
+import dev.openfeature.sdk.exceptions.ProviderNotReadyError
+import zio._
+import zio.test._
+
+/** Verifies spec §4.3.5-4.3.8: the after/error/finally hook stages observe the evaluation context as modified by the
+  * before hooks, not the original invocation context.
+  */
+object HookStageContextSpec extends ZIOSpecDefault {
+
+  private class StaticBooleanProvider(name: String, value: Boolean, failKeys: Set[String] = Set.empty)
+      extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { override def getName: String = name }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+
+    override def getBooleanEvaluation(
+      key: String,
+      defaultValue: java.lang.Boolean,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Boolean] =
+      if (failKeys.contains(key)) throw new ProviderNotReadyError(s"simulated failure for $key")
+      else ProviderEvaluation.builder[java.lang.Boolean]().value(value).reason("STATIC").build()
+
+    override def getStringEvaluation(
+      key: String,
+      defaultValue: String,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[String] =
+      ProviderEvaluation.builder[String]().value(defaultValue).reason("STATIC").build()
+
+    override def getIntegerEvaluation(
+      key: String,
+      defaultValue: java.lang.Integer,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Integer] =
+      ProviderEvaluation.builder[java.lang.Integer]().value(defaultValue).reason("STATIC").build()
+
+    override def getDoubleEvaluation(
+      key: String,
+      defaultValue: java.lang.Double,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Double] =
+      ProviderEvaluation.builder[java.lang.Double]().value(defaultValue).reason("STATIC").build()
+
+    override def getObjectEvaluation(
+      key: String,
+      defaultValue: dev.openfeature.sdk.Value,
+      ctx: OFEvaluationContext
+    ): ProviderEvaluation[dev.openfeature.sdk.Value] =
+      ProviderEvaluation.builder[dev.openfeature.sdk.Value]().value(defaultValue).reason("STATIC").build()
+  }
+
+  private def buildIsolated(provider: EventProvider): ZIO[Scope, Throwable, FeatureFlags] = {
+    val api    = OpenFeatureAPIFactory.create()
+    val domain = s"hook-stage-ctx-${java.util.UUID.randomUUID()}"
+    FeatureFlags.build(
+      provider,
+      domain = Some(domain),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = false,
+      apiOverride = Some(api)
+    )
+  }
+
+  private val marker = "added-by-before"
+
+  /** A hook whose before stage adds a marker attribute and whose later stages record whether they saw it. */
+  private def contextProbeHook(
+    sawInAfter: Ref[Option[Boolean]],
+    sawInError: Ref[Option[Boolean]],
+    sawInFinally: Ref[Option[Boolean]]
+  ): FeatureHook =
+    new FeatureHook {
+      override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+        ZIO.some((ctx.evaluationContext.withAttribute(marker, AttributeValue.BoolValue(true)), hints))
+
+      override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+        sawInAfter.set(Some(ctx.evaluationContext.getBoolean(marker).contains(true)))
+
+      override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
+        sawInError.set(Some(ctx.evaluationContext.getBoolean(marker).contains(true)))
+
+      override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
+        sawInFinally.set(Some(ctx.evaluationContext.getBoolean(marker).contains(true)))
+    }
+
+  def spec = suite("Hook stage context (spec 4.3.5-4.3.8)")(
+    test("after and finally stages see the context modified by before hooks") {
+      ZIO.scoped {
+        for {
+          sawAfter   <- Ref.make[Option[Boolean]](None)
+          sawError   <- Ref.make[Option[Boolean]](None)
+          sawFinally <- Ref.make[Option[Boolean]](None)
+          ff         <- buildIsolated(new StaticBooleanProvider("p", value = true))
+          _          <- ff.addHook(contextProbeHook(sawAfter, sawError, sawFinally))
+          value      <- ff.boolean("flag", default = false)
+          after      <- sawAfter.get
+          fin        <- sawFinally.get
+        } yield assertTrue(value, after.contains(true), fin.contains(true))
+      }
+    },
+    test("error and finally stages see the context modified by before hooks") {
+      ZIO.scoped {
+        for {
+          sawAfter   <- Ref.make[Option[Boolean]](None)
+          sawError   <- Ref.make[Option[Boolean]](None)
+          sawFinally <- Ref.make[Option[Boolean]](None)
+          ff         <- buildIsolated(new StaticBooleanProvider("p", value = true, failKeys = Set("boom")))
+          _          <- ff.addHook(contextProbeHook(sawAfter, sawError, sawFinally))
+          result     <- ff.boolean("boom", default = false).exit
+          err        <- sawError.get
+          fin        <- sawFinally.get
+        } yield assertTrue(result.isFailure, err.contains(true), fin.contains(true))
+      }
+    }
+  )
+}


### PR DESCRIPTION
## Summary

Per OpenFeature spec §4.3.5–4.3.8, the `after`, `error`, and `finally` hook stages must observe the evaluation context as modified by `before` hooks. `runHookPipeline` evaluated with the modified context but passed the original `HookContext` to the later stages, so hooks inspecting `ctx.evaluationContext` (logging, metrics tags, audit) saw a context that differed from what was actually evaluated.

## Changes

- `runHookPipeline` now builds `stageCtx = hookCtx.copy(evaluationContext = effectiveCtx)` and passes it to `error`, `after`, and `finallyAfter`.
- Renamed the shadowing `hookCtx` binding in the `beforeResult` destructure to `modifiedCtx` for clarity.

Per-hook `HookData` continuity is unaffected: `FeatureHook.compose` re-attaches each hook's `HookData` via `ctxForHook` regardless of the context instance passed in.

## Tests

New `HookStageContextSpec` (end-to-end through `FeatureFlags.build` with an isolated `OpenFeatureAPI`):
- a before hook adds a marker attribute; the after and finally stages assert they see it on the success path
- same assertion for the error and finally stages on a failing evaluation (`ProviderNotReadyError`)

Full suite green: `sbt scalafmtAll test`.

Fixes #178