### PR TITLE
Optimizely provider: explicit lifecycle, fail loudly on init after shutdown

### DIFF
--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
@@ -14,7 +14,7 @@ import dev.openfeature.sdk.{
   Structure,
   Value
 }
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 import scala.jdk.CollectionConverters._
 import scala.util.Try
@@ -52,10 +52,13 @@ final class OptimizelyFeatureProvider private[optimizely] (
   // Public construction is via the OptimizelyProvider factory in this package — the constructor is private to keep
   // lifecycle invariants (single initialize, registered handler) intact.
 
+  import OptimizelyFeatureProvider.Lifecycle
+
   private val stateRef           = new AtomicReference[ProviderState](ProviderState.NOT_READY)
-  private val initialized        = new AtomicBoolean(false)
+  private val lifecycle          = new AtomicReference[Lifecycle](Lifecycle.Fresh)
   private val notificationHandle = new AtomicInteger(-1)
-  private val initLatch          = new CountDownLatch(1)
+  // Replaced on re-initialization (caller-managed clients only); each init cycle gets a single-use latch.
+  private val initLatchRef = new AtomicReference(new CountDownLatch(1))
 
   @scala.annotation.nowarn("msg=deprecated")
   override def getMetadata: Metadata = new Metadata {
@@ -66,7 +69,27 @@ final class OptimizelyFeatureProvider private[optimizely] (
   override def getState: ProviderState = stateRef.get()
 
   override def initialize(ctx: OFEvaluationContext): Unit = {
-    if (!initialized.compareAndSet(false, true)) return
+    // Lifecycle transitions: Fresh -> Initialized (first init), Initialized -> no-op (idempotent),
+    // ShutDown -> Initialized only for caller-managed clients (closeOnShutdown = false). A provider whose
+    // client was closed on shutdown cannot be revived — fail loudly instead of silently never becoming
+    // READY (the Java SDK treats a non-throwing initialize as success, so a silent no-op here would leave
+    // every subsequent evaluation failing with PROVIDER_NOT_READY far from the cause).
+    val transitioned =
+      lifecycle.compareAndSet(Lifecycle.Fresh, Lifecycle.Initialized) || {
+        if (lifecycle.get() == Lifecycle.ShutDown) {
+          if (closeOnShutdown)
+            throw new IllegalStateException(
+              "OptimizelyFeatureProvider was shut down and its Optimizely client closed; create a new instance via OptimizelyProvider.make"
+            )
+          else if (lifecycle.compareAndSet(Lifecycle.ShutDown, Lifecycle.Initialized)) {
+            initLatchRef.set(new CountDownLatch(1)) // fresh single-use latch for this init cycle
+            true
+          } else false
+        } else false
+      }
+    if (!transitioned) return
+
+    val initLatch = initLatchRef.get()
 
     val handlerId = optimizely.addUpdateConfigNotificationHandler { _ =>
       // The latch is single-use; subsequent updates are CONFIGURATION_CHANGED only.
@@ -103,6 +126,7 @@ final class OptimizelyFeatureProvider private[optimizely] (
   }
 
   override def shutdown(): Unit = {
+    lifecycle.set(Lifecycle.ShutDown)
     val handle = notificationHandle.getAndSet(-1)
     if (handle > 0) {
       // Removing the handler is best-effort; if the notification center is already shut down we ignore.
@@ -294,6 +318,17 @@ final class OptimizelyFeatureProvider private[optimizely] (
 
 object OptimizelyFeatureProvider {
   val Name: String = "Optimizely"
+
+  /** Provider lifecycle: `Fresh -> Initialized -> ShutDown`, plus `ShutDown -> Initialized` for caller-managed clients.
+    * Tracked explicitly (instead of a boolean) so initialize-after-shutdown can fail loudly when the underlying client
+    * was closed.
+    */
+  sealed private[optimizely] trait Lifecycle
+  private[optimizely] object Lifecycle {
+    case object Fresh       extends Lifecycle
+    case object Initialized extends Lifecycle
+    case object ShutDown    extends Lifecycle
+  }
 
   /** Context attribute key callers can set to override which Optimizely variable is read for typed evaluations. */
   val VariableKeyAttribute: String = "openfeature.variableKey"

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderLifecycleSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderLifecycleSpec.scala
@@ -114,6 +114,46 @@ object OptimizelyProviderLifecycleSpec extends ZIOSpecDefault {
         )
       }
     },
+    test("initialize after shutdown fails loudly when the client was closed (#185)") {
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafile)))
+        val client   = buildClient(server)
+        val provider = new OptimizelyFeatureProvider(client, java.time.Duration.ofSeconds(3), closeOnShutdown = true)
+        val first    = tryInit(provider)
+        provider.shutdown()
+        val second = tryInit(provider)
+        assertTrue(
+          first.isRight,
+          // No silent no-op: re-registering a closed provider must surface immediately, not as
+          // PROVIDER_NOT_READY on every later evaluation.
+          second.isLeft,
+          second.left.exists(_.isInstanceOf[IllegalStateException]),
+          stateOf(provider) == ProviderState.NOT_READY
+        )
+      }
+    },
+    test("initialize after shutdown re-initializes when the client is caller-managed (#185)") {
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafile)))
+        val client   = buildClient(server)
+        val provider = new OptimizelyFeatureProvider(client, java.time.Duration.ofSeconds(3), closeOnShutdown = false)
+        val first    = tryInit(provider)
+        val stateAfterFirst = stateOf(provider)
+        provider.shutdown()
+        val stateAfterShutdown = stateOf(provider)
+        val second             = tryInit(provider)
+        val stateAfterSecond   = stateOf(provider)
+        try
+          assertTrue(
+            first.isRight,
+            stateAfterFirst == ProviderState.READY,
+            stateAfterShutdown == ProviderState.NOT_READY,
+            second.isRight,
+            stateAfterSecond == ProviderState.READY
+          )
+        finally client.close()
+      }
+    },
     test("shutdown before initialize — no exception, state stays NOT_READY") {
       withMockServer { server =>
         server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafile)))


### PR DESCRIPTION
## Summary

`OptimizelyFeatureProvider` guarded `initialize` with a single-shot `AtomicBoolean` that was never reset by `shutdown`. Re-registering a shut-down provider instance (e.g. swapped back via `FeatureFlags.setProvider`, or reused across registry domains) made the second `initialize()` return silently — the Java SDK treats a non-throwing initialize as success, so the provider was considered registered while stuck in `NOT_READY`, failing every evaluation with `PROVIDER_NOT_READY` far from the cause.

## Changes

A small explicit lifecycle replaces the boolean: `Fresh -> Initialized -> ShutDown`.

- `initialize` from `Initialized`: no-op (idempotency for concurrent/duplicate init preserved).
- `initialize` from `ShutDown` with `closeOnShutdown = true` (factory-built providers, client closed): throws `IllegalStateException` with a pointer to `OptimizelyProvider.make` — a loud immediate failure instead of a silent never-ready provider.
- `initialize` from `ShutDown` with `closeOnShutdown = false` (caller-managed client via `fromOptimizelyClient`): genuine re-initialization — a fresh single-use init latch is installed and the datafile-update notification handler is re-registered (it was removed by `shutdown`).

## Tests

Two new tests in `OptimizelyProviderLifecycleSpec` (WireMock-backed):
- init → shutdown → init with a closed client fails with `IllegalStateException`
- init → shutdown → init with a caller-managed client returns to `READY`

All existing lifecycle tests (idempotent init/shutdown, shutdown-before-init, state transitions, concurrent init) unchanged and green.

Fixes #185