### PR TITLE
Clear ZIO API hooks on shutdown and reject evaluations while ShuttingDown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`shutdown` clears ZIO API-level hooks and rejects in-flight evaluations.** API-level hooks (added via
+  `addZioApiHook`) previously survived shutdown, and the `ShuttingDown` status was unreachable; shutdown now
+  transitions through `ShuttingDown` (evaluations fail with `ProviderNotReady(ShuttingDown)`) and ends at
+  `NotReady`. (#183)
 - **Nested `Instant` attributes survive the SDK round-trip.** Instants inside lists and structs were converted to
   strings on the way into the Java SDK and came back as `StringValue`, silently breaking date-based targeting on
   nested attributes. The Long → Double 2^53 precision limit is now documented on `AttributeValue.LongValue`. (#184)

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -181,6 +181,15 @@ trait FeatureFlags {
   def setProvider(provider: OFFeatureProvider): IO[FeatureFlagError, Unit]
 
   // Shutdown API (spec 1.6.1)
+
+  /** Shut down this instance (spec 1.6.1, 1.6.2).
+    *
+    * The status transitions to `ShuttingDown` for the duration of the teardown (evaluations started in that window fail
+    * with `ProviderNotReady(ShuttingDown)`) and ends at `NotReady`. Client-level and ZIO API-level hooks, the global
+    * and client contexts, and the tracked-events recorder are cleared; the event hub is shut down and the underlying
+    * OpenFeature API (and with it the provider) is shut down. Fiber-local context and any in-flight transaction state
+    * are fiber-scoped and unaffected.
+    */
   def shutdown: UIO[Unit]
 
   // Tracking API

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -235,7 +235,9 @@ final private[openfeature] class FeatureFlagsLive(
       case ProviderStatus.Fatal    => ZIO.fail(FeatureFlagError.ProviderFatal)
       case ProviderStatus.NotReady => ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.NotReady))
       case ProviderStatus.Error    => ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.Error))
-      case _                       => Exit.unit
+      case ProviderStatus.ShuttingDown =>
+        ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.ShuttingDown))
+      case _ => Exit.unit
     }
 
   // Context is already merged by evaluateWithDetails before entering the hook pipeline
@@ -883,13 +885,17 @@ final private[openfeature] class FeatureFlagsLive(
   // Shutdown API (spec 1.6.1, 1.6.2)
 
   override def shutdown: UIO[Unit] =
-    state.statusRef.set(ProviderStatus.NotReady) *>
+    // ShuttingDown rejects evaluations for the duration of the teardown (checkProviderStatus);
+    // the terminal state after teardown is NotReady.
+    state.statusRef.set(ProviderStatus.ShuttingDown) *>
       state.hooksRef.set(List.empty) *>
+      state.zioApiHooksRef.set(List.empty) *>
       state.globalContextRef.set(EvaluationContext.empty) *>
       state.clientContextRef.set(EvaluationContext.empty) *>
       state.trackRecorder.set(Chunk.empty) *>
       state.eventHub.shutdown *>
-      ZIO.attemptBlocking(api.shutdown()).ignore
+      ZIO.attemptBlocking(api.shutdown()).ignore *>
+      state.statusRef.set(ProviderStatus.NotReady)
 
   // Tracking API
 

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -646,6 +646,33 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
           after  <- FeatureFlags.clientContext
         } yield assertTrue(before.targetingKey.contains("client-user")) &&
           assertTrue(after.isEmpty)
+      }.provide(testLayer()),
+      test("shutdown clears ZIO API-level hooks") {
+        val hook = FeatureHook.noop
+        for {
+          _      <- FeatureFlags.addZioApiHook(hook)
+          before <- FeatureFlags.zioApiHooks
+          _      <- FeatureFlags.shutdown
+          after  <- FeatureFlags.zioApiHooks
+        } yield assertTrue(before.length == 1) &&
+          assertTrue(after.isEmpty)
+      }.provide(testLayer()),
+      test("shutdown ends in NotReady and evaluations fail afterwards") {
+        for {
+          _      <- FeatureFlags.shutdown
+          status <- FeatureFlags.providerStatus
+          result <- FeatureFlags.boolean("flag", default = false).exit
+        } yield assertTrue(status == ProviderStatus.NotReady) &&
+          assertTrue(result.isFailure)
+      }.provide(testLayer()),
+      test("evaluations are rejected while status is ShuttingDown") {
+        for {
+          testProvider <- ZIO.service[TestFeatureProvider]
+          _            <- testProvider.setStatus(ProviderStatus.ShuttingDown)
+          result       <- FeatureFlags.boolean("flag", default = false).exit
+        } yield assert(result)(
+          Assertion.fails(Assertion.equalTo(FeatureFlagError.ProviderNotReady(ProviderStatus.ShuttingDown)))
+        )
       }.provide(testLayer())
     ),
     suite("Provider Fatal Guard")(


### PR DESCRIPTION
## Summary

Two gaps in the shutdown path:

1. `shutdown` cleared client-level hooks but left ZIO API-level hooks (`addZioApiHook`, added in #171) registered — an oversight from when the new hook level was introduced.
2. `ProviderStatus.ShuttingDown` was an unreachable enum case: never assigned, and `checkProviderStatus` would have allowed evaluations through it anyway.

## Changes

- `shutdown` now also clears `zioApiHooksRef`.
- `shutdown` transitions to `ShuttingDown` for the duration of the teardown and ends at `NotReady`; `checkProviderStatus` rejects evaluations with `ProviderNotReady(ShuttingDown)` during that window, making the previously dead enum case reachable and meaningful.
- Documented the post-shutdown contract on `FeatureFlags.shutdown` (what is cleared, what is fiber-scoped and unaffected).

## Tests

New tests in `FeatureFlagsSpec`:
- shutdown clears ZIO API-level hooks
- shutdown ends in `NotReady` and subsequent evaluations fail
- evaluations are rejected with `ProviderNotReady(ShuttingDown)` while the status is `ShuttingDown`

Fixes #183