### PR TITLE
Testkit: bounded SDK-event waits, replace layer sleep with ready handshake

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -452,7 +452,8 @@ object FeatureFlags {
     addShutdownFinalizer: Boolean,
     apiOverride: Option[OpenFeatureAPI] = None,
     evaluationTimeout: Option[Duration] = None,
-    initTimeout: Duration = DefaultInitTimeout
+    initTimeout: Duration = DefaultInitTimeout,
+    onReady: Option[java.util.concurrent.CountDownLatch] = None
   ): ZIO[Scope, Throwable, FeatureFlagsLive] =
     for {
       api <- ZIO.succeed(apiOverride.getOrElse(OpenFeatureAPI.getInstance()))
@@ -490,7 +491,8 @@ object FeatureFlags {
         state,
         api,
         swapLock,
-        evaluationTimeout = evaluationTimeout
+        onReady,
+        evaluationTimeout
       )
       _ <- ff.startEventBridge
     } yield ff
@@ -587,7 +589,8 @@ object FeatureFlags {
     provider: OFFeatureProvider,
     domain: String,
     statusRef: Ref[ProviderStatus],
-    api: Option[OpenFeatureAPI] = None
+    api: Option[OpenFeatureAPI] = None,
+    onReady: Option[java.util.concurrent.CountDownLatch] = None
   ): ZLayer[Scope, Throwable, FeatureFlags] =
     ZLayer.scoped(
       build(
@@ -597,7 +600,8 @@ object FeatureFlags {
         initialHooks = Nil,
         statusRef = Some(statusRef),
         addShutdownFinalizer = false,
-        apiOverride = api
+        apiOverride = api,
+        onReady = onReady
       )
     )
 

--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -219,24 +219,24 @@ final class TestFeatureProvider private (
 
   /** Set the provider status. For async test layers, setting Ready releases the init latch and waits for the Java SDK's
     * background `initialize()` thread to complete, ensuring the provider is fully ready before returning.
+    *
+    * The wait runs on the blocking pool with a bounded timeout: an unbounded `await` on a runtime thread could starve
+    * the ZIO runtime (and hang the whole suite) if the SDK never delivers PROVIDER_READY. On timeout this dies with a
+    * descriptive error instead — a fast, diagnosable failure.
     */
   def setStatus(status: ProviderStatus): UIO[Unit] =
-    statusRef.set(status) *> ZIO.succeed {
-      status match {
-        case ProviderStatus.Ready =>
+    statusRef.set(status) *> (status match {
+      case ProviderStatus.Ready =>
+        ZIO.succeed {
           state.set(ProviderState.READY)
           initLatch.foreach(_.countDown())
-          // Wait for the event bridge to receive PROVIDER_READY from the Java SDK.
-          // This confirms the SDK has fully processed the initialization and the
-          // provider is registered as ready — no sleep needed.
-          initDone.foreach(_.await())
-        case ProviderStatus.NotReady     => state.set(ProviderState.NOT_READY)
-        case ProviderStatus.Error        => state.set(ProviderState.ERROR)
-        case ProviderStatus.Stale        => state.set(ProviderState.STALE)
-        case ProviderStatus.Fatal        => state.set(ProviderState.FATAL)
-        case ProviderStatus.ShuttingDown => state.set(ProviderState.NOT_READY)
-      }
-    }
+        } *> TestFeatureProvider.awaitLatch(initDone, "PROVIDER_READY after setStatus(Ready)")
+      case ProviderStatus.NotReady     => ZIO.succeed(state.set(ProviderState.NOT_READY))
+      case ProviderStatus.Error        => ZIO.succeed(state.set(ProviderState.ERROR))
+      case ProviderStatus.Stale        => ZIO.succeed(state.set(ProviderState.STALE))
+      case ProviderStatus.Fatal        => ZIO.succeed(state.set(ProviderState.FATAL))
+      case ProviderStatus.ShuttingDown => ZIO.succeed(state.set(ProviderState.NOT_READY))
+    })
 
   /** Get the current status. */
   def getStatus: UIO[ProviderStatus] =
@@ -350,6 +350,23 @@ final class TestFeatureProvider private (
 
 object TestFeatureProvider {
 
+  /** Upper bound on waits for Java SDK event delivery. Generous — the SDK dispatch is normally milliseconds — but
+    * bounded so a missing event fails the test quickly and descriptively instead of hanging the suite.
+    */
+  private val SdkEventTimeout: Duration = 30.seconds
+
+  /** Await a CountDownLatch on the blocking pool with a bounded timeout; dies descriptively on expiry. */
+  private def awaitLatch(latch: Option[CountDownLatch], what: String): UIO[Unit] =
+    ZIO.foreachDiscard(latch) { l =>
+      ZIO.attemptBlocking {
+        if (!l.await(SdkEventTimeout.toMillis, java.util.concurrent.TimeUnit.MILLISECONDS))
+          throw new IllegalStateException(
+            s"TestFeatureProvider timed out after $SdkEventTimeout waiting for $what; " +
+              "the Java SDK never delivered the event"
+          )
+      }.orDie
+    }
+
   // Behavior Controls — types
 
   private[testkit] case class BehaviorConfig(
@@ -424,24 +441,52 @@ object TestFeatureProvider {
     ZLayer
       .scoped {
         for {
-          testProvider <- make(flags)
+          testProvider <- makeReadyWithInitDone(flags)
           api    = OpenFeatureAPIFactory.create()
           domain = s"test-${java.util.UUID.randomUUID()}"
           featureFlags <- FeatureFlags
-            .fromProviderWithDomain(testProvider, domain, testProvider.statusRef, api = Some(api))
+            .fromProviderWithDomain(
+              testProvider,
+              domain,
+              testProvider.statusRef,
+              api = Some(api),
+              onReady = testProvider.initDone
+            )
             .build
             .map(_.get)
-          // The Java SDK dispatches an initial PROVIDER_READY event asynchronously when
-          // handlers are registered on an already-ready provider. Wait briefly for this
-          // event to settle so that subsequent setStatus() calls in tests are not overwritten.
-          // Use the live clock to avoid blocking on ZIO's TestClock.
-          _ <- ZIO.attemptBlocking(Thread.sleep(50)).ignore
+          // The Java SDK dispatches an initial PROVIDER_READY event asynchronously when handlers are
+          // registered on an already-ready provider. The event bridge counts down `initDone` when that
+          // replay arrives — a deterministic handshake (formerly a fixed 50ms sleep) ensuring subsequent
+          // setStatus() calls in tests are not overwritten by the late replay.
+          _ <- awaitLatch(testProvider.initDone, "initial PROVIDER_READY replay during layer construction")
         } yield (testProvider, featureFlags)
       }
       .flatMap { env =>
         val (testProvider, featureFlags) = env.get[(TestFeatureProvider, FeatureFlags)]
         ZLayer.succeed(testProvider) ++ ZLayer.succeed(featureFlags)
       }
+
+  /** Like [[make]], but in Ready state with an `initDone` latch wired for the sync layer's PROVIDER_READY handshake. */
+  private def makeReadyWithInitDone(initialFlags: Map[String, Any]): UIO[TestFeatureProvider] =
+    for {
+      eventsHub <- Hub.unbounded[ProviderEvent]
+      statusRef <- Ref.make[ProviderStatus](ProviderStatus.Ready)
+      provider <- ZIO.succeed {
+        val flags = new ConcurrentHashMap[String, Any]()
+        initialFlags.foreach { case (k, v) => flags.put(k, v) }
+        val state       = new AtomicReference[ProviderState](ProviderState.READY)
+        val evaluations = new CopyOnWriteArrayList[(String, OFEvaluationContext)]()
+        new TestFeatureProvider(
+          flags,
+          state,
+          evaluations,
+          eventsHub,
+          statusRef,
+          initLatch = None,
+          initDone = Some(new CountDownLatch(1))
+        )
+      }
+    } yield provider
 
   /** Create just the TestFeatureProvider layer (without FeatureFlags). */
   def providerLayer: ULayer[TestFeatureProvider] =


### PR DESCRIPTION
## Summary

Two blocking hazards in `TestFeatureProvider`:

1. `setStatus(Ready)` ran `initDone.await()` (unbounded) inside `ZIO.succeed` — parking a **core runtime thread** until the Java SDK's background init fired PROVIDER_READY. If that event never arrived (misconfigured provider, watchdog already Fatal), the await never returned: an unkillable fiber and a starved runtime thread, capable of deadlocking a parallel suite.
2. `layer()` settled the SDK's async initial PROVIDER_READY replay with a fixed `Thread.sleep(50)` — a flakiness source on slow CI.

## Changes

- New `awaitLatch` helper: latch waits run on the blocking pool with a bounded 30s timeout and **die descriptively** on expiry ("timed out waiting for PROVIDER_READY...") — a fast diagnosable failure instead of a hang.
- `setStatus` uses it; the non-Ready branches are unchanged.
- `layer()` now wires the provider's `initDone` latch into the event bridge via a new optional `onReady` parameter on the sync `FeatureFlags.build` path (the async path already had it). The bridge counts the latch down when the SDK delivers the initial PROVIDER_READY replay, and the layer awaits that — a deterministic handshake replacing the sleep.
- The sync layer's provider is created by a private `makeReadyWithInitDone` so the public `make` (whose providers aren't wired to any bridge) keeps its previous no-latch behavior.

## Tests

Covered by the existing testkit suite (171 tests), which exercises `setStatus` and `layer` heavily across sync/async layers; ran twice to check for timing flakes — green both times.

Fixes #186