### PR TITLE
Remove dead Java hook adapter; document FeatureHook error semantics

### DIFF
--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -5,12 +5,8 @@ import zio.stream._
 import zio.openfeature.internal.{ClientEvaluator, ContextConverter, ErrorCodeConverter, FeatureFlagsState}
 import dev.openfeature.sdk.{
   Client => OFClient,
-  ErrorCode => OFErrorCode,
   FeatureProvider => OFFeatureProvider,
-  FlagValueType => JavaFlagValueType,
-  HookContext => JavaHookContext,
   ProviderEvent => JavaProviderEvent,
-  Reason => OFReason,
   EventDetails,
   FlagEvaluationDetails,
   MutableTrackingEventDetails,
@@ -18,7 +14,6 @@ import dev.openfeature.sdk.{
 }
 
 import scala.jdk.CollectionConverters._
-import scala.util.control.NonFatal
 
 final private[openfeature] class FeatureFlagsLive(
   client: OFClient,
@@ -734,110 +729,6 @@ final private[openfeature] class FeatureFlagsLive(
 
   override def clearApiHooks: UIO[Unit] =
     ZIO.succeed(api.clearHooks())
-
-  // Provider hooks (spec: provider hooks included in hook pipeline)
-
-  private def getProviderHooks: UIO[List[FeatureHook]] =
-    providerRef.get.flatMap { p =>
-      try {
-        val javaHooks = p.getProviderHooks
-        val res =
-          if (javaHooks == null || javaHooks.isEmpty) Nil
-          else javaHooks.asScala.toList.map(wrapJavaHook)
-        Exit.succeed(res)
-      } catch {
-        case NonFatal(e) =>
-          ZIO.logWarningCause(s"Failed to get provider hooks", Cause.fail(e)).as(Nil)
-      }
-    }
-
-  @scala.annotation.nowarn("msg=deprecated")
-  private def toJavaHookContext(ctx: HookContext): JavaHookContext[Any] =
-    JavaHookContext.from[Any](
-      ctx.flagKey,
-      toJavaFlagValueType(ctx.flagType),
-      new dev.openfeature.sdk.ClientMetadata {
-        def getDomain: String = domain.orNull
-      },
-      new dev.openfeature.sdk.Metadata {
-        def getName: String = ctx.providerMetadata.name
-      },
-      ContextConverter.toOpenFeature(ctx.evaluationContext),
-      ctx.defaultValue
-    )
-
-  private def toJavaFlagValueType(fvt: FlagValueType): JavaFlagValueType = fvt match {
-    case FlagValueType.Boolean => JavaFlagValueType.BOOLEAN
-    case FlagValueType.String  => JavaFlagValueType.STRING
-    case FlagValueType.Int     => JavaFlagValueType.INTEGER
-    case FlagValueType.Double  => JavaFlagValueType.DOUBLE
-    case FlagValueType.Object  => JavaFlagValueType.OBJECT
-  }
-
-  private def toJavaFlagEvalDetails[A](res: FlagResolution[A]): FlagEvaluationDetails[Any] = {
-    val details = new FlagEvaluationDetails[Any]()
-    details.setFlagKey(res.flagKey)
-    details.setValue(res.value)
-    res.variant.foreach(details.setVariant)
-    details.setReason(res.reason.toString)
-    res.errorCode.foreach(ec => details.setErrorCode(ErrorCodeConverter.toJava(ec)))
-    res.errorMessage.foreach(details.setErrorMessage)
-    details
-  }
-
-  private def fromJavaEvaluationContext(ctx: dev.openfeature.sdk.EvaluationContext): EvaluationContext =
-    if (ctx == null) EvaluationContext.empty
-    else ContextConverter.fromOpenFeature(ctx)
-
-  private def wrapJavaHook(javaHook: dev.openfeature.sdk.Hook[_]): FeatureHook = {
-    val hook = javaHook.asInstanceOf[dev.openfeature.sdk.Hook[Any]]
-    new FeatureHook {
-      override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
-        ZIO.succeed {
-          try {
-            val jCtx   = toJavaHookContext(ctx)
-            val jHints = hints.values.map { case (k, v) => k -> v.asInstanceOf[Object] }.asJava
-            val result = hook.before(jCtx, jHints)
-            if (result != null && result.isPresent) {
-              val newCtx = fromJavaEvaluationContext(result.get())
-              Some((newCtx, hints))
-            } else None
-          } catch { case NonFatal(_) => None }
-        }
-
-      override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
-        ZIO.attempt {
-          val jCtx     = toJavaHookContext(ctx)
-          val jDetails = toJavaFlagEvalDetails(details)
-          val jHints   = hints.values.map { case (k, v) => k -> v.asInstanceOf[Object] }.asJava
-          hook.after(jCtx, jDetails, jHints)
-        }.ignore
-
-      override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
-        ZIO.attempt {
-          val jCtx   = toJavaHookContext(ctx)
-          val jHints = hints.values.map { case (k, v) => k -> v.asInstanceOf[Object] }.asJava
-          val ex: Exception = err.cause match {
-            case Some(e: Exception) => e
-            case Some(t)            => new RuntimeException(t.getMessage, t)
-            case None               => new RuntimeException(err.message)
-          }
-          hook.error(jCtx, ex, jHints)
-        }.ignore
-
-      override def finallyAfter(
-        ctx: HookContext,
-        details: Option[FlagResolution[_]],
-        hints: HookHints
-      ): UIO[Unit] =
-        ZIO.attempt {
-          val jCtx     = toJavaHookContext(ctx)
-          val jHints   = hints.values.map { case (k, v) => k -> v.asInstanceOf[Object] }.asJava
-          val jDetails = details.map(toJavaFlagEvalDetails(_)).getOrElse(new FlagEvaluationDetails[Any]())
-          hook.finallyAfter(jCtx, jDetails, jHints)
-        }.ignore
-    }
-  }
 
   // Provider hot-swap
 

--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -101,6 +101,20 @@ object HookHints {
     HookHints(entries.toMap)
 }
 
+/** A ZIO-level evaluation hook (spec §4).
+  *
+  * '''Error semantics''': every stage returns `UIO` — hooks are infallible by construction and cannot abort an
+  * evaluation. This is an intentional deviation from spec §4.4.6 (which aborts evaluation when a before/after hook
+  * errors): a misbehaving observer (logging, metrics, audit) should never take flag evaluation down with it. Handle
+  * failures inside the hook (`.catchAll`, `.ignoreLogged`, retries) — anything a stage must not crash on has to be
+  * dealt with there, because there is no error channel for the pipeline to react to. Defects (`die`) in a hook will
+  * still propagate and fail the evaluation fiber, so wrap genuinely untrusted code in `ZIO.attempt(...).ignoreLogged`
+  * or similar.
+  *
+  * Provider-level hooks are not modeled here: they run inside the Java SDK evaluation call, per the OpenFeature
+  * architecture (see #167). Java `dev.openfeature.sdk.Hook` instances can be registered at the Java API level via
+  * `FeatureFlags.addApiHook` and likewise run inside the SDK.
+  */
 trait FeatureHook {
 
   /** The set of flag value types this hook supports. Hooks are only invoked for evaluations whose flag type is in this

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -250,6 +250,14 @@ val customHook = new FeatureHook:
     ZIO.unit
 ```
 
+### Error semantics
+
+Every `FeatureHook` stage returns `UIO`, so hooks are **infallible by construction and cannot abort an evaluation**. This is an intentional deviation from spec §4.4.6: a misbehaving observer (logging, metrics, validation) must never take flag evaluation down. The consequences:
+
+- Handle expected failures **inside** the hook (e.g. `.catchAll`/`.ignore` on effects that can fail) — there is no typed error channel to surface them.
+- Defects (unexpected `Throwable`s) still propagate as defects, so wrap untrusted third-party code (e.g. with `.catchAllDefect`) if it must not interfere with evaluation.
+- For hooks that should run **inside the Java SDK** (and participate in the SDK's own hook error model), register them with `addApiHook` instead of `addHook`.
+
 ### Hook Context
 
 The `HookContext` provides information about the current evaluation:


### PR DESCRIPTION
## Summary

Issue #179 flagged two problems in the Java hook adapter (`wrapJavaHook`): before-hook exceptions silently swallowed (deviating from spec §4.4.6) and third-party Java hook code running inside `ZIO.succeed` on core runtime threads.

Investigating the fix revealed the whole adapter path is **dead code**: `getProviderHooks` (its only consumer) has been unreferenced since #167 moved provider hooks inside the Java SDK evaluation call. The spec deviation can't occur because the code never runs — the correct fix is deletion, plus making the intended hook error model explicit.

## Changes

- Deleted the dead provider-hook adapter block: `getProviderHooks`, `wrapJavaHook`, `toJavaHookContext`, `toJavaFlagValueType`, `toJavaFlagEvalDetails`, `fromJavaEvaluationContext` (~90 lines), and the imports they held alive.
- Documented the error contract on `FeatureHook`: stages return `UIO` — hooks are infallible by construction and cannot abort evaluation, an intentional deviation from spec §4.4.6 so a misbehaving observer never takes flag evaluation down. The doc spells out the consequences (handle failures inside the hook; defects still propagate; wrap untrusted code) and points to `addApiHook` for Java SDK-level hooks, which run inside the SDK as the architecture intends.

This also covers the `getProviderHooks` item of #190.

## Tests

No behavior change — deleted code was unreachable. `ProviderHookDuplicationSpec` (provider hooks fire exactly once, inside the SDK) and the full core suite remain green.

Fixes #179