### PR TITLE
Core cleanups: emptiness naming, converter fallback, auth token match, hot-path tidy-ups

### DIFF
--- a/core/src/main/scala-2/zio/openfeature/AttributeValue.scala
+++ b/core/src/main/scala-2/zio/openfeature/AttributeValue.scala
@@ -46,12 +46,16 @@ sealed trait AttributeValue extends Product with Serializable {
     case _                             => None
   }
 
-  def isNull: Boolean = this match {
+  /** True when the value is an "empty" container: empty string, empty list, or empty struct. */
+  def isEmptyValue: Boolean = this match {
     case AttributeValue.StringValue("")             => true
     case AttributeValue.ListValue(Nil)              => true
     case AttributeValue.StructValue(m) if m.isEmpty => true
     case _                                          => false
   }
+
+  @deprecated("isNull tests emptiness, not null-ness; use isEmptyValue", "0.9.2")
+  def isNull: Boolean = isEmptyValue
 }
 
 object AttributeValue {

--- a/core/src/main/scala-3/zio/openfeature/AttributeValue.scala
+++ b/core/src/main/scala-3/zio/openfeature/AttributeValue.scala
@@ -47,11 +47,15 @@ enum AttributeValue:
     case StructValue(v) => Some(v)
     case _              => None
 
-  def isNull: Boolean = this match
+  /** True when the value is an "empty" container: empty string, empty list, or empty struct. */
+  def isEmptyValue: Boolean = this match
     case StringValue("")             => true
     case ListValue(Nil)              => true
     case StructValue(m) if m.isEmpty => true
     case _                           => false
+
+  @deprecated("isNull tests emptiness, not null-ness; use isEmptyValue", "0.9.2")
+  def isNull: Boolean = isEmptyValue
 
 object AttributeValue:
   def bool(value: Boolean): AttributeValue                      = BoolValue(value)

--- a/core/src/main/scala/zio/openfeature/FeatureFlagError.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagError.scala
@@ -139,14 +139,17 @@ object FeatureFlagError {
   // so we fall back to scanning the exception message for the canonical "401"/"403" tokens. This is permissive — if a
   // provider message happens to contain those substrings for another reason it will be misclassified, but the cost is
   // low (caller still sees the original Throwable on Unauthorized.cause-equivalent flows when needed).
+  // Word-boundary match so "401"/"403" only hit as standalone tokens — a port 4013, a byte count, or a
+  // flag key containing the digits must not classify as an auth failure.
+  private val AuthStatusToken = java.util.regex.Pattern.compile("\\b(401|403)\\b")
+
   private def isHttpAuthFailure(t: Throwable, msg: String): Boolean = {
     val cls    = t.getClass.getName
     val msgLow = msg.toLowerCase
     cls.endsWith("HttpResponseException") ||
     cls.endsWith("UnauthorizedException") ||
     cls.endsWith("ForbiddenException") ||
-    msgLow.contains("401") ||
-    msgLow.contains("403") ||
+    AuthStatusToken.matcher(msgLow).find() ||
     msgLow.contains("unauthorized") ||
     msgLow.contains("forbidden")
   }

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -119,6 +119,12 @@ trait FeatureFlags {
 
   def withContext[R, E, A](ctx: EvaluationContext)(zio: ZIO[R, E, A]): ZIO[R, E, A]
 
+  /** Run `zio` inside a flag transaction with optional overrides and per-call evaluation caching.
+    *
+    * Error channel: on Scala 3, `Compat.OrError[E, FeatureFlagError]` is the union `E | FeatureFlagError`. Scala 2.13
+    * has no union types, so there it erases to `Any` — when handling transaction errors on 2.13, match on
+    * `FeatureFlagError` cases (e.g. `NestedTransactionNotAllowed`) and your own `E` explicitly.
+    */
   def transaction[R, E, A](
     overrides: Map[String, Any] = Map.empty,
     context: EvaluationContext = EvaluationContext.empty,
@@ -472,10 +478,10 @@ object FeatureFlags {
         case _                  => ZIO.attempt(api.getClient())
       }
       providerName = Option(provider.getMetadata).map(_.getName).getOrElse("unknown")
-      providerRef     <- Ref.make(provider)
-      providerNameRef <- Ref.make(providerName)
-      swapLock        <- Semaphore.make(1)
-      baseState       <- FeatureFlagsState.make
+      providerRef <- Ref.make(provider)
+      providerNameRef = new java.util.concurrent.atomic.AtomicReference(providerName)
+      swapLock  <- Semaphore.make(1)
+      baseState <- FeatureFlagsState.make
       state = statusRef.fold(baseState)(ref => baseState.copy(statusRef = ref))
       _ <- state.hooksRef.set(initialHooks)
       // Only seed status when the caller didn't hand us a shared ref (testkit shares one).
@@ -666,10 +672,10 @@ object FeatureFlags {
         case _                  => ZIO.attempt(api.getClient())
       }
       providerName = Option(provider.getMetadata).map(_.getName).getOrElse("unknown")
-      providerRef     <- Ref.make(provider)
-      providerNameRef <- Ref.make(providerName)
-      swapLock        <- Semaphore.make(1)
-      baseState       <- FeatureFlagsState.make
+      providerRef <- Ref.make(provider)
+      providerNameRef = new java.util.concurrent.atomic.AtomicReference(providerName)
+      swapLock  <- Semaphore.make(1)
+      baseState <- FeatureFlagsState.make
       state = statusRef.fold(baseState)(ref => baseState.copy(statusRef = ref))
       _ <- state.hooksRef.set(initialHooks)
       _ <- ZIO.when(addShutdownFinalizer)(ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore))

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -23,7 +23,9 @@ import scala.util.control.NonFatal
 final private[openfeature] class FeatureFlagsLive(
   client: OFClient,
   providerRef: Ref[OFFeatureProvider],
-  providerNameRef: Ref[String],
+  // AtomicReference (not Ref): the event bridge reads the name synchronously from Java SDK threads on
+  // every event; a Ref would force a runtime.unsafe.run round-trip per event.
+  providerNameRef: java.util.concurrent.atomic.AtomicReference[String],
   domain: Option[String],
   version: Option[String],
   state: FeatureFlagsState,
@@ -51,18 +53,7 @@ final private[openfeature] class FeatureFlagsLive(
   // Bridge Java SDK provider events to ZIO event system
   private[openfeature] def startEventBridge: ZIO[Scope, Nothing, Unit] = {
     // Read provider name dynamically so events after a provider swap use the new name
-    def currentMetadata(runtime: Runtime[Any]): ProviderMetadata = {
-      val name = Unsafe.unsafe { implicit u =>
-        runtime.unsafe
-          .run(
-            providerNameRef.get.catchAllCause(c =>
-              ZIO.logErrorCause("event bridge: providerNameRef.get", c).as("unknown")
-            )
-          )
-          .getOrElse(_ => "unknown")
-      }
-      ProviderMetadata(name)
-    }
+    def currentMetadata(): ProviderMetadata = ProviderMetadata(providerNameRef.get())
 
     // Run an event-publish effect from a Java SDK thread. Failures are logged via the ZIO logger
     // rather than thrown, so the Java SDK's event dispatch thread is never killed by a defect.
@@ -99,7 +90,7 @@ final private[openfeature] class FeatureFlagsLive(
               if (sinceFailure >= FailedSwapGuardMillis) ProviderStatus.Ready else ProviderStatus.Error
             case other => other
           } *>
-            state.eventHub.publish(ProviderEvent.Ready(currentMetadata(runtime), em)).unit
+            state.eventHub.publish(ProviderEvent.Ready(currentMetadata(), em)).unit
         )
         onReady.foreach(_.countDown())
       }
@@ -111,7 +102,7 @@ final private[openfeature] class FeatureFlagsLive(
         runHandler(runtime, "PROVIDER_ERROR")(
           state.statusRef.set(ProviderStatus.Error) *>
             state.eventHub
-              .publish(ProviderEvent.Error(error, currentMetadata(runtime), errorCode, Option(details.getMessage), em))
+              .publish(ProviderEvent.Error(error, currentMetadata(), errorCode, Option(details.getMessage), em))
               .unit
         )
       }
@@ -121,7 +112,7 @@ final private[openfeature] class FeatureFlagsLive(
         val em     = extractEventMetadata(details)
         runHandler(runtime, "PROVIDER_STALE")(
           state.statusRef.set(ProviderStatus.Stale) *>
-            state.eventHub.publish(ProviderEvent.Stale(reason, currentMetadata(runtime), em)).unit
+            state.eventHub.publish(ProviderEvent.Stale(reason, currentMetadata(), em)).unit
         )
       }
 
@@ -132,7 +123,7 @@ final private[openfeature] class FeatureFlagsLive(
         val em = extractEventMetadata(details)
         runHandler(runtime, "PROVIDER_CONFIGURATION_CHANGED")(
           state.eventHub
-            .publish(ProviderEvent.ConfigurationChanged(flags, currentMetadata(runtime), em))
+            .publish(ProviderEvent.ConfigurationChanged(flags, currentMetadata(), em))
             .unit
         )
       }
@@ -181,14 +172,17 @@ final private[openfeature] class FeatureFlagsLive(
     for {
       apiHooks     <- state.zioApiHooksRef.get
       currentHooks <- state.hooksRef.get
-      pName        <- providerNameRef.get
+      pName        <- ZIO.succeed(providerNameRef.get())
+      flagType = FlagValueType.fromFlagType[A]
       // Order per spec §4.4.1: API -> Client -> Invocation. Provider hooks run inside the Java SDK call.
-      allHooks   = apiHooks ++ currentHooks ++ extraHooks
+      // Pre-filtering by flag type (spec 4.4.2.1) lets evaluations with no applicable hooks skip the
+      // pipeline entirely; the composed hook's own per-stage filter then has nothing left to drop.
+      allHooks   = (apiHooks ++ currentHooks ++ extraHooks).filter(_.supportedFlagTypes.contains(flagType))
       metadata   = ProviderMetadata(pName)
       clientMeta = ClientMetadata(domain, version)
       hookCtx = HookContext(
         flagKey = key,
-        flagType = FlagValueType.fromFlagType[A],
+        flagType = flagType,
         defaultValue = default,
         evaluationContext = context,
         clientMetadata = clientMeta,
@@ -211,19 +205,20 @@ final private[openfeature] class FeatureFlagsLive(
     for {
       beforeResult <- composedHook.before(hookCtx, initialHints)
       (effectiveCtx, hints) = beforeResult match {
-        case Some((hookCtx, h)) => (hookCtx, h)
-        case None               => (context, initialHints)
+        case Some((modifiedCtx, h)) => (modifiedCtx, h)
+        case None                   => (context, initialHints)
       }
-      resultRef <- Ref.make[Option[FlagResolution[_]]](None)
+      // finallyAfter runs on every exit (success, failure, interruption); the resolution is read straight
+      // off the Exit rather than smuggled through a per-evaluation Ref.
       result <- evaluate(effectiveCtx)
-        .tap(res => resultRef.set(Some(res)))
         .tapBoth(
           err => composedHook.error(hookCtx, err, hints),
           res => composedHook.after(hookCtx, res, hints)
         )
-        .ensuring(
-          resultRef.get.flatMap(details => composedHook.finallyAfter(hookCtx, details, hints)).ignore
-        )
+        .onExit { exit =>
+          val details: Option[FlagResolution[_]] = exit.foldExit(_ => None, res => Some(res))
+          composedHook.finallyAfter(hookCtx, details, hints)
+        }
     } yield result
   }
 
@@ -328,13 +323,7 @@ final private[openfeature] class FeatureFlagsLive(
     val evaluation: IO[FeatureFlagError, FlagResolution[A]] =
       ClientEvaluator.evaluateStandard[A](flagType.typeName, client, key, default, ofContext) match {
         case Some(erased) =>
-          val timedEval = timeout match {
-            case Some(d) =>
-              erased.task.disconnect
-                .timeoutFail(new java.util.concurrent.TimeoutException(s"Evaluation of '$key' timed out after $d"))(d)
-            case None => erased.task
-          }
-          timedEval
+          withTimeout(erased.task)
             .mapError(e => FeatureFlagError.classify(e))
             .flatMap { details =>
               toFlagResolution(key, details).map(r => r.copy(value = erased.extract(details)))
@@ -625,7 +614,7 @@ final private[openfeature] class FeatureFlagsLive(
     state.statusRef.get
 
   override def providerMetadata: UIO[ProviderMetadata] =
-    providerNameRef.get.map(ProviderMetadata(_))
+    ZIO.succeed(ProviderMetadata(providerNameRef.get()))
 
   override def clientMetadata: UIO[ClientMetadata] =
     ZIO.succeed(ClientMetadata(domain, version))
@@ -647,7 +636,7 @@ final private[openfeature] class FeatureFlagsLive(
     } yield fiber.interrupt.unit
 
   override def onProviderReady(handler: ProviderMetadata => UIO[Unit]): UIO[UIO[Unit]] =
-    providerNameRef.get.flatMap { pName =>
+    ZIO.succeed(providerNameRef.get()).flatMap { pName =>
       val metadata = ProviderMetadata(pName)
       subscribeToEvent(
         _ == ProviderStatus.Ready,
@@ -658,7 +647,7 @@ final private[openfeature] class FeatureFlagsLive(
     }
 
   override def onProviderError(handler: (Throwable, ProviderMetadata) => UIO[Unit]): UIO[UIO[Unit]] =
-    providerNameRef.get.flatMap { pName =>
+    ZIO.succeed(providerNameRef.get()).flatMap { pName =>
       val metadata = ProviderMetadata(pName)
       subscribeToEvent(
         s => s == ProviderStatus.Error || s == ProviderStatus.Fatal,
@@ -669,7 +658,7 @@ final private[openfeature] class FeatureFlagsLive(
     }
 
   override def onProviderStale(handler: (String, ProviderMetadata) => UIO[Unit]): UIO[UIO[Unit]] =
-    providerNameRef.get.flatMap { pName =>
+    ZIO.succeed(providerNameRef.get()).flatMap { pName =>
       val metadata = ProviderMetadata(pName)
       subscribeToEvent(
         _ == ProviderStatus.Stale,
@@ -849,14 +838,14 @@ final private[openfeature] class FeatureFlagsLive(
       for {
         // Save old state for rollback on failure
         oldProvider <- providerRef.get
-        oldName     <- providerNameRef.get
+        oldName     <- ZIO.succeed(providerNameRef.get())
         // 1. Transition to NOT_READY — new evaluations fail fast during swap
         _ <- state.statusRef.set(ProviderStatus.NotReady)
         // 2. Update refs BEFORE registering with Java SDK, so the event bridge
         //    (which fires PROVIDER_READY during setProviderAndWait) sees consistent metadata
         newName = Option(newProvider.getMetadata).map(_.getName).getOrElse("unknown")
         _ <- providerRef.set(newProvider)
-        _ <- providerNameRef.set(newName)
+        _ <- ZIO.succeed(providerNameRef.set(newName))
         // 3. Register new provider with Java SDK (shuts down old, initializes new)
         _ <- (domain match {
           case Some(d) => ZIO.attemptBlocking(api.setProviderAndWait(d, newProvider))
@@ -868,7 +857,7 @@ final private[openfeature] class FeatureFlagsLive(
             // failure timestamp and skips overwriting Error within the guard window.
             ZIO.succeed(recentSwapFailureAt.set(java.lang.System.currentTimeMillis())) *>
               providerRef.set(oldProvider) *>
-              providerNameRef.set(oldName) *>
+              ZIO.succeed(providerNameRef.set(oldName)) *>
               state.statusRef.set(ProviderStatus.Error)
           )
         // 4. Mark ready — the Java SDK event bridge will also fire PROVIDER_READY,

--- a/core/src/main/scala/zio/openfeature/internal/ErrorCodeConverter.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ErrorCodeConverter.scala
@@ -14,7 +14,9 @@ private[openfeature] object ErrorCodeConverter {
       case OFErrorCode.TYPE_MISMATCH         => ErrorCode.TypeMismatch
       case OFErrorCode.TARGETING_KEY_MISSING => ErrorCode.TargetingKeyMissing
       case OFErrorCode.INVALID_CONTEXT       => ErrorCode.InvalidContext
-      case OFErrorCode.GENERAL               => ErrorCode.General
+      // GENERAL plus future-proofing: a Java SDK upgrade may add enum values at runtime; mapping
+      // anything unrecognized to General beats a MatchError deep inside the evaluation path.
+      case _ => ErrorCode.General
     }
 
   def toJava(errorCode: ErrorCode): OFErrorCode =

--- a/core/src/test/scala/zio/openfeature/AttributeValueSpec.scala
+++ b/core/src/test/scala/zio/openfeature/AttributeValueSpec.scala
@@ -130,31 +130,31 @@ object AttributeValueSpec extends ZIOSpecDefault {
         assertTrue(AttributeValue.ListValue(Nil).asStruct == None)
       }
     ),
-    suite("isNull check")(
-      test("empty string is null") {
-        assertTrue(AttributeValue.StringValue("").isNull == true)
+    suite("isEmptyValue check")(
+      test("empty string is empty") {
+        assertTrue(AttributeValue.StringValue("").isEmptyValue == true)
       },
-      test("non-empty string is not null") {
-        assertTrue(AttributeValue.StringValue("test").isNull == false)
+      test("non-empty string is not empty") {
+        assertTrue(AttributeValue.StringValue("test").isEmptyValue == false)
       },
-      test("empty list is null") {
-        assertTrue(AttributeValue.ListValue(Nil).isNull == true)
+      test("empty list is empty") {
+        assertTrue(AttributeValue.ListValue(Nil).isEmptyValue == true)
       },
-      test("non-empty list is not null") {
-        assertTrue(AttributeValue.ListValue(List(AttributeValue.IntValue(1))).isNull == false)
+      test("non-empty list is not empty") {
+        assertTrue(AttributeValue.ListValue(List(AttributeValue.IntValue(1))).isEmptyValue == false)
       },
-      test("empty struct is null") {
-        assertTrue(AttributeValue.StructValue(Map.empty).isNull == true)
+      test("empty struct is empty") {
+        assertTrue(AttributeValue.StructValue(Map.empty).isEmptyValue == true)
       },
-      test("non-empty struct is not null") {
-        assertTrue(AttributeValue.StructValue(Map("a" -> AttributeValue.IntValue(1))).isNull == false)
+      test("non-empty struct is not empty") {
+        assertTrue(AttributeValue.StructValue(Map("a" -> AttributeValue.IntValue(1))).isEmptyValue == false)
       },
-      test("other types are not null") {
-        assertTrue(AttributeValue.BoolValue(false).isNull == false) &&
-        assertTrue(AttributeValue.IntValue(0).isNull == false) &&
-        assertTrue(AttributeValue.LongValue(0L).isNull == false) &&
-        assertTrue(AttributeValue.DoubleValue(0.0).isNull == false) &&
-        assertTrue(AttributeValue.InstantValue(Instant.EPOCH).isNull == false)
+      test("other types are not empty") {
+        assertTrue(AttributeValue.BoolValue(false).isEmptyValue == false) &&
+        assertTrue(AttributeValue.IntValue(0).isEmptyValue == false) &&
+        assertTrue(AttributeValue.LongValue(0L).isEmptyValue == false) &&
+        assertTrue(AttributeValue.DoubleValue(0.0).isEmptyValue == false) &&
+        assertTrue(AttributeValue.InstantValue(Instant.EPOCH).isEmptyValue == false)
       }
     ),
     suite("implicit conversions")(

--- a/core/src/test/scala/zio/openfeature/FeatureFlagErrorSpec.scala
+++ b/core/src/test/scala/zio/openfeature/FeatureFlagErrorSpec.scala
@@ -159,6 +159,19 @@ object FeatureFlagErrorSpec extends ZIOSpecDefault {
       }
     ),
     suite("classify")(
+      test("401/403 only classify as Unauthorized as standalone tokens") {
+        val auth401 = FeatureFlagError.classify(new RuntimeException("HTTP 401 from provider"))
+        val auth403 = FeatureFlagError.classify(new RuntimeException("server replied 403"))
+        // Digits embedded in larger numbers must NOT classify as auth failures
+        val port    = FeatureFlagError.classify(new RuntimeException("connect to host on port 4013 failed"))
+        val payload = FeatureFlagError.classify(new RuntimeException("response size 14034 exceeded limit"))
+        assertTrue(
+          auth401.isInstanceOf[FeatureFlagError.Unauthorized],
+          auth403.isInstanceOf[FeatureFlagError.Unauthorized],
+          port.isInstanceOf[FeatureFlagError.ProviderError],
+          payload.isInstanceOf[FeatureFlagError.ProviderError]
+        )
+      },
       test("UnknownHostException is classified as Unreachable") {
         val cause = new java.net.UnknownHostException("flags.example.com")
         val ok = FeatureFlagError.classify(cause) match {


### PR DESCRIPTION
## Summary

The cleanup batch from #190 (the dead `getProviderHooks` adapter was removed separately in #206 / PR for #179).

## Changes

**Hardening**
- `ErrorCodeConverter.fromJava`: the GENERAL arm is now a wildcard, so a future Java SDK enum value maps to `ErrorCode.General` at runtime instead of throwing `MatchError` deep inside the evaluation path.
- `FeatureFlagError.isHttpAuthFailure`: "401"/"403" now match only as standalone tokens (word-boundary regex) — a port 4013 or a byte count 14034 in an error message no longer misclassifies as `Unauthorized`.

**API clarity**
- `AttributeValue.isNull` (true for empty string/list/struct — emptiness, not null-ness) is deprecated in favor of the accurately named `isEmptyValue`, in both Scala 2.13 and Scala 3 sources.
- `FeatureFlags.transaction` documents the error channel: `E | FeatureFlagError` on Scala 3, erased to `Any` on 2.13 (no union types) with guidance to match `FeatureFlagError` cases explicitly.

**Hot-path tidy-ups (no behavior change)**
- `runHookPipeline` no longer allocates a `Ref` per evaluation; `finallyAfter` reads the resolution straight off the `Exit` via `onExit` (still runs on success, failure, and interruption).
- `runWithHooks` pre-filters hooks by flag type (spec 4.4.2.1), so evaluations with no applicable hooks skip the pipeline entirely.
- `evaluateFromClient` reuses its `withTimeout` helper in the standard-type branch instead of duplicating the disconnect/timeout logic inline.
- The provider name moved from `Ref[String]` to `AtomicReference[String]`: the event bridge reads it synchronously from Java SDK threads on every event, and the `Ref` forced a `runtime.unsafe.run` round-trip per event.

## Tests

- New classify test: 401/403 as standalone tokens → `Unauthorized`; embedded digits (port 4013, size 14034) → `ProviderError`.
- `AttributeValueSpec`'s isNull suite renamed to assert `isEmptyValue`.
- Full core suite green on Scala 3 and 2.13.

Fixes #190