### PR TITLE
Bound the tracking event recorder to the last 1000 events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`trackedEvents` is bounded to the last 1000 events** (oldest dropped). The recorder previously grew without
+  limit, leaking memory in long-running apps that call `track` per request; it is a test/debug affordance —
+  providers still receive every `track` call. (#174)
+
 ### Fixed
 
 - **Nested `Instant` attributes survive the SDK round-trip.** Instants inside lists and structs were converted to

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -188,6 +188,12 @@ trait FeatureFlags {
   def track(eventName: String, context: EvaluationContext): IO[FeatureFlagError, Unit]
   def track(eventName: String, details: TrackingEventDetails): IO[FeatureFlagError, Unit]
   def track(eventName: String, context: EvaluationContext, details: TrackingEventDetails): IO[FeatureFlagError, Unit]
+
+  /** The most recent tracking events recorded by this instance, oldest first.
+    *
+    * The recorder is a bounded test/debug affordance: only the last 1000 events are retained; older events are dropped.
+    * It is not a delivery guarantee mechanism — providers receive every `track` call regardless.
+    */
   def trackedEvents: UIO[List[(String, EvaluationContext, Option[TrackingEventDetails])]]
 }
 

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -887,64 +887,61 @@ final private[openfeature] class FeatureFlagsLive(
       state.hooksRef.set(List.empty) *>
       state.globalContextRef.set(EvaluationContext.empty) *>
       state.clientContextRef.set(EvaluationContext.empty) *>
-      state.trackRecorder.set(List.empty) *>
+      state.trackRecorder.set(Chunk.empty) *>
       state.eventHub.shutdown *>
       ZIO.attemptBlocking(api.shutdown()).ignore
 
   // Tracking API
 
   override def track(eventName: String): IO[FeatureFlagError, Unit] =
-    effectiveContext(EvaluationContext.empty).flatMap { merged =>
-      state.trackRecorder.update(_ :+ (eventName, merged, None)) *>
-        ZIO
-          .attemptBlocking {
-            val ofContext = ContextConverter.toOpenFeature(merged)
-            client.track(eventName, ofContext)
-          }
-          .mapError(e => FeatureFlagError.classify(e))
-    }
+    trackImpl(eventName, EvaluationContext.empty, None)
 
   override def track(eventName: String, context: EvaluationContext): IO[FeatureFlagError, Unit] =
-    effectiveContext(context).flatMap { merged =>
-      state.trackRecorder.update(_ :+ (eventName, merged, None)) *>
-        ZIO
-          .attemptBlocking {
-            val ofContext = ContextConverter.toOpenFeature(merged)
-            client.track(eventName, ofContext)
-          }
-          .mapError(e => FeatureFlagError.classify(e))
-    }
+    trackImpl(eventName, context, None)
 
   override def track(eventName: String, details: TrackingEventDetails): IO[FeatureFlagError, Unit] =
-    effectiveContext(EvaluationContext.empty).flatMap { merged =>
-      state.trackRecorder.update(_ :+ (eventName, merged, Some(details))) *>
-        ZIO
-          .attemptBlocking {
-            val ofContext = ContextConverter.toOpenFeature(merged)
-            val ofDetails = toOpenFeatureDetails(details)
-            client.track(eventName, ofContext, ofDetails)
-          }
-          .mapError(e => FeatureFlagError.classify(e))
-    }
+    trackImpl(eventName, EvaluationContext.empty, Some(details))
 
   override def track(
     eventName: String,
     context: EvaluationContext,
     details: TrackingEventDetails
   ): IO[FeatureFlagError, Unit] =
+    trackImpl(eventName, context, Some(details))
+
+  private def trackImpl(
+    eventName: String,
+    context: EvaluationContext,
+    details: Option[TrackingEventDetails]
+  ): IO[FeatureFlagError, Unit] =
     effectiveContext(context).flatMap { merged =>
-      state.trackRecorder.update(_ :+ (eventName, merged, Some(details))) *>
+      recordTrack(eventName, merged, details) *>
         ZIO
           .attemptBlocking {
             val ofContext = ContextConverter.toOpenFeature(merged)
-            val ofDetails = toOpenFeatureDetails(details)
-            client.track(eventName, ofContext, ofDetails)
+            details match {
+              case Some(d) => client.track(eventName, ofContext, toOpenFeatureDetails(d))
+              case None    => client.track(eventName, ofContext)
+            }
           }
           .mapError(e => FeatureFlagError.classify(e))
     }
 
+  // The recorder is bounded: when full, the oldest entries are dropped so long-running apps that
+  // call `track` per request don't accumulate events (and their merged contexts) without limit.
+  private def recordTrack(
+    eventName: String,
+    merged: EvaluationContext,
+    details: Option[TrackingEventDetails]
+  ): UIO[Unit] =
+    state.trackRecorder.update { rec =>
+      val appended = rec :+ ((eventName, merged, details))
+      val overflow = appended.length - FeatureFlagsState.MaxTrackedEvents
+      if (overflow > 0) appended.drop(overflow) else appended
+    }
+
   override def trackedEvents: UIO[List[(String, EvaluationContext, Option[TrackingEventDetails])]] =
-    state.trackRecorder.get
+    state.trackRecorder.get.map(_.toList)
 
   private def toOpenFeatureDetails(details: TrackingEventDetails): MutableTrackingEventDetails = {
     val result = details.value match {

--- a/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
+++ b/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
@@ -12,10 +12,17 @@ final case class FeatureFlagsState(
   hooksRef: Ref[List[FeatureHook]],
   eventHub: Hub[ProviderEvent],
   statusRef: Ref[ProviderStatus],
-  trackRecorder: Ref[List[(String, EvaluationContext, Option[TrackingEventDetails])]]
+  trackRecorder: Ref[Chunk[(String, EvaluationContext, Option[TrackingEventDetails])]]
 )
 
 object FeatureFlagsState {
+
+  /** Maximum number of tracking events retained for `trackedEvents`. The recorder exists for test/debug introspection;
+    * bounding it keeps long-running production apps that call `track` per request from accumulating events (and their
+    * merged contexts) without limit. When full, the oldest events are dropped.
+    */
+  val MaxTrackedEvents: Int = 1000
+
   def make: URIO[Scope, FeatureFlagsState] =
     for {
       globalCtxRef   <- Ref.make(EvaluationContext.empty)
@@ -27,7 +34,7 @@ object FeatureFlagsState {
       // Bounded; subscribers reconcile via current state on next evaluation, so dropping intermediate events is safe.
       eventHub  <- Hub.dropping[ProviderEvent](256)
       statusRef <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
-      trackRec  <- Ref.make(List.empty[(String, EvaluationContext, Option[TrackingEventDetails])])
+      trackRec  <- Ref.make(Chunk.empty[(String, EvaluationContext, Option[TrackingEventDetails])])
     } yield FeatureFlagsState(
       globalCtxRef,
       clientCtxRef,

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -592,6 +592,19 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
           assertTrue(events(2)._3.exists(_.value.contains(1.0))) &&
           assertTrue(events(3)._3.exists(_.value.contains(2.0)))
       }.provide(testLayer()),
+      test("trackedEvents recorder is bounded and drops oldest events") {
+        val max   = zio.openfeature.internal.FeatureFlagsState.MaxTrackedEvents
+        val total = max + 10
+        for {
+          _      <- ZIO.foreachDiscard(1 to total)(i => FeatureFlags.track(s"event-$i"))
+          events <- FeatureFlags.trackedEvents
+        } yield assertTrue(
+          events.size == max,
+          // The 10 oldest events were dropped; the window starts at event-11.
+          events.headOption.map(_._1).contains(s"event-${total - max + 1}"),
+          events.lastOption.map(_._1).contains(s"event-$total")
+        )
+      }.provide(testLayer()),
       test("TrackingEventDetails builder methods work") {
         val details = TrackingEventDetails.empty
           .withValue(50.0)


### PR DESCRIPTION
## Summary

Every `track(...)` call appended the event (including its full merged `EvaluationContext`) to an unbounded `Ref[List]` that was only cleared on `shutdown` — a memory leak for long-running apps that track per request, with O(n) `List :+` appends making the cumulative cost quadratic.

## Changes

- The recorder is now a `Ref[Chunk[...]]` capped at `FeatureFlagsState.MaxTrackedEvents` (1000); when full, the oldest entries are dropped. `Chunk` appends are O(1).
- The four `track` overloads were collapsed into a single `trackImpl` (they only differed in context/details presence), removing the previous 4x duplication.
- `trackedEvents` keeps its `List` signature and is documented as a bounded test/debug affordance — providers still receive every `track` call.

## Tests

New test in `FeatureFlagsSpec`: tracking `MaxTrackedEvents + 10` events retains exactly 1000, dropping the 10 oldest (verified via head/last event names). Existing tracking tests (context merging, details pass-through) unchanged and green.

Fixes #174