### PR TITLE
Tighten FlagType decoders: reject lossy and surprising coercions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`FlagType` decoders no longer coerce silently** (#187). Lossy and surprising conversions now fail with `Left`
+  (surfacing as `TypeMismatch` / `OverrideTypeMismatch` instead of a wrong-but-plausible value):
+  - `Int`/`Long`: fractional doubles are rejected (previously truncated, e.g. `42.9 → 42`); out-of-range longs are
+    rejected (previously wrapped).
+  - `Boolean`: numbers are rejected (previously C-style `n != 0`).
+  - `String`: only strings decode (previously any value via `toString`, and `null` as `""`).
+  - `Float`: doubles outside Float range are rejected (previously overflowed to `±Infinity`); precision rounding
+    within range is still accepted.
+  String parsing of numerics/booleans (e.g. `"42"`, `"true"`) is unchanged.
+
 ## [0.9.1] — 2026-06-04
 
 ### Fixed

--- a/core/src/main/scala-2/zio/openfeature/FlagType.scala
+++ b/core/src/main/scala-2/zio/openfeature/FlagType.scala
@@ -13,13 +13,18 @@ object FlagType {
   def apply[A](implicit ft: FlagType[A]): FlagType[A] = ft
   def typeName[A](implicit ft: FlagType[A]): String   = ft.typeName
 
+  // A Double is an exact Long when it is integral and inside [Long.MinValue, Long.MaxValue). The strict
+  // upper bound rejects Long.MaxValue.toDouble, which rounds up to 2^63 and would saturate on .toLong.
+  private def isExactLong(d: Double): Boolean =
+    d == d.toLong.toDouble && d >= Long.MinValue.toDouble && d < Long.MaxValue.toDouble
+
   implicit val booleanFlagType: FlagType[Boolean] = new FlagType[Boolean] {
     def typeName: String      = "Boolean"
     def defaultValue: Boolean = false
     def decode(value: Any): Either[String, Boolean] = value match {
       case b: Boolean => Right(b)
       case s: String  => s.toBooleanOption.toRight(s"Cannot parse '$s' as Boolean")
-      case n: Number  => Right(n.intValue() != 0)
+      case null       => Left("Cannot convert null to Boolean")
       case _          => Left(s"Cannot convert ${value.getClass.getSimpleName} to Boolean")
     }
   }
@@ -29,8 +34,8 @@ object FlagType {
     def defaultValue: String = ""
     def decode(value: Any): Either[String, String] = value match {
       case s: String => Right(s)
-      case null      => Right("")
-      case other     => Right(other.toString)
+      case null      => Left("Cannot convert null to String")
+      case other     => Left(s"Cannot convert ${other.getClass.getSimpleName} to String")
     }
   }
 
@@ -38,10 +43,13 @@ object FlagType {
     def typeName: String  = "Int"
     def defaultValue: Int = 0
     def decode(value: Any): Either[String, Int] = value match {
-      case i: Int    => Right(i)
-      case l: Long   => Right(l.toInt)
-      case d: Double => Right(d.toInt)
-      case n: Number => Right(n.intValue())
+      case i: Int                  => Right(i)
+      case l: Long if l.isValidInt => Right(l.toInt)
+      case l: Long                 => Left(s"Long value $l is out of Int range")
+      case d: Double               => if (d.isValidInt) Right(d.toInt) else Left(s"Double value $d is not a valid Int")
+      case n: Number =>
+        val d = n.doubleValue()
+        if (d.isValidInt) Right(d.toInt) else Left(s"Numeric value $n is not a valid Int")
       case s: String => s.toIntOption.toRight(s"Cannot parse '$s' as Int")
       case _         => Left(s"Cannot convert ${value.getClass.getSimpleName} to Int")
     }
@@ -53,8 +61,10 @@ object FlagType {
     def decode(value: Any): Either[String, Long] = value match {
       case l: Long   => Right(l)
       case i: Int    => Right(i.toLong)
-      case d: Double => Right(d.toLong)
-      case n: Number => Right(n.longValue())
+      case d: Double => if (isExactLong(d)) Right(d.toLong) else Left(s"Double value $d is not a valid Long")
+      case n: Number =>
+        val d = n.doubleValue()
+        if (isExactLong(d)) Right(d.toLong) else Left(s"Numeric value $n is not a valid Long")
       case s: String => s.toLongOption.toRight(s"Cannot parse '$s' as Long")
       case _         => Left(s"Cannot convert ${value.getClass.getSimpleName} to Long")
     }
@@ -78,11 +88,14 @@ object FlagType {
     def typeName: String    = "Float"
     def defaultValue: Float = 0.0f
     def decode(value: Any): Either[String, Float] = value match {
-      case f: Float  => Right(f)
-      case d: Double => Right(d.toFloat)
+      case f: Float => Right(f)
+      case d: Double =>
+        // Rounding to Float precision is inherent and expected; only reject magnitude overflow,
+        // which would silently turn a finite value into +/-Infinity.
+        if (d.isNaN || d.isInfinity || math.abs(d) <= java.lang.Float.MAX_VALUE.toDouble) Right(d.toFloat)
+        else Left(s"Double value $d is out of Float range")
       case i: Int    => Right(i.toFloat)
       case l: Long   => Right(l.toFloat)
-      case n: Number => Right(n.floatValue())
       case s: String => s.toFloatOption.toRight(s"Cannot parse '$s' as Float")
       case _         => Left(s"Cannot convert ${value.getClass.getSimpleName} to Float")
     }

--- a/core/src/main/scala-3/zio/openfeature/FlagType.scala
+++ b/core/src/main/scala-3/zio/openfeature/FlagType.scala
@@ -12,13 +12,18 @@ object FlagType:
   def apply[A](using ft: FlagType[A]): FlagType[A] = ft
   def typeName[A](using ft: FlagType[A]): String   = ft.typeName
 
+  // A Double is an exact Long when it is integral and inside [Long.MinValue, Long.MaxValue). The strict
+  // upper bound rejects Long.MaxValue.toDouble, which rounds up to 2^63 and would saturate on .toLong.
+  private def isExactLong(d: Double): Boolean =
+    d == d.toLong.toDouble && d >= Long.MinValue.toDouble && d < Long.MaxValue.toDouble
+
   given booleanFlagType: FlagType[Boolean] with
     def typeName: String      = "Boolean"
     def defaultValue: Boolean = false
     def decode(value: Any): Either[String, Boolean] = value match
       case b: Boolean => Right(b)
       case s: String  => s.toBooleanOption.toRight(s"Cannot parse '$s' as Boolean")
-      case n: Number  => Right(n.intValue() != 0)
+      case null       => Left("Cannot convert null to Boolean")
       case _          => Left(s"Cannot convert ${value.getClass.getSimpleName} to Boolean")
 
   given stringFlagType: FlagType[String] with
@@ -26,17 +31,20 @@ object FlagType:
     def defaultValue: String = ""
     def decode(value: Any): Either[String, String] = value match
       case s: String => Right(s)
-      case null      => Right("")
-      case other     => Right(other.toString)
+      case null      => Left("Cannot convert null to String")
+      case other     => Left(s"Cannot convert ${other.getClass.getSimpleName} to String")
 
   given intFlagType: FlagType[Int] with
     def typeName: String  = "Int"
     def defaultValue: Int = 0
     def decode(value: Any): Either[String, Int] = value match
-      case i: Int    => Right(i)
-      case l: Long   => Right(l.toInt)
-      case d: Double => Right(d.toInt)
-      case n: Number => Right(n.intValue())
+      case i: Int                  => Right(i)
+      case l: Long if l.isValidInt => Right(l.toInt)
+      case l: Long                 => Left(s"Long value $l is out of Int range")
+      case d: Double => if d.isValidInt then Right(d.toInt) else Left(s"Double value $d is not a valid Int")
+      case n: Number =>
+        val d = n.doubleValue()
+        if d.isValidInt then Right(d.toInt) else Left(s"Numeric value $n is not a valid Int")
       case s: String => s.toIntOption.toRight(s"Cannot parse '$s' as Int")
       case _         => Left(s"Cannot convert ${value.getClass.getSimpleName} to Int")
 
@@ -46,8 +54,10 @@ object FlagType:
     def decode(value: Any): Either[String, Long] = value match
       case l: Long   => Right(l)
       case i: Int    => Right(i.toLong)
-      case d: Double => Right(d.toLong)
-      case n: Number => Right(n.longValue())
+      case d: Double => if isExactLong(d) then Right(d.toLong) else Left(s"Double value $d is not a valid Long")
+      case n: Number =>
+        val d = n.doubleValue()
+        if isExactLong(d) then Right(d.toLong) else Left(s"Numeric value $n is not a valid Long")
       case s: String => s.toLongOption.toRight(s"Cannot parse '$s' as Long")
       case _         => Left(s"Cannot convert ${value.getClass.getSimpleName} to Long")
 
@@ -68,10 +78,13 @@ object FlagType:
     def defaultValue: Float = 0.0f
     def decode(value: Any): Either[String, Float] = value match
       case f: Float  => Right(f)
-      case d: Double => Right(d.toFloat)
+      case d: Double =>
+        // Rounding to Float precision is inherent and expected; only reject magnitude overflow,
+        // which would silently turn a finite value into +/-Infinity.
+        if d.isNaN || d.isInfinity || math.abs(d) <= java.lang.Float.MAX_VALUE.toDouble then Right(d.toFloat)
+        else Left(s"Double value $d is out of Float range")
       case i: Int    => Right(i.toFloat)
       case l: Long   => Right(l.toFloat)
-      case n: Number => Right(n.floatValue())
       case s: String => s.toFloatOption.toRight(s"Cannot parse '$s' as Float")
       case _         => Left(s"Cannot convert ${value.getClass.getSimpleName} to Float")
 

--- a/core/src/test/scala/zio/openfeature/FlagTypeSpec.scala
+++ b/core/src/test/scala/zio/openfeature/FlagTypeSpec.scala
@@ -23,13 +23,10 @@ object FlagTypeSpec extends ZIOSpecDefault {
         val result = FlagType[Boolean].decode("false")
         assertTrue(result == Right(false))
       },
-      test("decodes non-zero number as true") {
-        val result = FlagType[Boolean].decode(java.lang.Integer.valueOf(1))
-        assertTrue(result == Right(true))
-      },
-      test("decodes zero as false") {
-        val result = FlagType[Boolean].decode(java.lang.Integer.valueOf(0))
-        assertTrue(result == Right(false))
+      test("rejects numbers (no C-style truthiness)") {
+        val one  = FlagType[Boolean].decode(java.lang.Integer.valueOf(1))
+        val zero = FlagType[Boolean].decode(java.lang.Integer.valueOf(0))
+        assertTrue(one.isLeft, zero.isLeft)
       },
       test("has correct typeName") {
         assertTrue(FlagType[Boolean].typeName == "Boolean")
@@ -43,13 +40,13 @@ object FlagTypeSpec extends ZIOSpecDefault {
         val result = FlagType[String].decode("hello")
         assertTrue(result == Right("hello"))
       },
-      test("decodes null as empty string") {
+      test("rejects null") {
         val result = FlagType[String].decode(null)
-        assertTrue(result == Right(""))
+        assertTrue(result.isLeft)
       },
-      test("decodes other types via toString") {
+      test("rejects non-string types (no silent toString)") {
         val result = FlagType[String].decode(java.lang.Integer.valueOf(42))
-        assertTrue(result == Right("42"))
+        assertTrue(result.isLeft)
       },
       test("has correct typeName") {
         assertTrue(FlagType[String].typeName == "String")
@@ -64,9 +61,17 @@ object FlagTypeSpec extends ZIOSpecDefault {
         val result = FlagType[Int].decode(42L)
         assertTrue(result == Right(42))
       },
-      test("decodes double to int") {
-        val result = FlagType[Int].decode(42.9)
+      test("decodes whole double to int") {
+        val result = FlagType[Int].decode(42.0)
         assertTrue(result == Right(42))
+      },
+      test("rejects fractional double (no silent truncation)") {
+        val result = FlagType[Int].decode(42.9)
+        assertTrue(result.isLeft)
+      },
+      test("rejects out-of-range long") {
+        val result = FlagType[Int].decode(Int.MaxValue.toLong + 1L)
+        assertTrue(result.isLeft)
       },
       test("decodes Java Integer") {
         val result = FlagType[Int].decode(java.lang.Integer.valueOf(42))
@@ -223,9 +228,13 @@ object FlagTypeSpec extends ZIOSpecDefault {
       }
     ),
     suite("Long decode edge cases")(
-      test("decodes double to long") {
-        val result = FlagType[Long].decode(42.9)
+      test("decodes whole double to long") {
+        val result = FlagType[Long].decode(42.0)
         assertTrue(result == Right(42L))
+      },
+      test("rejects fractional double (no silent truncation)") {
+        val result = FlagType[Long].decode(42.9)
+        assertTrue(result.isLeft)
       },
       test("decodes Java Number") {
         val result = FlagType[Long].decode(java.lang.Long.valueOf(123L))


### PR DESCRIPTION
## Summary

The built-in `FlagType` decoders silently coerced values in ways that masked type mismatches on the custom-type evaluation path and transaction overrides — for a feature-flag library, a wrong-but-plausible value (a targeting decision flipping silently) is worse than an error.

## Changes (both Scala 2.13 and Scala 3 sources)

- `Int`/`Long`: fractional doubles are rejected instead of truncated (`42.9` no longer decodes as `42`); out-of-range longs/doubles are rejected instead of wrapping/saturating (with a strict upper bound excluding `Long.MaxValue.toDouble`, which rounds to 2^63). Whole, in-range doubles still decode.
- `Boolean`: numbers no longer decode C-style (`n != 0` removed).
- `String`: only strings decode — the `anything.toString` and `null → ""` coercions are gone.
- `Float`: doubles are range-checked (no silent overflow to ±Infinity); precision rounding within range is accepted, since that's inherent to Float (an exact-representation rule would reject virtually every decimal literal).
- `Double` keeps accepting Int/Long widening (documented as acceptable in #187).
- Explicit string parsing of numerics and booleans (`"42"`, `"true"`) is unchanged.

These now surface as `TypeMismatch` / `OverrideTypeMismatch` errors. CHANGELOG entry added under Unreleased since this is a behavioral change.

## Tests

`FlagTypeSpec` updated: the tests that pinned the lenient behavior now assert rejection (fractional truncation, out-of-range long, number-as-boolean, toString/null-as-string), with new acceptance tests for the lossless paths (whole doubles). Full core suite green on Scala 3 and 2.13.

Fixes #187