### PR TITLE
Rate-limit delegate state polling in CircuitBreakerProvider

### DIFF
--- a/docs/extras.md
+++ b/docs/extras.md
@@ -265,7 +265,7 @@ The circuit breaker has three states:
 ### Two tripping mechanisms
 
 1. **Failure-count**: After `failureThreshold` consecutive evaluation failures (including timeouts), the circuit opens.
-2. **State-driven**: Before each evaluation, the delegate's state is checked. If `ERROR` or `FATAL`, the circuit opens immediately — no failed evaluations needed. When the delegate recovers to `READY`, the circuit closes automatically.
+2. **State-driven**: The delegate's state is polled at most once per `stateCheckInterval` (default `1.second`) rather than on every call, keeping the hot path cheap. If the observed state is `ERROR` or `FATAL`, the circuit opens immediately — no failed evaluations needed. When the delegate recovers to `READY`, the circuit closes automatically. Set `stateCheckInterval` to `Duration.Zero` to poll the delegate state on every evaluation.
 
 ### Usage
 
@@ -316,6 +316,7 @@ yield layer
 | `evaluationTimeout` | `500.millis` | Max duration for a single delegate evaluation |
 | `halfOpenMaxCalls` | `1` | Successful probes required to close the circuit |
 | `stalePolicy` | `StalePolicy.Open` | Behavior when delegate reports `STALE` state |
+| `stateCheckInterval` | `1.second` | Minimum interval between delegate state polls (`Duration.Zero` polls on every call) |
 
 ### Stale policy
 

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
@@ -32,13 +32,19 @@ object StalePolicy {
   *   Number of successful probes in half-open state required to close the circuit
   * @param stalePolicy
   *   How to react when the delegate provider is in STALE state
+  * @param stateCheckInterval
+  *   Minimum time between polls of the delegate's `getState()` on the evaluation path. The state-driven trip mechanism
+  *   only needs periodic freshness; polling on every evaluation puts delegate-defined work (locks, computed state) on
+  *   the hot path. `Duration.Zero` checks on every evaluation. Failure-count tripping is unaffected and reacts to every
+  *   evaluation outcome immediately.
   */
 final case class CircuitBreakerProviderConfig(
   failureThreshold: Int = 5,
   resetTimeout: Duration = 30.seconds,
   evaluationTimeout: Duration = 500.millis,
   halfOpenMaxCalls: Int = 1,
-  stalePolicy: StalePolicy = StalePolicy.Open
+  stalePolicy: StalePolicy = StalePolicy.Open,
+  stateCheckInterval: Duration = 1.second
 ) {
   private[extras] def toCircuitBreakerConfig: CircuitBreakerConfig =
     CircuitBreakerConfig(
@@ -241,7 +247,25 @@ final class CircuitBreakerProvider private (
   @scala.annotation.nowarn("msg=deprecated")
   private def delegateState(): ProviderState = underlying.getState
 
-  private def checkDelegateState(): Unit =
+  // Sentinel meaning "never checked" so the very first evaluation (and initialize) always polls,
+  // regardless of where the configured clock starts.
+  private val NeverChecked     = Long.MinValue
+  private val lastStateCheckAt = new java.util.concurrent.atomic.AtomicLong(NeverChecked)
+
+  // Rate-limit delegate state polling on the evaluation hot path. Whichever caller wins the CAS
+  // performs the poll; losers skip it — the next winner after the interval re-polls.
+  private def checkDelegateState(): Unit = {
+    val interval = config.stateCheckInterval.toMillis
+    if (interval <= 0L) doCheckDelegateState()
+    else {
+      val last = lastStateCheckAt.get()
+      val now  = breaker.clock.millis()
+      if ((last == NeverChecked || now - last >= interval) && lastStateCheckAt.compareAndSet(last, now))
+        doCheckDelegateState()
+    }
+  }
+
+  private def doCheckDelegateState(): Unit =
     scala.util.Try(delegateState()).toOption match {
       case None => breaker.trip()
       case Some(state) =>

--- a/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerProviderSpec.scala
@@ -302,8 +302,14 @@ object CircuitBreakerProviderSpec extends ZIOSpecDefault {
       test("closes when delegate recovers to READY") {
         val underlying = new FailableProvider(Map("flag" -> true))
         val clock      = new TestClock()
-        val config     = CircuitBreakerProviderConfig(failureThreshold = 2, resetTimeout = 1.minute)
-        val cb         = CircuitBreakerProvider(underlying, config, clock)
+        // stateCheckInterval = Zero: this test needs the delegate state observed on every call
+        val config =
+          CircuitBreakerProviderConfig(
+            failureThreshold = 2,
+            resetTimeout = 1.minute,
+            stateCheckInterval = Duration.Zero
+          )
+        val cb = CircuitBreakerProvider(underlying, config, clock)
         // Trip via state
         underlying.setState(ProviderState.ERROR)
         val tryResult       = scala.util.Try(cb.getBooleanEvaluation("flag", false, ctx))
@@ -342,6 +348,41 @@ object CircuitBreakerProviderSpec extends ZIOSpecDefault {
         // First call allowed as probe
         val result = cb.getBooleanEvaluation("flag", false, ctx)
         assertTrue(result.getValue == true)
+      },
+      test("delegate getState polling is bounded by stateCheckInterval, not evaluation count") {
+        val stateChecks = new java.util.concurrent.atomic.AtomicInteger(0)
+        val underlying = new FailableProvider(Map("flag" -> true)) {
+          override def getState: ProviderState = {
+            stateChecks.incrementAndGet()
+            super.getState
+          }
+        }
+        val clock  = new TestClock()
+        val config = CircuitBreakerProviderConfig(stateCheckInterval = 1.second)
+        val cb     = CircuitBreakerProvider(underlying, config, clock)
+        // 10 evaluations inside one interval: only the first polls the delegate state
+        (1 to 10).foreach(_ => cb.getBooleanEvaluation("flag", false, ctx))
+        val checksWithinInterval = stateChecks.get()
+        // Advancing past the interval re-enables exactly one more poll
+        clock.advance(2.seconds)
+        (1 to 10).foreach(_ => cb.getBooleanEvaluation("flag", false, ctx))
+        val checksAfterAdvance = stateChecks.get()
+        assertTrue(checksWithinInterval == 1) &&
+        assertTrue(checksAfterAdvance == 2) &&
+        assertTrue(underlying.evaluationCount.get() == 20)
+      },
+      test("stateCheckInterval Zero polls delegate state on every evaluation") {
+        val stateChecks = new java.util.concurrent.atomic.AtomicInteger(0)
+        val underlying = new FailableProvider(Map("flag" -> true)) {
+          override def getState: ProviderState = {
+            stateChecks.incrementAndGet()
+            super.getState
+          }
+        }
+        val config = CircuitBreakerProviderConfig(stateCheckInterval = Duration.Zero)
+        val cb     = CircuitBreakerProvider(underlying, config)
+        (1 to 5).foreach(_ => cb.getBooleanEvaluation("flag", false, ctx))
+        assertTrue(stateChecks.get() == 5)
       }
     ),
     suite("Lifecycle")(


### PR DESCRIPTION
## Summary

`protect` called `underlying.getState` before **every** evaluation. For delegates where `getState` is non-trivial (synchronized state, nested wrappers, third-party providers), that puts delegate-defined work and lock contention on the hot path — exactly where the circuit breaker is supposed to be cheap.

## Changes

- New `CircuitBreakerProviderConfig.stateCheckInterval` (default 1 second): the state-driven trip mechanism now polls `getState` at most once per interval, using a CAS so exactly one concurrent caller performs the poll. A `NeverChecked` sentinel guarantees the very first evaluation (and `initialize`) always polls, regardless of where the configured clock starts.
- `Duration.Zero` restores the previous poll-on-every-call behavior.
- Failure-count tripping is unaffected: every evaluation outcome is still recorded immediately, so detection latency for a failing provider is bounded by `min(stateCheckInterval, failureThreshold x call rate)`.

Behavioral note: with the 1s default, a delegate that flips to ERROR *without any evaluation failing* is now detected up to 1s later than before. Failure-driven opening (the common path) is unchanged.

## Tests

- New: 10 evaluations within one interval poll the delegate state exactly once; advancing the test clock past the interval re-enables exactly one more poll; evaluations themselves are unaffected (20/20 reach the delegate).
- New: `stateCheckInterval = Duration.Zero` polls on every evaluation.
- The one existing test that needs per-call state observation ("closes when delegate recovers to READY") now passes `Duration.Zero` explicitly; all other tests are unchanged and green.

Fixes #189