### PR TITLE
Establish event hub subscription before handler registration returns

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -134,9 +134,16 @@ trait FeatureFlags {
   def clientMetadata: UIO[ClientMetadata]
 
   // Event Handlers - return a cancellation effect
+  //
+  // Delivery semantics: the event subscription is established before the registration effect returns, so no event
+  // published afterwards is lost. Handlers with an "associated state" (ready/error/stale) also run immediately when
+  // the provider is already in that state (spec 5.3.3); an event arriving during registration may therefore invoke
+  // the handler twice — delivery is at-least-once and handlers should be idempotent.
+
   /** Register a handler for provider ready events. Returns a cancellation effect.
     *
-    * Per OpenFeature spec 5.2.1 and 5.2.7, handlers can be registered and removed.
+    * Per OpenFeature spec 5.2.1 and 5.2.7, handlers can be registered and removed. Delivery is at-least-once — see the
+    * note on event handlers above.
     */
   def onProviderReady(handler: ProviderMetadata => UIO[Unit]): UIO[UIO[Unit]]
 

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -632,7 +632,26 @@ final private[openfeature] class FeatureFlagsLive(
 
   // Event Handlers - return cancellation effects per OpenFeature spec 5.2.7
 
+  /** Fork a daemon fiber consuming hub events, guaranteeing the hub subscription is established before this method
+    * returns. Without the handshake, events published between handler registration and the forked stream's first pull
+    * would be silently lost. The returned effect cancels the subscription.
+    */
+  private def consumeEvents(consume: ZStream[Any, Nothing, ProviderEvent] => UIO[Unit]): UIO[UIO[Unit]] =
+    for {
+      subscribed <- Promise.make[Nothing, Unit]
+      fiber <- ZIO.scoped {
+        state.eventHub.subscribe.flatMap { queue =>
+          subscribed.succeed(()) *> consume(ZStream.fromQueue(queue))
+        }
+      }.forkDaemon
+      _ <- subscribed.await
+    } yield fiber.interrupt.unit
+
   /** Per OpenFeature spec 5.3.3, handlers attached after the provider reaches an associated state MUST run immediately.
+    *
+    * The subscription is established first, then the current status is checked: no event can fall between the two. The
+    * cost is at-least-once delivery — an event arriving in that window may invoke the handler via both the immediate
+    * check and the stream.
     */
   private def subscribeToEvent[A](
     immediateCondition: ProviderStatus => Boolean,
@@ -641,10 +660,10 @@ final private[openfeature] class FeatureFlagsLive(
     handler: A => UIO[Unit]
   ): UIO[UIO[Unit]] =
     for {
+      cancel <- consumeEvents(_.collect(collect).foreach(handler))
       status <- providerStatus
       _      <- ZIO.when(immediateCondition(status))(handler(immediatePayload))
-      fiber  <- events.collect(collect).foreach(handler).forkDaemon
-    } yield fiber.interrupt.unit
+    } yield cancel
 
   override def onProviderReady(handler: ProviderMetadata => UIO[Unit]): UIO[UIO[Unit]] =
     providerNameRef.get.flatMap { pName =>
@@ -681,11 +700,10 @@ final private[openfeature] class FeatureFlagsLive(
 
   override def onConfigurationChanged(handler: (Set[String], ProviderMetadata) => UIO[Unit]): UIO[UIO[Unit]] =
     // Configuration changed doesn't have an "associated state" so no immediate execution needed
-    events
-      .collect { case ProviderEvent.ConfigurationChanged(flags, m, _) => (flags, m) }
-      .foreach { case (flags, m) => handler(flags, m) }
-      .forkDaemon
-      .map(fiber => fiber.interrupt.unit)
+    consumeEvents(
+      _.collect { case ProviderEvent.ConfigurationChanged(flags, m, _) => (flags, m) }
+        .foreach { case (flags, m) => handler(flags, m) }
+    )
 
   override def on(eventType: ProviderEventType, handler: ProviderEvent => UIO[Unit]): UIO[UIO[Unit]] =
     eventType match {
@@ -698,11 +716,7 @@ final private[openfeature] class FeatureFlagsLive(
       case ProviderEventType.ConfigurationChanged =>
         onConfigurationChanged((flags, m) => handler(ProviderEvent.ConfigurationChanged(flags, m)))
       case ProviderEventType.Reconnecting =>
-        events
-          .filter(_.eventType == ProviderEventType.Reconnecting)
-          .foreach(handler)
-          .forkDaemon
-          .map(fiber => fiber.interrupt.unit)
+        consumeEvents(_.filter(_.eventType == ProviderEventType.Reconnecting).foreach(handler))
     }
 
   override def addHook(hook: FeatureHook): UIO[Unit] =

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -708,6 +708,8 @@ FeatureFlags.onProviderReady { metadata =>
 }
 ```
 
+Delivery is **at-least-once**: the hub subscription is established before registration returns, so an event published immediately after you register is never lost. As a consequence, an event that arrives during registration may invoke the handler twice (once via the live subscription and once via the spec-5.3.3 immediate-state check). Make handlers idempotent if duplicate invocation would be a problem.
+
 ### Event Stream
 
 For reactive event processing, use the ZStream:

--- a/testkit/src/test/scala/zio/openfeature/testkit/EventSubscriptionSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/EventSubscriptionSpec.scala
@@ -1,0 +1,67 @@
+package zio.openfeature.testkit
+
+import zio._
+import zio.test._
+import zio.openfeature._
+
+/** Pins the registration guarantee fixed in #177: the hub subscription is established before the `on*` registration
+  * effect returns, so an event published immediately afterwards is always delivered (previously the forked stream could
+  * subscribe after the event, silently losing it).
+  */
+object EventSubscriptionSpec extends ZIOSpecDefault {
+
+  private def testLayer: ZLayer[Any, Throwable, TestFeatureProvider with FeatureFlags] =
+    Scope.default >>> TestFeatureProvider.layer(Map.empty)
+
+  private def awaitCount(ref: Ref[Int], atLeast: Int): UIO[Int] =
+    ref.get.repeatUntil(_ >= atLeast)
+
+  def spec = suite("Event handler subscription guarantee (#177)")(
+    test("onConfigurationChanged delivers an event emitted right after registration") {
+      for {
+        ref          <- Ref.make(0)
+        testProvider <- ZIO.service[TestFeatureProvider]
+        _            <- FeatureFlags.onConfigurationChanged((_, _) => ref.update(_ + 1))
+        _            <- testProvider.emitEvent(ProviderEvent.ConfigurationChanged(Set("f"), testProvider.metadata))
+        n            <- awaitCount(ref, 1).timeoutFail(new RuntimeException("event never delivered"))(10.seconds)
+      } yield assertTrue(n >= 1)
+    },
+    test("on(Stale) delivers an event emitted right after registration") {
+      for {
+        ref          <- Ref.make(0)
+        testProvider <- ZIO.service[TestFeatureProvider]
+        _            <- FeatureFlags.on(ProviderEventType.ConfigurationChanged, _ => ref.update(_ + 1))
+        _            <- testProvider.emitEvent(ProviderEvent.ConfigurationChanged(Set("g"), testProvider.metadata))
+        n            <- awaitCount(ref, 1).timeoutFail(new RuntimeException("event never delivered"))(10.seconds)
+      } yield assertTrue(n >= 1)
+    },
+    test("repeated register-then-emit cycles never lose the event") {
+      // Exercises the former race window repeatedly; with the subscription handshake every cycle must deliver.
+      ZIO
+        .foreach(1 to 20) { i =>
+          for {
+            ref          <- Ref.make(0)
+            testProvider <- ZIO.service[TestFeatureProvider]
+            cancel       <- FeatureFlags.onConfigurationChanged((_, _) => ref.update(_ + 1))
+            _ <- testProvider.emitEvent(ProviderEvent.ConfigurationChanged(Set(s"flag-$i"), testProvider.metadata))
+            n <- awaitCount(ref, 1).timeoutFail(new RuntimeException(s"cycle $i lost the event"))(10.seconds)
+            _ <- cancel
+          } yield n
+        }
+        .map(counts => assertTrue(counts.forall(_ >= 1)))
+    },
+    test("cancellation stops delivery") {
+      for {
+        ref          <- Ref.make(0)
+        testProvider <- ZIO.service[TestFeatureProvider]
+        cancel       <- FeatureFlags.onConfigurationChanged((_, _) => ref.update(_ + 1))
+        _            <- testProvider.emitEvent(ProviderEvent.ConfigurationChanged(Set("a"), testProvider.metadata))
+        _            <- awaitCount(ref, 1).timeoutFail(new RuntimeException("first event never delivered"))(10.seconds)
+        _            <- cancel
+        _            <- testProvider.emitEvent(ProviderEvent.ConfigurationChanged(Set("b"), testProvider.metadata))
+        _            <- ZIO.sleep(200.millis)
+        n            <- ref.get
+      } yield assertTrue(n == 1)
+    }
+  ).provide(testLayer) @@ TestAspect.withLiveClock @@ TestAspect.sequential
+}


### PR DESCRIPTION
## Summary

`subscribeToEvent`, `onConfigurationChanged`, and the `Reconnecting` arm of `on` consumed events via `ZStream.fromHub(...).foreach(...).forkDaemon`. The hub subscription only takes effect when the forked stream starts pulling, so any event published between handler registration and the fiber's first pull was silently lost — a caller registering `onProviderReady` while the provider flips to ready in that window never got called, with no later reconciliation.

A secondary issue: the spec-5.3.3 "immediate" invocation ran *before* the subscription existed, so the same event could be missed entirely rather than at worst duplicated.

## Changes

- New `consumeEvents` helper: subscribes to the hub inside a scope, signals a `Promise` once the subscription (a `Dequeue`) exists, and only then returns the cancellation effect. Registration now has a happens-before edge with any subsequent publish.
- `subscribeToEvent` checks the provider status *after* the subscription is live: no event can fall between subscribe and the immediate-invocation check. The trade-off is at-least-once delivery (an event arriving during registration may invoke the handler via both paths), now documented on the trait's event-handler section.
- `onConfigurationChanged` and `on(Reconnecting)` use the same helper.

## Tests

New `EventSubscriptionSpec`:
- `onConfigurationChanged` / `on` deliver an event emitted immediately after registration (no settling sleep)
- 20 register-then-emit cycles never lose an event (repeatedly exercises the former race window)
- the returned cancellation effect stops delivery

Fixes #177