### PR TITLE
Propagate wrapped-provider events through extras wrappers

### DIFF
--- a/extras/src/main/scala/dev/openfeature/sdk/EventProviderBridge.scala
+++ b/extras/src/main/scala/dev/openfeature/sdk/EventProviderBridge.scala
@@ -1,0 +1,27 @@
+package dev.openfeature.sdk
+
+import dev.openfeature.sdk.internal.TriConsumer
+
+/** Accessor for the Java SDK's package-private `EventProvider.attach`/`detach`.
+  *
+  * Provider wrappers (CachingProvider, CircuitBreakerProvider) hold a delegate that is never registered with an
+  * `OpenFeatureAPI`, so events the delegate emits would otherwise go nowhere — the SDK only attaches to the provider it
+  * registers (the wrapper). This object lives in the `dev.openfeature.sdk` package (same pattern as
+  * `OpenFeatureAPIFactory`) to reach the package-private attach hook and forward delegate emissions to the wrapper.
+  *
+  * A delegate supports exactly one attachment; wrapping a provider takes ownership of its event channel. Registering
+  * the same delegate instance directly with an API while it is wrapped is unsupported (the SDK's own attach would
+  * fail).
+  */
+object EventProviderBridge {
+
+  /** Forward every event emitted by `delegate` to `onEvent`. Runs on the delegate's emitter executor. */
+  def attach(delegate: EventProvider, onEvent: (ProviderEvent, ProviderEventDetails) => Unit): Unit =
+    delegate.attach(new TriConsumer[EventProvider, ProviderEvent, ProviderEventDetails] {
+      override def accept(p: EventProvider, event: ProviderEvent, details: ProviderEventDetails): Unit =
+        onEvent(event, details)
+    })
+
+  /** Remove the attachment installed by [[attach]]. */
+  def detach(delegate: EventProvider): Unit = delegate.detach()
+}

--- a/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
@@ -2,15 +2,19 @@ package zio.openfeature.extras
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
+  ProviderEvent => JavaProviderEvent,
   EventProvider,
+  EventProviderBridge,
   Metadata,
   ProviderEvaluation,
+  ProviderEventDetails,
   ProviderState,
   Value
 }
 import zio._
 import zio.cache.{Cache, Lookup}
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.jdk.CollectionConverters._
 
 /** Configuration for the caching provider.
@@ -44,8 +48,12 @@ final private[extras] case class CacheKey(flagKey: String, flagType: String, con
   *   - TTL-based expiration
   *   - LRU eviction when max capacity is reached
   *
-  * Cached evaluations return `CACHED` as the resolution reason. Call `invalidateAll` when receiving
-  * `ConfigurationChanged` events from the underlying provider.
+  * Cached evaluations return `CACHED` as the resolution reason.
+  *
+  * Events emitted by the wrapped provider are forwarded through this wrapper (so `FeatureFlags.events` subscribers
+  * still see them), and a `PROVIDER_CONFIGURATION_CHANGED` emission automatically invalidates the cache. The wrapper
+  * takes ownership of the delegate's event channel on `initialize`; do not register the same delegate instance directly
+  * with an `OpenFeatureAPI` while it is wrapped.
   */
 final class CachingProvider private (
   val underlying: EventProvider,
@@ -63,10 +71,29 @@ final class CachingProvider private (
   @scala.annotation.nowarn("msg=deprecated")
   override def getState: ProviderState = underlying.getState
 
-  override def initialize(context: OFEvaluationContext): Unit =
+  private val delegateAttached = new AtomicBoolean(false)
+
+  // Forward delegate emissions upward (the delegate is never registered with an API, so without this its
+  // events go nowhere) and invalidate the cache on configuration changes so stale values aren't served
+  // for the remainder of the TTL.
+  private def onDelegateEvent(event: JavaProviderEvent, details: ProviderEventDetails): Unit = {
+    if (event == JavaProviderEvent.PROVIDER_CONFIGURATION_CHANGED)
+      Unsafe.unsafe { implicit u =>
+        runtime.unsafe.run(cache.invalidateAll).getOrThrowFiberFailure()
+      }
+    emit(event, details)
+    ()
+  }
+
+  override def initialize(context: OFEvaluationContext): Unit = {
+    if (delegateAttached.compareAndSet(false, true))
+      EventProviderBridge.attach(underlying, onDelegateEvent)
     underlying.initialize(context)
+  }
 
   override def shutdown(): Unit = {
+    if (delegateAttached.compareAndSet(true, false))
+      scala.util.Try(EventProviderBridge.detach(underlying))
     Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(cache.invalidateAll).getOrThrowFiberFailure()
     }

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
@@ -2,9 +2,12 @@ package zio.openfeature.extras
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
+  ProviderEvent => JavaProviderEvent,
   EventProvider,
+  EventProviderBridge,
   Metadata,
   ProviderEvaluation,
+  ProviderEventDetails,
   ProviderState,
   Value
 }
@@ -54,10 +57,15 @@ final case class CircuitBreakerProviderConfig(
   * fail immediately (< 1ms) without calling the delegate. This enables fast failover when composed with `MultiProvider`
   * and `FirstSuccessfulStrategy`.
   *
-  * State transitions happen via two mechanisms:
+  * State transitions happen via three mechanisms:
   *   - '''Failure-count''': after `failureThreshold` consecutive evaluation failures, the circuit opens.
-  *   - '''State-driven''': before each evaluation, the delegate's `getState()` is checked. If `ERROR` or `FATAL`, the
-  *     circuit opens immediately without waiting for failures.
+  *   - '''State-driven''': before an evaluation (rate-limited by `stateCheckInterval`), the delegate's `getState()` is
+  *     checked. If `ERROR` or `FATAL`, the circuit opens immediately without waiting for failures.
+  *   - '''Event-driven''': events emitted by the delegate feed the breaker directly — `PROVIDER_ERROR` trips it,
+  *     `PROVIDER_READY` resets an externally-opened circuit, `PROVIDER_STALE` applies `stalePolicy`. Delegate events
+  *     are also re-emitted through this wrapper so downstream subscribers still see them. The wrapper takes ownership
+  *     of the delegate's event channel on `initialize`; do not register the same delegate instance directly with an
+  *     `OpenFeatureAPI` while it is wrapped.
   *
   * In open state, after `resetTimeout` elapses, the circuit transitions to half-open and allows a single probe
   * evaluation through. On success the circuit closes; on failure it re-opens.
@@ -88,8 +96,31 @@ final class CircuitBreakerProvider private (
     case _: CircuitState.HalfOpen => ProviderState.STALE
   }
 
+  private val delegateAttached = new java.util.concurrent.atomic.AtomicBoolean(false)
+
+  // Forward delegate emissions upward (the delegate is never registered with an API, so without this its
+  // events go nowhere) and feed them into the breaker so an unhealthy delegate is detected as soon as it
+  // says so, not only via polling or evaluation failures.
+  private def onDelegateEvent(event: JavaProviderEvent, details: ProviderEventDetails): Unit = {
+    event match {
+      case JavaProviderEvent.PROVIDER_ERROR => breaker.trip()
+      case JavaProviderEvent.PROVIDER_READY => breaker.reset()
+      case JavaProviderEvent.PROVIDER_STALE =>
+        config.stalePolicy match {
+          case StalePolicy.Open     => breaker.trip()
+          case StalePolicy.HalfOpen => breaker.transitionToHalfOpen()
+          case StalePolicy.Ignore   => ()
+        }
+      case _ => ()
+    }
+    emit(event, details)
+    ()
+  }
+
   override def initialize(context: OFEvaluationContext): Unit =
     try {
+      if (delegateAttached.compareAndSet(false, true))
+        EventProviderBridge.attach(underlying, onDelegateEvent)
       underlying.initialize(context)
       checkDelegateState()
     } catch {
@@ -98,7 +129,11 @@ final class CircuitBreakerProvider private (
         throw e
     }
 
-  override def shutdown(): Unit = underlying.shutdown()
+  override def shutdown(): Unit = {
+    if (delegateAttached.compareAndSet(true, false))
+      scala.util.Try(EventProviderBridge.detach(underlying))
+    underlying.shutdown()
+  }
 
   override def getBooleanEvaluation(
     key: String,

--- a/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
@@ -323,6 +323,50 @@ object CachingProviderSpec extends ZIOSpecDefault {
           assertTrue(underlying.evaluationCount.get() == 1)
       }
     ),
+    suite("Delegate event propagation (#176)")(
+      test("delegate CONFIGURATION_CHANGED invalidates the cache") {
+        class EmittingProvider extends CountingProvider(Map("flag" -> true)) {
+          def fireConfigChanged(): Unit = {
+            emitProviderConfigurationChanged(dev.openfeature.sdk.ProviderEventDetails.builder().build())
+            ()
+          }
+        }
+        for {
+          underlying <- ZIO.succeed(new EmittingProvider)
+          cached     <- CachingProvider.make(underlying, CachingConfig(ttl = 10.minutes))
+          _          <- ZIO.attemptBlocking(cached.initialize(ctx))
+          _          <- ZIO.attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx))
+          r2         <- ZIO.attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx))
+          _          <- ZIO.succeed(underlying.fireConfigChanged())
+          // The emission runs on the delegate's emitter executor; poll until the cache misses again
+          _ <- ZIO
+            .attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx))
+            .repeatUntil(_.getReason != "CACHED")
+            .timeoutFail(new RuntimeException("cache was never invalidated"))(10.seconds)
+        } yield assertTrue(r2.getReason == "CACHED", underlying.evaluationCount.get() >= 2)
+      },
+      test("delegate events are re-emitted through the wrapper") {
+        class EmittingProvider extends CountingProvider(Map("flag" -> true)) {
+          def fireStale(): Unit = {
+            emitProviderStale(dev.openfeature.sdk.ProviderEventDetails.builder().message("stale!").build())
+            ()
+          }
+        }
+        val seen = new java.util.concurrent.ConcurrentLinkedQueue[dev.openfeature.sdk.ProviderEvent]()
+        for {
+          underlying <- ZIO.succeed(new EmittingProvider)
+          cached     <- CachingProvider.make(underlying)
+          // Stand in for the SDK: attach to the wrapper the way OpenFeatureAPI would on registration
+          _ <- ZIO.succeed(dev.openfeature.sdk.EventProviderBridge.attach(cached, (e, _) => { seen.add(e); () }))
+          _ <- ZIO.attemptBlocking(cached.initialize(ctx))
+          _ <- ZIO.succeed(underlying.fireStale())
+          _ <- ZIO
+            .succeed(seen.contains(dev.openfeature.sdk.ProviderEvent.PROVIDER_STALE))
+            .repeatUntil(identity)
+            .timeoutFail(new RuntimeException("delegate event was not re-emitted"))(10.seconds)
+        } yield assertTrue(seen.contains(dev.openfeature.sdk.ProviderEvent.PROVIDER_STALE))
+      }
+    ),
     suite("Lifecycle")(
       test("metadata includes underlying provider name") {
         val underlying = new CountingProvider(Map.empty)

--- a/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerProviderSpec.scala
@@ -344,6 +344,71 @@ object CircuitBreakerProviderSpec extends ZIOSpecDefault {
         assertTrue(result.getValue == true)
       }
     ),
+    suite("Delegate event propagation (#176)")(
+      test("delegate PROVIDER_ERROR event trips the circuit without an evaluation failure") {
+        // Asserts on the breaker directly: evaluating would re-poll the delegate's (READY) state,
+        // which legitimately resets an externally-opened circuit.
+        class EmittingProvider extends FailableProvider(Map("flag" -> true)) {
+          def fireError(): Unit = {
+            emitProviderError(dev.openfeature.sdk.ProviderEventDetails.builder().message("boom").build())
+            ()
+          }
+        }
+        val underlying = new EmittingProvider
+        val cb         = CircuitBreakerProvider(underlying)
+        for {
+          _ <- ZIO.attemptBlocking(cb.initialize(ctx))
+          _ <- ZIO.succeed(underlying.fireError())
+          // Emission is async; poll until the breaker opens
+          _ <- ZIO
+            .succeed(cb.breaker.isOpen)
+            .repeatUntil(identity)
+            .timeoutFail(new RuntimeException("circuit never opened from delegate event"))(10.seconds)
+        } yield assertTrue(cb.breaker.isOpen, underlying.evaluationCount.get() == 0)
+      },
+      test("delegate PROVIDER_READY event closes an externally-opened circuit") {
+        class EmittingProvider extends FailableProvider(Map("flag" -> true)) {
+          def fireError(): Unit = { emitProviderError(dev.openfeature.sdk.ProviderEventDetails.builder().build()); () }
+          def fireReady(): Unit = { emitProviderReady(dev.openfeature.sdk.ProviderEventDetails.builder().build()); () }
+        }
+        val underlying = new EmittingProvider
+        val cb         = CircuitBreakerProvider(underlying)
+        for {
+          _ <- ZIO.attemptBlocking(cb.initialize(ctx))
+          _ <- ZIO.succeed(underlying.fireError())
+          _ <- ZIO
+            .succeed(cb.breaker.isOpen)
+            .repeatUntil(identity)
+            .timeoutFail(new RuntimeException("circuit never opened"))(10.seconds)
+          _ <- ZIO.succeed(underlying.fireReady())
+          _ <- ZIO
+            .succeed(cb.breaker.isClosed)
+            .repeatUntil(identity)
+            .timeoutFail(new RuntimeException("circuit never closed after recovery event"))(10.seconds)
+          result <- ZIO.attemptBlocking(cb.getBooleanEvaluation("flag", false, ctx))
+        } yield assertTrue(result.getValue == true)
+      },
+      test("delegate events are re-emitted through the wrapper") {
+        class EmittingProvider extends FailableProvider(Map("flag" -> true)) {
+          def fireConfigChanged(): Unit = {
+            emitProviderConfigurationChanged(dev.openfeature.sdk.ProviderEventDetails.builder().build())
+            ()
+          }
+        }
+        val underlying = new EmittingProvider
+        val cb         = CircuitBreakerProvider(underlying)
+        val seen       = new java.util.concurrent.ConcurrentLinkedQueue[dev.openfeature.sdk.ProviderEvent]()
+        for {
+          _ <- ZIO.succeed(dev.openfeature.sdk.EventProviderBridge.attach(cb, (e, _) => { seen.add(e); () }))
+          _ <- ZIO.attemptBlocking(cb.initialize(ctx))
+          _ <- ZIO.succeed(underlying.fireConfigChanged())
+          _ <- ZIO
+            .succeed(seen.contains(dev.openfeature.sdk.ProviderEvent.PROVIDER_CONFIGURATION_CHANGED))
+            .repeatUntil(identity)
+            .timeoutFail(new RuntimeException("delegate event was not re-emitted"))(10.seconds)
+        } yield assertTrue(seen.contains(dev.openfeature.sdk.ProviderEvent.PROVIDER_CONFIGURATION_CHANGED))
+      }
+    ) @@ TestAspect.withLiveClock,
     suite("Lifecycle")(
       test("metadata includes underlying provider name") {
         val underlying = new FailableProvider()


### PR DESCRIPTION
## Summary

`CachingProvider` and `CircuitBreakerProvider` forwarded evaluations to their delegate but not *events*. The SDK attaches its event channel to the provider it registers — the wrapper — so events emitted by the wrapped delegate (CONFIGURATION_CHANGED, STALE, ERROR, READY) went nowhere. Consequences: the cache served stale values for up to the TTL after every config change (and the documented "call `invalidateAll` on ConfigurationChanged" advice was impossible to follow, since the event was unobservable), and downstream `FeatureFlags.events` subscribers never saw delegate events.

## Changes

- New `dev.openfeature.sdk.EventProviderBridge` (same package-access pattern as the existing `OpenFeatureAPIFactory`) exposing the SDK's package-private `EventProvider.attach`/`detach` for wrapper-to-delegate event forwarding.
- Both wrappers attach to the delegate on `initialize` (guarded by a CAS so re-init can't double-attach) and detach on `shutdown`. Every delegate event is re-emitted through the wrapper, so the SDK and `FeatureFlags.events` see it.
- `CachingProvider` additionally invalidates the whole cache on a delegate `PROVIDER_CONFIGURATION_CHANGED`.
- `CircuitBreakerProvider` additionally feeds delegate events into the breaker: `PROVIDER_ERROR` trips it, `PROVIDER_READY` resets an externally-opened circuit, `PROVIDER_STALE` applies the configured `stalePolicy` — unhealthy delegates are now detected as soon as they say so, not only via polling or evaluation failures.
- Documented on both wrappers that wrapping takes ownership of the delegate's event channel (a delegate supports exactly one attachment).

## Tests

New "Delegate event propagation" suites in both specs:
- delegate CONFIGURATION_CHANGED invalidates the cache (subsequent evaluation reaches the delegate again)
- delegate events are re-emitted through each wrapper (captured by attaching to the wrapper the way the SDK would)
- delegate PROVIDER_ERROR opens the breaker without any evaluation failing; PROVIDER_READY closes it again

Fixes #176