### PR TITLE
CachingProvider: never cache failures, carry evaluation in the cache key

### DIFF
--- a/docs/extras.md
+++ b/docs/extras.md
@@ -400,6 +400,7 @@ yield layer
 - **Subsequent evaluations**: Returns cached result with `CACHED` reason
 - **Different contexts**: Cached separately (cache key includes context hash)
 - **TTL expiry**: Re-evaluates from the underlying provider after TTL
+- **Failures are never cached**: an evaluation that throws or resolves with an error code is returned to the caller but not stored, so the next call retries the delegate (a transient error never poisons the entry for the full TTL)
 
 ### High-cardinality contexts
 

--- a/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
@@ -10,7 +10,6 @@ import dev.openfeature.sdk.{
 }
 import zio._
 import zio.cache.{Cache, Lookup}
-import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.CollectionConverters._
 
 /** Configuration for the caching provider.
@@ -33,8 +32,26 @@ final case class CachingConfig(
 
 /** A cache key combining the flag key, evaluation type, and a fingerprint of the evaluation context. Uses a string
   * fingerprint instead of a hash to avoid collisions that could serve wrong flag values to different users.
+  *
+  * The key also carries the evaluation thunk for cache misses. zio-cache's `Lookup` is fixed at construction, so the
+  * only race-free way to hand it the delegate call for *this* evaluation is through the key itself. The thunk is
+  * deliberately excluded from `equals`/`hashCode` — logical identity is (flagKey, flagType, contextFingerprint), and
+  * concurrent callers with the same logical key deduplicate onto whichever thunk triggers the lookup.
   */
-final private[extras] case class CacheKey(flagKey: String, flagType: String, contextFingerprint: String)
+final private[extras] class CacheKey(
+  val flagKey: String,
+  val flagType: String,
+  val contextFingerprint: String,
+  val evaluate: () => ProviderEvaluation[Any]
+) {
+  override def equals(other: Any): Boolean = other match {
+    case that: CacheKey =>
+      flagKey == that.flagKey && flagType == that.flagType && contextFingerprint == that.contextFingerprint
+    case _ => false
+  }
+  override def hashCode: Int    = (flagKey, flagType, contextFingerprint).hashCode()
+  override def toString: String = s"CacheKey($flagKey, $flagType, $contextFingerprint)"
+}
 
 /** A decorator provider that wraps any existing provider and adds evaluation caching backed by `zio-cache`.
   *
@@ -46,12 +63,15 @@ final private[extras] case class CacheKey(flagKey: String, flagType: String, con
   *
   * Cached evaluations return `CACHED` as the resolution reason. Call `invalidateAll` when receiving
   * `ConfigurationChanged` events from the underlying provider.
+  *
+  * Failures are never served from cache: a delegate exception (and any evaluation that resolves with an error code)
+  * invalidates its entry, so the next evaluation retries the delegate instead of replaying a transient error for the
+  * remainder of the TTL.
   */
 final class CachingProvider private (
   val underlying: EventProvider,
   val config: CachingConfig,
   private val cache: Cache[CacheKey, Throwable, ProviderEvaluation[Any]],
-  private val evaluators: ConcurrentHashMap[CacheKey, () => ProviderEvaluation[Any]],
   private val runtime: Runtime[Any]
 ) extends EventProvider {
 
@@ -70,7 +90,6 @@ final class CachingProvider private (
     Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(cache.invalidateAll).getOrThrowFiberFailure()
     }
-    evaluators.clear()
     underlying.shutdown()
   }
 
@@ -111,26 +130,26 @@ final class CachingProvider private (
     context: OFEvaluationContext,
     evaluate: => ProviderEvaluation[A]
   ): ProviderEvaluation[A] = {
-    val ck = CacheKey(key, flagType, contextFingerprint(context))
-    // Register the evaluation thunk before calling cache.get. On a cache miss, the Lookup reads this thunk.
-    // zio-cache deduplicates concurrent Lookups for the same key, so only one Lookup runs. The try/finally
-    // ensures the evaluators entry is always removed — on cache hit (Lookup never runs) and on miss alike.
-    evaluators.put(ck, () => evaluate.asInstanceOf[ProviderEvaluation[Any]])
-    try
-      Unsafe.unsafe { implicit u =>
-        runtime.unsafe
-          .run(
-            cache.contains(ck).flatMap { hit =>
-              cache
-                .get(ck)
-                .map(_.asInstanceOf[ProviderEvaluation[A]])
-                .map(r => if (hit) withCachedReason(r) else r)
-            }
-          )
-          .getOrThrowFiberFailure()
-      }
-    finally
-      evaluators.remove(ck)
+    val ck =
+      new CacheKey(key, flagType, contextFingerprint(context), () => evaluate.asInstanceOf[ProviderEvaluation[Any]])
+    Unsafe.unsafe { implicit u =>
+      runtime.unsafe
+        .run(
+          cache.contains(ck).flatMap { hit =>
+            cache
+              .get(ck)
+              // zio-cache stores the completed lookup Exit, failures included. Without this invalidation a
+              // single transient delegate exception would be replayed for the rest of the TTL.
+              .onError(_ => cache.invalidate(ck))
+              // Error *results* (errorCode set, no exception) are returned to this caller but not kept either:
+              // serving an error from cache would delay recovery by up to the TTL.
+              .tap(r => ZIO.when(r.getErrorCode != null)(cache.invalidate(ck)))
+              .map(_.asInstanceOf[ProviderEvaluation[A]])
+              .map(r => if (hit) withCachedReason(r) else r)
+          }
+        )
+        .getOrThrowFiberFailure()
+    }
   }
 
   override def getBooleanEvaluation(
@@ -181,19 +200,14 @@ object CachingProvider {
   def make(underlying: EventProvider, config: CachingConfig = CachingConfig()): UIO[CachingProvider] =
     for {
       rt <- ZIO.runtime[Any]
-      evaluators = new ConcurrentHashMap[CacheKey, () => ProviderEvaluation[Any]]()
       cache <- Cache.make(
         config.maxEntries,
         config.ttl,
-        Lookup[CacheKey, Any, Throwable, ProviderEvaluation[Any]] { ck =>
-          ZIO.attempt {
-            val eval = evaluators.remove(ck)
-            if (eval == null) throw new IllegalStateException(s"No evaluator registered for $ck")
-            eval()
-          }
-        }
+        // The key carries the delegate call for this evaluation; zio-cache deduplicates concurrent
+        // lookups for the same logical key, so the delegate runs once per miss.
+        Lookup[CacheKey, Any, Throwable, ProviderEvaluation[Any]](ck => ZIO.attemptBlocking(ck.evaluate()))
       )
-    } yield new CachingProvider(underlying, config, cache, evaluators, rt)
+    } yield new CachingProvider(underlying, config, cache, rt)
 
   /** Create a CachingProvider (convenience, requires ZIO runtime). */
   def apply(underlying: EventProvider, config: CachingConfig = CachingConfig()): CachingProvider = {

--- a/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
@@ -323,6 +323,79 @@ object CachingProviderSpec extends ZIOSpecDefault {
           assertTrue(underlying.evaluationCount.get() == 1)
       }
     ),
+    suite("Failure handling (#175)")(
+      test("a delegate exception is not served from cache — next evaluation retries the delegate") {
+        val failFirst = new java.util.concurrent.atomic.AtomicBoolean(true)
+        val underlying = new CountingProvider(Map("flag" -> true)) {
+          override def getBooleanEvaluation(
+            key: String,
+            defaultValue: java.lang.Boolean,
+            c: OFEvaluationContext
+          ): ProviderEvaluation[java.lang.Boolean] = {
+            if (failFirst.getAndSet(false)) {
+              evaluationCount.incrementAndGet()
+              throw new RuntimeException("transient outage")
+            }
+            super.getBooleanEvaluation(key, defaultValue, c)
+          }
+        }
+        for {
+          cached <- CachingProvider.make(underlying, CachingConfig(ttl = 1.minute))
+          first  <- ZIO.attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx)).exit
+          second <- ZIO.attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx))
+        } yield assertTrue(
+          first.isFailure,
+          second.getValue == true,
+          underlying.evaluationCount.get() == 2
+        )
+      },
+      test("an evaluation that resolves with an error code is returned but not cached") {
+        val errorFirst = new java.util.concurrent.atomic.AtomicBoolean(true)
+        val underlying = new CountingProvider(Map("flag" -> true)) {
+          override def getBooleanEvaluation(
+            key: String,
+            defaultValue: java.lang.Boolean,
+            c: OFEvaluationContext
+          ): ProviderEvaluation[java.lang.Boolean] =
+            if (errorFirst.getAndSet(false)) {
+              evaluationCount.incrementAndGet()
+              ProviderEvaluation
+                .builder[java.lang.Boolean]()
+                .value(defaultValue)
+                .reason("ERROR")
+                .errorCode(dev.openfeature.sdk.ErrorCode.GENERAL)
+                .errorMessage("upstream hiccup")
+                .build()
+            } else super.getBooleanEvaluation(key, defaultValue, c)
+        }
+        for {
+          cached <- CachingProvider.make(underlying, CachingConfig(ttl = 1.minute))
+          first  <- ZIO.attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx))
+          second <- ZIO.attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx))
+          third  <- ZIO.attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx))
+        } yield assertTrue(
+          first.getErrorCode != null,
+          second.getValue == true,
+          second.getErrorCode == null,
+          third.getReason == "CACHED",
+          underlying.evaluationCount.get() == 2
+        )
+      },
+      test("high-contention same-key evaluations never fail with a registration race") {
+        // The previous implementation handed the lookup its thunk via a shared mutable map; under contention a
+        // caller's cleanup could remove another caller's thunk, surfacing IllegalStateException and caching it.
+        for {
+          underlying <- ZIO.succeed(new CountingProvider(Map("flag" -> true), delay = Some(5.millis)))
+          cached     <- CachingProvider.make(underlying, CachingConfig(ttl = 50.millis))
+          // Many waves of concurrent calls across TTL expirations to repeatedly exercise the miss path
+          results <- ZIO.foreach(1 to 5) { _ =>
+            ZIO.collectAllPar(
+              (1 to 30).map(_ => ZIO.attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx)).exit)
+            ) <* ZIO.sleep(60.millis)
+          }
+        } yield assertTrue(results.flatten.forall(_.isSuccess))
+      }
+    ),
     suite("Lifecycle")(
       test("metadata includes underlying provider name") {
         val underlying = new CountingProvider(Map.empty)


### PR DESCRIPTION
## Summary

Two related defects rooted in the same design:

1. **Failures were cached for the full TTL.** zio-cache stores the completed lookup Exit — success or failure — so a single transient delegate exception poisoned that flag+context key for up to `ttl` (default 5 minutes), replaying the error instead of retrying the delegate.
2. **The evaluator side-channel raced under contention.** The lookup thunk was smuggled through a shared `ConcurrentHashMap` (`put` → `cache.get` → `finally remove`); one caller's cleanup could remove another caller's thunk before its Lookup ran, producing `IllegalStateException("No evaluator registered")` — which then got cached per defect 1.

## Changes

- `CacheKey` now carries the evaluation thunk directly, excluded from `equals`/`hashCode` (logical identity stays flagKey + flagType + contextFingerprint). The `Lookup` simply runs `ck.evaluate()` on the blocking pool. The `evaluators` map is gone, and with it the race.
- A failed `cache.get` invalidates the entry before rethrowing (`onError`), so the next evaluation retries the delegate.
- Evaluations that *resolve* with an error code are returned to the caller but also invalidated — serving an error result from cache would delay recovery by up to the TTL.
- Concurrent dedup of successful lookups is preserved (zio-cache still deduplicates same-key lookups).

## Tests

New "Failure handling" suite:
- delegate throws once then recovers → first call fails, second call reaches the delegate and succeeds
- delegate resolves with an error code once → returned, not cached; subsequent success is cached normally
- 5 waves x 30 concurrent same-key evaluations across TTL expirations all succeed (previously could surface the registration race)

Existing dedup/TTL/eviction tests unchanged and green.

Fixes #175