### PR TITLE
Map HOCON typed-read failures to TYPE_MISMATCH and PARSE_ERROR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`HoconProvider` reports spec-correct error codes.** A config value of the wrong type now surfaces as
+  `TYPE_MISMATCH` and an unparseable value as `PARSE_ERROR`, instead of a GENERAL error wrapping a
+  `ConfigException`. (#188)
 - **`shutdown` clears ZIO API-level hooks and rejects in-flight evaluations.** API-level hooks (added via
   `addZioApiHook`) previously survived shutdown, and the `ShuttingDown` status was unreachable; shutdown now
   transitions through `ShuttingDown` (evaluations fail with `ProviderNotReady(ShuttingDown)`) and ends at

--- a/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
@@ -1,6 +1,6 @@
 package zio.openfeature.extras
 
-import com.typesafe.config.{Config, ConfigFactory, ConfigValueType}
+import com.typesafe.config.{Config, ConfigException, ConfigFactory, ConfigValueType}
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
   FeatureProvider,
@@ -10,6 +10,7 @@ import dev.openfeature.sdk.{
   Structure,
   Value
 }
+import dev.openfeature.sdk.exceptions.{ParseError, TypeMismatchError}
 import zio._
 import java.util.concurrent.atomic.AtomicReference
 import scala.jdk.CollectionConverters._
@@ -37,6 +38,15 @@ final class HoconProvider private (
 
   override def getState: ProviderState = state.get()
 
+  // Translate Typesafe Config's typed-read failures into the OpenFeature error model so callers see
+  // TYPE_MISMATCH / PARSE_ERROR instead of a GENERAL error wrapping a ConfigException (spec 7.3.6).
+  private def typedRead[A](key: String, read: => A): A =
+    try read
+    catch {
+      case e: ConfigException.WrongType => throw new TypeMismatchError(s"Flag '$key': ${e.getMessage}")
+      case e: ConfigException.BadValue  => throw new ParseError(s"Flag '$key': ${e.getMessage}")
+    }
+
   override def getBooleanEvaluation(
     key: String,
     defaultValue: java.lang.Boolean,
@@ -45,7 +55,7 @@ final class HoconProvider private (
     if (config.hasPath(key))
       ProviderEvaluation
         .builder[java.lang.Boolean]()
-        .value(config.getBoolean(key))
+        .value(typedRead(key, config.getBoolean(key)))
         .reason("STATIC")
         .build()
     else
@@ -57,7 +67,7 @@ final class HoconProvider private (
     context: OFEvaluationContext
   ): ProviderEvaluation[String] =
     if (config.hasPath(key))
-      ProviderEvaluation.builder[String]().value(config.getString(key)).reason("STATIC").build()
+      ProviderEvaluation.builder[String]().value(typedRead(key, config.getString(key))).reason("STATIC").build()
     else
       ProviderEvaluation.builder[String]().value(defaultValue).reason("DEFAULT").build()
 
@@ -67,7 +77,7 @@ final class HoconProvider private (
     context: OFEvaluationContext
   ): ProviderEvaluation[java.lang.Integer] =
     if (config.hasPath(key))
-      ProviderEvaluation.builder[java.lang.Integer]().value(config.getInt(key)).reason("STATIC").build()
+      ProviderEvaluation.builder[java.lang.Integer]().value(typedRead(key, config.getInt(key))).reason("STATIC").build()
     else
       ProviderEvaluation.builder[java.lang.Integer]().value(defaultValue).reason("DEFAULT").build()
 
@@ -77,7 +87,11 @@ final class HoconProvider private (
     context: OFEvaluationContext
   ): ProviderEvaluation[java.lang.Double] =
     if (config.hasPath(key))
-      ProviderEvaluation.builder[java.lang.Double]().value(config.getDouble(key)).reason("STATIC").build()
+      ProviderEvaluation
+        .builder[java.lang.Double]()
+        .value(typedRead(key, config.getDouble(key)))
+        .reason("STATIC")
+        .build()
     else
       ProviderEvaluation.builder[java.lang.Double]().value(defaultValue).reason("DEFAULT").build()
 
@@ -87,7 +101,7 @@ final class HoconProvider private (
     context: OFEvaluationContext
   ): ProviderEvaluation[Value] =
     if (config.hasPath(key)) {
-      val value = configValueToSdkValue(config.getValue(key))
+      val value = typedRead(key, configValueToSdkValue(config.getValue(key)))
       ProviderEvaluation.builder[Value]().value(value).reason("STATIC").build()
     } else
       ProviderEvaluation.builder[Value]().value(defaultValue).reason("DEFAULT").build()

--- a/extras/src/test/scala/zio/openfeature/extras/HoconProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/HoconProviderSpec.scala
@@ -77,6 +77,41 @@ object HoconProviderSpec extends ZIOSpecDefault {
         assertTrue(list.map(_.asInteger().intValue()) == List(2, 3, 5, 7))
       }
     ),
+    suite("error codes (spec 7.3.6)")(
+      test("wrong-typed value evaluated as boolean throws TypeMismatchError") {
+        val result = ZIO.attempt(provider.getBooleanEvaluation("welcome-message", false, ctx)).exit
+        result.map { exit =>
+          assertTrue(exit.isFailure) &&
+          assertTrue(exit.causeOption.flatMap(_.failureOption).exists {
+            case e: dev.openfeature.sdk.exceptions.OpenFeatureError =>
+              e.getErrorCode == dev.openfeature.sdk.ErrorCode.TYPE_MISMATCH
+            case _ => false
+          })
+        }
+      },
+      test("wrong-typed value evaluated as int throws TypeMismatchError") {
+        val result = ZIO.attempt(provider.getIntegerEvaluation("new-checkout", 0, ctx)).exit
+        result.map { exit =>
+          assertTrue(exit.isFailure) &&
+          assertTrue(exit.causeOption.flatMap(_.failureOption).exists {
+            case e: dev.openfeature.sdk.exceptions.OpenFeatureError =>
+              e.getErrorCode == dev.openfeature.sdk.ErrorCode.TYPE_MISMATCH
+            case _ => false
+          })
+        }
+      },
+      test("wrong-typed value evaluated as double throws TypeMismatchError") {
+        val result = ZIO.attempt(provider.getDoubleEvaluation("welcome-message", 0.0, ctx)).exit
+        result.map { exit =>
+          assertTrue(exit.isFailure) &&
+          assertTrue(exit.causeOption.flatMap(_.failureOption).exists {
+            case e: dev.openfeature.sdk.exceptions.OpenFeatureError =>
+              e.getErrorCode == dev.openfeature.sdk.ErrorCode.TYPE_MISMATCH
+            case _ => false
+          })
+        }
+      }
+    ),
     suite("metadata")(
       test("provider name is HoconProvider") {
         assertTrue(provider.getMetadata.getName == "HoconProvider")


### PR DESCRIPTION
## Summary

`HoconProvider` called `config.getBoolean/getString/getInt/getDouble/getValue` directly. When a config value existed with the wrong type, Typesafe Config's `ConfigException.WrongType` escaped uncaught, so the Java SDK reported it as a GENERAL error instead of the spec-correct TYPE_MISMATCH (spec 7.3.6). Same for malformed values (`ConfigException.BadValue` → should be PARSE_ERROR).

## Changes

All typed reads go through a `typedRead` helper that translates:
- `ConfigException.WrongType` → `dev.openfeature.sdk.exceptions.TypeMismatchError`
- `ConfigException.BadValue` → `dev.openfeature.sdk.exceptions.ParseError`

so the SDK propagates the right error codes, which classify into the right `FeatureFlagError` on the ZIO side.

## Tests

New `HoconProviderSpec` suite: a string config value evaluated as boolean/double and a boolean evaluated as int each fail with `TYPE_MISMATCH` (asserted via `OpenFeatureError.getErrorCode`).

Fixes #188