### PR TITLE
Register shutdown finalizer before provider init; tear down provider on init failure

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -456,16 +456,23 @@ object FeatureFlags {
   ): ZIO[Scope, Throwable, FeatureFlagsLive] =
     for {
       api <- ZIO.succeed(apiOverride.getOrElse(OpenFeatureAPI.getInstance()))
+      // Register the API shutdown finalizer BEFORE initiating provider registration. If init times out,
+      // the provider reports a bad state, or getClient fails, the scope close still tears down whatever
+      // the (possibly still-running, disconnected) setProviderAndWait managed to register.
+      _ <- ZIO.when(addShutdownFinalizer)(ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore))
       setAndWait = domain match {
         case Some(d) => ZIO.attemptBlocking(api.setProviderAndWait(d, provider))
         case None    => ZIO.attemptBlocking(api.setProviderAndWait(provider))
       }
       // Bound the blocking init. `.disconnect` ensures the timeout returns promptly even though
       // `attemptBlocking` runs on the blocking pool; the underlying call may still run to completion
-      // in the background and is handled by the Java SDK / addShutdownFinalizer path.
-      _ <- setAndWait.disconnect
-        .timeoutFail(new TimeoutException(s"Provider initialization exceeded $initTimeout"))(initTimeout)
-      verified <- verifyInitState(provider)
+      // in the background. On any init failure the provider itself is shut down (best-effort) so it
+      // doesn't keep threads/connections alive — this also covers the domain/registry paths where no
+      // API finalizer is registered.
+      verified <- (setAndWait.disconnect
+        .timeoutFail(new TimeoutException(s"Provider initialization exceeded $initTimeout"))(initTimeout) *>
+        verifyInitState(provider))
+        .tapError(_ => ZIO.attemptBlocking(provider.shutdown()).ignore)
       client <- (domain, version) match {
         case (Some(d), Some(v)) => ZIO.attempt(api.getClient(d, v))
         case (Some(d), None)    => ZIO.attempt(api.getClient(d))
@@ -480,7 +487,6 @@ object FeatureFlags {
       _ <- state.hooksRef.set(initialHooks)
       // Only seed status when the caller didn't hand us a shared ref (testkit shares one).
       _ <- statusRef.fold(state.statusRef.set(verified))(_ => ZIO.unit)
-      _ <- ZIO.when(addShutdownFinalizer)(ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore))
       ff = new FeatureFlagsLive(
         client,
         providerRef,
@@ -655,6 +661,9 @@ object FeatureFlags {
   ): ZIO[Scope, Throwable, FeatureFlagsLive] =
     for {
       api <- ZIO.succeed(apiOverride.getOrElse(OpenFeatureAPI.getInstance()))
+      // Register the API shutdown finalizer BEFORE the provider, so a failure later in the build
+      // (e.g. getClient) still tears down the registered provider when the scope closes.
+      _ <- ZIO.when(addShutdownFinalizer)(ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore))
       // Register provider FIRST so the client binds to it (not the NoOp default)
       _ <- domain match {
         case Some(d) => ZIO.succeed(api.setProvider(d, provider))
@@ -672,7 +681,6 @@ object FeatureFlags {
       baseState       <- FeatureFlagsState.make
       state = statusRef.fold(baseState)(ref => baseState.copy(statusRef = ref))
       _ <- state.hooksRef.set(initialHooks)
-      _ <- ZIO.when(addShutdownFinalizer)(ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore))
       ff = new FeatureFlagsLive(
         client,
         providerRef,

--- a/core/src/test/scala/zio/openfeature/ProviderInitHardeningSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderInitHardeningSpec.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicReference
 object ProviderInitHardeningSpec extends ZIOSpecDefault {
 
   /** A provider whose `initialize()` blocks until its latch is released. Used to simulate a hanging sync init. */
-  final private class BlockingInitProvider(latch: CountDownLatch) extends EventProvider {
+  private class BlockingInitProvider(latch: CountDownLatch) extends EventProvider {
     private val st = new AtomicReference[ProviderState](ProviderState.NOT_READY)
 
     override def getMetadata: Metadata   = new Metadata { def getName: String = "BlockingInitProvider" }
@@ -51,7 +51,7 @@ object ProviderInitHardeningSpec extends ZIOSpecDefault {
   /** A provider that returns successfully from `initialize()` but reports ERROR. The library should refuse to mark such
     * a provider Ready and instead fail layer construction.
     */
-  final private class InitToErrorProvider extends EventProvider {
+  private class InitToErrorProvider extends EventProvider {
     private val st                       = new AtomicReference[ProviderState](ProviderState.NOT_READY)
     override def getMetadata: Metadata   = new Metadata { def getName: String = "InitToErrorProvider" }
     override def getState: ProviderState = st.get()
@@ -125,6 +125,66 @@ object ProviderInitHardeningSpec extends ZIOSpecDefault {
           t.isInstanceOf[IllegalStateException] && Option(t.getMessage).exists(_.contains("ERROR"))
         )
       )
+    } @@ withLiveClock,
+    test("[#180] provider is shut down when sync init times out") {
+      val latch        = new CountDownLatch(1)
+      val shutdownSeen = new java.util.concurrent.atomic.AtomicInteger(0)
+      val provider = new BlockingInitProvider(latch) {
+        override def shutdown(): Unit = {
+          shutdownSeen.incrementAndGet()
+          super.shutdown()
+        }
+      }
+      val api = OpenFeatureAPIFactory.create()
+      val build = ZIO.scoped {
+        FeatureFlags
+          .build(
+            provider,
+            domain = Some(uniqueDomain("sync-timeout-cleanup")),
+            version = None,
+            initialHooks = Nil,
+            statusRef = None,
+            addShutdownFinalizer = false,
+            apiOverride = Some(api),
+            initTimeout = 200.millis
+          )
+          .unit
+      }
+      for {
+        result <- build.either
+      } yield assertTrue(
+        result.isLeft,
+        // The failure path shuts the provider down even though no API finalizer was registered.
+        // (BlockingInitProvider.shutdown also releases the latch, so the background init thread exits.)
+        shutdownSeen.get() >= 1
+      )
+    } @@ withLiveClock,
+    test("[#180] provider is shut down when it reports ERROR after init") {
+      val shutdownSeen = new java.util.concurrent.atomic.AtomicInteger(0)
+      val provider = new InitToErrorProvider {
+        override def shutdown(): Unit = {
+          shutdownSeen.incrementAndGet()
+          super.shutdown()
+        }
+      }
+      val api = OpenFeatureAPIFactory.create()
+      val build = ZIO.scoped {
+        FeatureFlags
+          .build(
+            provider,
+            domain = Some(uniqueDomain("sync-err-cleanup")),
+            version = None,
+            initialHooks = Nil,
+            statusRef = None,
+            addShutdownFinalizer = false,
+            apiOverride = Some(api),
+            initTimeout = 5.seconds
+          )
+          .unit
+      }
+      for {
+        result <- build.either
+      } yield assertTrue(result.isLeft, shutdownSeen.get() >= 1)
     } @@ withLiveClock,
     test("[A1 async] watchdog transitions provider to Fatal after initTimeout when init hangs") {
       // initialize() blocks forever — Java SDK never fires PROVIDER_READY, so the only way out


### PR DESCRIPTION
## Summary

In `FeatureFlags.build`, the `api.shutdown()` finalizer was registered *after* `setProviderAndWait` and `verifyInitState`. If init timed out, the provider reported ERROR/FATAL, or `getClient` threw, the scope closed having never registered the finalizer — and on timeout, the disconnected `setProviderAndWait` could still *complete* in the background, leaving a fully initialized provider (HTTP pools, polling threads) attached to an API nobody would shut down. `buildAsync` had the same late registration with a smaller window.

## Changes

- Both `build` and `buildAsync` register the `api.shutdown()` finalizer (when `addShutdownFinalizer` is set) before initiating provider registration.
- `build` additionally shuts the provider down (best-effort, `attemptBlocking(...).ignore`) via `tapError` when the init times out or `verifyInitState` rejects the post-init state. This covers the domain/registry paths where no API finalizer is registered at this level.

## Tests

Two new tests in `ProviderInitHardeningSpec` using shutdown-counting subclasses of the existing test providers:
- sync init timeout → build fails and `provider.shutdown()` was invoked (which also releases the blocked init thread)
- provider reports ERROR after init → build fails and `provider.shutdown()` was invoked

The test provider classes lost their `final` modifier to allow the counting subclasses.

Fixes #180