### PR TITLE
Registry: per-domain memoized init, typed errors, no lock across provider startup

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
@@ -7,16 +7,20 @@ trait FeatureFlagRegistry {
 
   /** Get or create a cached client for the given domain. If no provider was explicitly registered for this domain, the
     * default provider is used.
+    *
+    * Provider initialization happens at most once per domain (concurrent callers share the same build) and does not
+    * block clients of other domains. A failed initialization surfaces as
+    * `FeatureFlagError.ProviderInitializationFailed` and is not cached — a subsequent call retries.
     */
-  def getClient(domain: String): UIO[FeatureFlags]
+  def getClient(domain: String): IO[FeatureFlagError, FeatureFlags]
 
   /** Register (or replace) a provider for a domain. If a client already exists for the domain, the provider is
     * hot-swapped via `FeatureFlags.setProvider`.
     */
   def setProvider(domain: String, provider: OFFeatureProvider): IO[FeatureFlagError, Unit]
 
-  /** Get or create the default (no-domain) client. */
-  def defaultClient: UIO[FeatureFlags]
+  /** Get or create the default (no-domain) client. Same initialization semantics as [[getClient]]. */
+  def defaultClient: IO[FeatureFlagError, FeatureFlags]
 
   /** Register a ZIO API-level hook on all existing and future domain clients. */
   def addZioApiHook(hook: FeatureHook): UIO[Unit]
@@ -24,7 +28,7 @@ trait FeatureFlagRegistry {
 
 object FeatureFlagRegistry {
 
-  def getClient(domain: String): ZIO[FeatureFlagRegistry, Nothing, FeatureFlags] =
+  def getClient(domain: String): ZIO[FeatureFlagRegistry, FeatureFlagError, FeatureFlags] =
     ZIO.serviceWithZIO(_.getClient(domain))
 
   def setProvider(
@@ -33,7 +37,7 @@ object FeatureFlagRegistry {
   ): ZIO[FeatureFlagRegistry, FeatureFlagError, Unit] =
     ZIO.serviceWithZIO(_.setProvider(domain, provider))
 
-  def defaultClient: ZIO[FeatureFlagRegistry, Nothing, FeatureFlags] =
+  def defaultClient: ZIO[FeatureFlagRegistry, FeatureFlagError, FeatureFlags] =
     ZIO.serviceWithZIO(_.defaultClient)
 
   def addZioApiHook(hook: FeatureHook): ZIO[FeatureFlagRegistry, Nothing, Unit] =
@@ -44,9 +48,9 @@ object FeatureFlagRegistry {
       for {
         api            <- ZIO.succeed(OpenFeatureAPIFactory.create())
         scope          <- ZIO.service[Scope]
-        clients        <- Ref.make(Map.empty[String, FeatureFlags])
+        clients        <- Ref.make(Map.empty[String, Promise[FeatureFlagError, FeatureFlags]])
         providers      <- Ref.make(Map.empty[String, OFFeatureProvider])
-        defaultRef     <- Ref.make(Option.empty[FeatureFlags])
+        defaultRef     <- Ref.make(Option.empty[Promise[FeatureFlagError, FeatureFlags]])
         lock           <- Semaphore.make(1)
         zioApiHooksRef <- Ref.make(List.empty[FeatureHook])
         registry = new FeatureFlagRegistryLive(
@@ -64,84 +68,134 @@ object FeatureFlagRegistry {
     }
 }
 
+/** Registry implementation.
+  *
+  * Concurrency design: the single `lock` only ever guards map/ref bookkeeping — never provider initialization. Each
+  * domain's client is memoized as a `Promise`; the first caller inserts the promise (under the lock) and runs the build
+  * outside the lock, so a slow provider for one domain cannot stall `getClient` for other domains. Concurrent callers
+  * for the same domain await the same promise, guaranteeing at most one build per domain. On build failure the promise
+  * is failed (typed) and removed, making the failure visible to all waiters while allowing later retries.
+  *
+  * Hook bookkeeping: completing a build's promise and registering its accumulated API hooks happens in one lock
+  * section, and `addZioApiHook` updates the hook list and notifies completed clients in another — so a hook is applied
+  * to every client exactly once regardless of interleaving with in-flight builds.
+  */
 final private class FeatureFlagRegistryLive(
   defaultProvider: OFFeatureProvider,
   api: OpenFeatureAPI,
   scope: Scope,
-  clients: Ref[Map[String, FeatureFlags]],
+  clients: Ref[Map[String, Promise[FeatureFlagError, FeatureFlags]]],
   providers: Ref[Map[String, OFFeatureProvider]],
-  defaultRef: Ref[Option[FeatureFlags]],
+  defaultRef: Ref[Option[Promise[FeatureFlagError, FeatureFlags]]],
   lock: Semaphore,
   zioApiHooksRef: Ref[List[FeatureHook]]
 ) extends FeatureFlagRegistry {
 
-  override def getClient(domain: String): UIO[FeatureFlags] =
-    lock.withPermit {
-      clients.get.flatMap(_.get(domain) match {
-        case Some(c) => Exit.succeed(c)
-        case None    => createDomainClient(domain)
-      })
-    }
+  override def getClient(domain: String): IO[FeatureFlagError, FeatureFlags] =
+    memoizedClient(
+      get = clients.get.map(_.get(domain)),
+      put = p => clients.update(_ + (domain -> p)),
+      remove = clients.update(_ - domain),
+      buildClient = buildClient(Some(domain))
+    )
+
+  override def defaultClient: IO[FeatureFlagError, FeatureFlags] =
+    memoizedClient(
+      get = defaultRef.get,
+      put = p => defaultRef.set(Some(p)),
+      remove = defaultRef.set(None),
+      buildClient = buildClient(None)
+    )
 
   override def setProvider(domain: String, provider: OFFeatureProvider): IO[FeatureFlagError, Unit] =
-    lock.withPermit {
-      clients.get.flatMap(_.get(domain) match {
-        case Some(client) =>
-          client
-            .setProvider(provider)
-            .tap(_ => providers.update(_ + (domain -> provider)))
-        case None =>
-          providers.update(_ + (domain -> provider))
-      })
-    }
-
-  override def defaultClient: UIO[FeatureFlags] =
-    lock.withPermit {
-      defaultRef.get.flatMap {
-        case Some(c) => Exit.succeed(c)
-        case None    => createDefaultClient
+    for {
+      existing <- lock.withPermit {
+        providers.update(_ + (domain -> provider)) *> clients.get.map(_.get(domain))
       }
-    }
+      // Hot-swap outside the lock: setProviderAndWait can take up to the init timeout and must not
+      // block unrelated registry calls. If a build for this domain is in flight, wait for it and swap
+      // the resulting client (the build may already have picked up the new provider; swapping to the
+      // same provider is harmless).
+      _ <- existing match {
+        case Some(promise) => promise.await.flatMap(_.setProvider(provider))
+        case None          => ZIO.unit
+      }
+    } yield ()
 
   override def addZioApiHook(hook: FeatureHook): UIO[Unit] =
     lock.withPermit {
       for {
-        _               <- zioApiHooksRef.update(_ :+ hook)
-        existingClients <- clients.get.map(_.values.toList)
-        defaultC        <- defaultRef.get
-        _               <- ZIO.foreachDiscard(existingClients ++ defaultC.toList)(_.addZioApiHook(hook))
+        _        <- zioApiHooksRef.update(_ :+ hook)
+        domainPs <- clients.get.map(_.values.toList)
+        defaultP <- defaultRef.get
+        // Only clients whose build already completed (successfully) get the hook here; in-flight builds
+        // read the updated hook list when they complete (both happen under this lock).
+        _ <- ZIO.foreachDiscard(domainPs ++ defaultP.toList) { p =>
+          p.poll.flatMap {
+            case Some(io) => io.foldZIO(_ => ZIO.unit, _.addZioApiHook(hook))
+            case None     => ZIO.unit
+          }
+        }
       } yield ()
     }
 
-  private def createDomainClient(domain: String): UIO[FeatureFlags] =
+  /** Get-or-insert the memoized promise under the lock, build outside it (first caller only), await. */
+  private def memoizedClient(
+    get: UIO[Option[Promise[FeatureFlagError, FeatureFlags]]],
+    put: Promise[FeatureFlagError, FeatureFlags] => UIO[Unit],
+    remove: UIO[Unit],
+    buildClient: IO[FeatureFlagError, FeatureFlags]
+  ): IO[FeatureFlagError, FeatureFlags] =
     for {
-      pm <- providers.get
-      provider = pm.getOrElse(domain, defaultProvider)
-      client <- scope
-        .extend[Any](
-          FeatureFlags.build(
-            provider,
-            domain = Some(domain),
-            version = None,
-            initialHooks = Nil,
-            statusRef = None,
-            addShutdownFinalizer = false,
-            apiOverride = Some(api)
-          )
-        )
-        .orDie
-      apiHooks <- zioApiHooksRef.get
-      _        <- client.addZioApiHooks(apiHooks)
-      _        <- clients.update(_ + (domain -> client))
+      inserted <- lock.withPermit {
+        get.flatMap {
+          case Some(p) => ZIO.succeed((p, false))
+          case None    => Promise.make[FeatureFlagError, FeatureFlags].flatMap(p => put(p).as((p, true)))
+        }
+      }
+      promise = inserted._1
+      isOwner = inserted._2
+      // The build runs on its own fiber in the registry scope: interrupting the caller that happened to
+      // trigger the build must not strand the other fibers awaiting the same promise. (Making the build
+      // uninterruptible on the caller fiber is not an option — fibers forked inside it, like buildAsync's
+      // init watchdog, would inherit uninterruptibility and block scope close.)
+      _      <- ZIO.when(isOwner)(runBuild(buildClient, promise, remove).forkIn(scope))
+      client <- promise.await
     } yield client
 
-  private def createDefaultClient: UIO[FeatureFlags] =
+  /** Run a build and settle its promise. If the registry scope closes mid-build, the promise is interrupted so awaiting
+    * fibers unblock. The build itself is bounded by the init timeout.
+    */
+  private def runBuild(
+    buildClient: IO[FeatureFlagError, FeatureFlags],
+    promise: Promise[FeatureFlagError, FeatureFlags],
+    remove: UIO[Unit]
+  ): UIO[Unit] =
+    buildClient
+      .foldZIO(
+        err => lock.withPermit(remove *> promise.fail(err)).unit,
+        client =>
+          lock.withPermit {
+            zioApiHooksRef.get.flatMap(client.addZioApiHooks) *> promise.succeed(client)
+          }.unit
+      )
+      .onInterrupt(promise.interrupt)
+
+  // Registers the provider asynchronously and awaits readiness here. The Java SDK's `setProviderAndWait`
+  // holds a STATIC write lock for the whole blocking initialization, serializing provider startup across
+  // every domain (and every OpenFeatureAPI instance in the JVM) — the async `setProvider` only holds it
+  // for the registration itself, so domains genuinely initialize in parallel.
+  private def buildClient(domain: Option[String]): IO[FeatureFlagError, FeatureFlags] =
     for {
+      provider <- domain match {
+        case Some(d) => providers.get.map(_.getOrElse(d, defaultProvider))
+        case None    => ZIO.succeed(defaultProvider)
+      }
       client <- scope
         .extend[Any](
-          FeatureFlags.build(
-            defaultProvider,
-            domain = None,
+          FeatureFlags.buildAsync(
+            provider,
+            domain = domain,
             version = None,
             initialHooks = Nil,
             statusRef = None,
@@ -149,9 +203,46 @@ final private class FeatureFlagRegistryLive(
             apiOverride = Some(api)
           )
         )
-        .orDie
-      apiHooks <- zioApiHooksRef.get
-      _        <- client.addZioApiHooks(apiHooks)
-      _        <- defaultRef.set(Some(client))
+        .mapError(t => FeatureFlagError.ProviderInitializationFailed(t))
+      _ <- awaitReady(client)
     } yield client
+
+  /** Wait for the freshly registered provider to become usable, failing typed on error states or timeout.
+    *
+    * Deliberately polls with blocking-pool sleeps instead of `ZIO.sleep`/`Schedule`: registry construction must work
+    * inside zio-test suites where the TestClock is frozen, exactly like the previous blocking `setProviderAndWait` did.
+    * The loop is bounded by the default init timeout.
+    */
+  private def awaitReady(client: FeatureFlags): IO[FeatureFlagError, Unit] = {
+    val pollMillis = 10L
+    val maxPolls   = math.max(1L, FeatureFlags.DefaultInitTimeout.toMillis / pollMillis)
+
+    val check: IO[FeatureFlagError, Option[Unit]] = client.providerStatus.flatMap {
+      case ProviderStatus.Ready | ProviderStatus.Stale => ZIO.some(())
+      case ProviderStatus.Fatal | ProviderStatus.Error =>
+        ZIO.fail(
+          FeatureFlagError.ProviderInitializationFailed(
+            new IllegalStateException("Provider entered an error state during initialization")
+          )
+        )
+      case _ => ZIO.none
+    }
+
+    def loop(remaining: Long): IO[FeatureFlagError, Unit] =
+      check.flatMap {
+        case Some(_) => ZIO.unit
+        case None if remaining <= 0 =>
+          ZIO.fail(
+            FeatureFlagError.ProviderInitializationFailed(
+              new java.util.concurrent.TimeoutException(
+                s"Provider initialization exceeded ${FeatureFlags.DefaultInitTimeout}"
+              )
+            )
+          )
+        case None =>
+          ZIO.attemptBlocking(Thread.sleep(pollMillis)).orDie *> loop(remaining - 1)
+      }
+
+    loop(maxPolls)
+  }
 }

--- a/core/src/test/scala/zio/openfeature/FeatureFlagRegistrySpec.scala
+++ b/core/src/test/scala/zio/openfeature/FeatureFlagRegistrySpec.scala
@@ -196,6 +196,72 @@ object FeatureFlagRegistrySpec extends ZIOSpecDefault {
         )
       }
     },
+    test("getClient for one domain is not blocked by a slow provider init in another (#182)") {
+      ZIO.scoped {
+        val slowStarted     = new java.util.concurrent.CountDownLatch(1)
+        val slowGate        = new java.util.concurrent.CountDownLatch(1)
+        val defaultProvider = new SimpleProvider("Default", Map("flag" -> "fast"))
+        val slowProvider = new SimpleProvider("Slow", Map("flag" -> "slow")) {
+          override def initialize(ctx: OFEvaluationContext): Unit = {
+            slowStarted.countDown()
+            slowGate.await() // hold the build until the fast domain has been served
+          }
+        }
+        for {
+          registry  <- registryLayer(defaultProvider).build.map(_.get[FeatureFlagRegistry])
+          _         <- registry.setProvider("slow", slowProvider)
+          slowFiber <- registry.getClient("slow").fork
+          // Ensure the slow build is actually in flight before asking for the fast domain
+          _    <- ZIO.attemptBlocking(slowStarted.await()).orDie
+          fast <- registry.getClient("fast") // must complete while "slow" is still initializing
+          v    <- fast.string("flag", default = "none")
+          _    <- ZIO.succeed(slowGate.countDown())
+          slow <- slowFiber.join
+          v2   <- slow.string("flag", default = "none")
+        } yield assertTrue(v == "fast", v2 == "slow")
+      }
+    },
+    test("concurrent getClient calls for the same domain build the client exactly once (#182)") {
+      ZIO.scoped {
+        val initCount = new java.util.concurrent.atomic.AtomicInteger(0)
+        val provider = new SimpleProvider("Counting", Map("flag" -> true)) {
+          override def initialize(ctx: OFEvaluationContext): Unit = {
+            initCount.incrementAndGet()
+            Thread.sleep(50) // widen the race window
+          }
+        }
+        for {
+          registry <- registryLayer(provider).build.map(_.get[FeatureFlagRegistry])
+          clientsR <- ZIO.collectAllPar((1 to 8).map(_ => registry.getClient("same")))
+        } yield assertTrue(
+          initCount.get() == 1,
+          clientsR.distinct.size == 1
+        )
+      }
+    },
+    test("failed init surfaces as a typed error and a later getClient can retry (#182)") {
+      ZIO.scoped {
+        val defaultProvider = new SimpleProvider("Default", Map("flag" -> "default"))
+        val failingProvider = new SimpleProvider("Failing", Map.empty) {
+          override def initialize(ctx: OFEvaluationContext): Unit =
+            throw new RuntimeException("boom")
+        }
+        val goodProvider = new SimpleProvider("Good", Map("flag" -> "good"))
+        for {
+          registry <- registryLayer(defaultProvider).build.map(_.get[FeatureFlagRegistry])
+          _        <- registry.setProvider("retryable", failingProvider)
+          first    <- registry.getClient("retryable").either
+          // The failed build is not memoized: register a working provider and retry
+          _      <- registry.setProvider("retryable", goodProvider)
+          client <- registry.getClient("retryable")
+          v      <- client.string("flag", default = "none")
+        } yield assertTrue(
+          first.isLeft,
+          first.left.exists(_.isInstanceOf[FeatureFlagError.ProviderInitializationFailed]),
+          v == "good"
+        )
+      }
+    },
     test("provider metadata reflects the domain provider") {
       ZIO.scoped {
         val defaultProvider = new SimpleProvider("Default", Map.empty)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -596,6 +596,8 @@ yield ()
 ### How it works
 
 - **Client caching** — `getClient` returns the same `FeatureFlags` instance for a given domain. State (hooks, context, event handlers) is preserved.
+- **Per-domain, non-blocking init** — each domain's client is built once, outside the registry lock; a slow or failing provider in one domain never blocks `getClient` for another. Concurrent callers for the same domain share a single initialization.
+- **Typed errors** — `getClient`, `defaultClient`, and `setProvider` return `IO[FeatureFlagError, _]`; a provider that fails to initialize surfaces `FeatureFlagError.ProviderInitializationFailed` (rather than dying), and a later call retries the build.
 - **Default fallback** — domains without an explicit provider use the default provider passed to `fromProvider`.
 - **Isolated API** — the registry creates its own `OpenFeatureAPI` instance, avoiding interference with other registries or standalone `FeatureFlags` layers.
 - **Lifecycle** — when the registry's scope closes, all managed providers are shut down.


### PR DESCRIPTION
## Summary

Three problems in `FeatureFlagRegistryLive`:

1. `getClient`/`defaultClient` held the single registry semaphore **while initializing the provider** (blocking, up to the 30s init timeout) — one slow provider stalled every other registry call.
2. Init failures were turned into defects via `.orDie` behind `UIO` signatures; callers couldn't handle, retry, or report them.
3. Worse than the registry lock: the Java SDK's `setProviderAndWait` holds a **static JVM-global write lock for the entire blocking initialization**, so even with the registry lock fixed, sync registrations serialized across all domains (and all `OpenFeatureAPI` instances). Discovered via a deadlocking test during this work.

## Changes

- **Per-domain memoized builds**: each domain's client is a `Promise`; the first caller inserts it under the lock and the build runs *outside* the lock on a fiber forked into the registry scope (so interrupting the triggering caller doesn't strand other waiters, and registry shutdown interrupts in-flight builds cleanly — note the build must not be `uninterruptible` on the caller fiber, or fibers forked inside it would inherit that and block scope close). Concurrent same-domain callers share one build; failed builds are failed typed and removed, so a later call retries.
- **Typed errors**: `getClient`/`defaultClient`/`setProvider` now return `IO[FeatureFlagError, _]` (breaking signature change, pre-1.0); init failures surface as `ProviderInitializationFailed`.
- **Async registration + readiness wait**: the registry registers via the SDK's non-blocking `setProvider` (static lock held only for the registration itself) and awaits readiness by polling provider status with blocking-pool sleeps — deliberately not `ZIO.sleep`/`Schedule`, so registry construction keeps working under zio-test's frozen TestClock exactly like the old blocking path did. Error/Fatal states and the 30s timeout fail typed.
- **Hook consistency**: completing a build (register accumulated hooks + succeed promise) and `addZioApiHook` (append + notify completed clients) each happen in single lock sections, so a hook reaches every client exactly once regardless of interleaving.

## Tests

New tests in `FeatureFlagRegistrySpec`:
- a domain whose provider init is gated on a latch does not block `getClient` for another domain (deadlocked under the old sync/static-lock design)
- 8 concurrent `getClient` calls for one domain initialize the provider exactly once and share one instance
- failed init returns `ProviderInitializationFailed` and a later `getClient` (after `setProvider` with a working provider) succeeds

All existing registry, hook, and full-suite tests green.

Fixes #182