### PR TITLE
Preserve Instant type for nested context attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Nested `Instant` attributes survive the SDK round-trip.** Instants inside lists and structs were converted to
+  strings on the way into the Java SDK and came back as `StringValue`, silently breaking date-based targeting on
+  nested attributes. The Long → Double 2^53 precision limit is now documented on `AttributeValue.LongValue`. (#184)
 - **Hook stages observe the context modified by before hooks.** The `after`, `error`, and `finallyAfter` stages
   previously received the pre-`before` evaluation context, so hooks logging or tagging by context saw different
   attributes than the evaluation actually used (spec §4.3.5–4.3.8). (#178)

--- a/core/src/main/scala-2/zio/openfeature/AttributeValue.scala
+++ b/core/src/main/scala-2/zio/openfeature/AttributeValue.scala
@@ -58,6 +58,14 @@ object AttributeValue {
   final case class BoolValue(value: Boolean)                       extends AttributeValue
   final case class StringValue(value: String)                      extends AttributeValue
   final case class IntValue(value: Int)                            extends AttributeValue
+
+  /** A 64-bit integer attribute.
+    *
+    * The OpenFeature Java SDK normalises every numeric to `Double`, so longs cross the SDK boundary through a `Double`
+    * mediation: values with magnitude up to 2^53 round-trip exactly, larger values silently lose precision at the
+    * provider boundary. If exact identity matters beyond 2^53 (e.g. snowflake IDs), pass the value as a `StringValue`
+    * instead.
+    */
   final case class LongValue(value: Long)                          extends AttributeValue
   final case class DoubleValue(value: Double)                      extends AttributeValue
   final case class InstantValue(value: Instant)                    extends AttributeValue

--- a/core/src/main/scala-3/zio/openfeature/AttributeValue.scala
+++ b/core/src/main/scala-3/zio/openfeature/AttributeValue.scala
@@ -6,6 +6,14 @@ enum AttributeValue:
   case BoolValue(value: Boolean)
   case StringValue(value: String)
   case IntValue(value: Int)
+
+  /** A 64-bit integer attribute.
+    *
+    * The OpenFeature Java SDK normalises every numeric to `Double`, so longs cross the SDK boundary through a `Double`
+    * mediation: values with magnitude up to 2^53 round-trip exactly, larger values silently lose precision at the
+    * provider boundary. If exact identity matters beyond 2^53 (e.g. snowflake IDs), pass the value as a `StringValue`
+    * instead.
+    */
   case LongValue(value: Long)
   case DoubleValue(value: Double)
   case InstantValue(value: Instant)

--- a/core/src/main/scala/zio/openfeature/internal/ContextConverter.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ContextConverter.scala
@@ -45,7 +45,7 @@ private[openfeature] object ContextConverter {
     case AttributeValue.IntValue(i)      => new Value(i)
     case AttributeValue.LongValue(l)     => new Value(l.toDouble)
     case AttributeValue.DoubleValue(d)   => new Value(d)
-    case AttributeValue.InstantValue(dt) => new Value(dt.toString)
+    case AttributeValue.InstantValue(dt) => new Value(dt)
     case AttributeValue.ListValue(list) =>
       val javaList = list.map(attributeToValue).asJava
       new Value(javaList)

--- a/core/src/test/scala/zio/openfeature/ValueRoundTripSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ValueRoundTripSpec.scala
@@ -146,6 +146,32 @@ object ValueRoundTripSpec extends ZIOSpecDefault {
         }
       }
     },
+    test("top-level InstantValue round-trips as InstantValue") {
+      check(Gen.instant(java.time.Instant.EPOCH, java.time.Instant.parse("2100-01-01T00:00:00Z"))) { i =>
+        roundTrip(AttributeValue.InstantValue(i)) match {
+          case AttributeValue.InstantValue(v) => assertTrue(v == i)
+          case other                          => assertTrue(false: Boolean) ?? s"expected InstantValue($i), got $other"
+        }
+      }
+    },
+    test("InstantValue nested in a struct round-trips as InstantValue (regression: was stringified)") {
+      check(Gen.instant(java.time.Instant.EPOCH, java.time.Instant.parse("2100-01-01T00:00:00Z"))) { i =>
+        roundTrip(AttributeValue.StructValue(Map("when" -> AttributeValue.InstantValue(i)))) match {
+          case AttributeValue.StructValue(fields) =>
+            assertTrue(fields("when").asInstant.contains(i)) ?? s"got ${fields("when")}"
+          case other => assertTrue(false: Boolean) ?? s"expected StructValue, got $other"
+        }
+      }
+    },
+    test("InstantValue nested in a list round-trips as InstantValue (regression: was stringified)") {
+      check(Gen.instant(java.time.Instant.EPOCH, java.time.Instant.parse("2100-01-01T00:00:00Z"))) { i =>
+        roundTrip(AttributeValue.ListValue(List(AttributeValue.InstantValue(i)))) match {
+          case AttributeValue.ListValue(items) =>
+            assertTrue(items.headOption.flatMap(_.asInstant).contains(i)) ?? s"got $items"
+          case other => assertTrue(false: Boolean) ?? s"expected ListValue, got $other"
+        }
+      }
+    },
     test("EvaluationContext with targetingKey + mixed attributes round-trips") {
       val ctxGen: Gen[Any, EvaluationContext] = for {
         tk <- Gen.option(nonEmptyString)


### PR DESCRIPTION
## Summary

`ContextConverter` converted top-level `InstantValue` attributes to real SDK `Instant` values but stringified instants nested inside lists and structs (`new Value(dt.toString)`). The same attribute tree therefore did not survive a `toOpenFeature`/`fromOpenFeature` round-trip: nested instants came back as `StringValue`, silently breaking date-based targeting on nested attributes.

## Changes

- `attributeToValue` now uses the SDK's `Value(Instant)` constructor, matching the top-level path.
- Documented the Long → Double 2^53 precision limitation on `AttributeValue.LongValue` (both Scala 2 and Scala 3 sources) with the recommended `StringValue` workaround for large IDs.

## Tests

Three new property tests in `ValueRoundTripSpec`: top-level, struct-nested, and list-nested `InstantValue` all round-trip as `InstantValue` (the nested cases are regressions that fail without the fix). Scala 2.13 cross-compile verified.

Fixes #184