### PR TITLE
Optimizely: defer datafile polling to initialize, scope-managed shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Optimizely provider no longer polls (or blocks) before `initialize()`** (#208). `OptimizelyProvider.make` used
+  to start the SDK's background datafile poller at construction and block up to the SDK's 10s `getConfig` timeout —
+  against an unreachable CDN or a bad key (403), a provider that was merely constructed (e.g. in a test) left a
+  retry loop polling forever and stalled construction. Construction now performs no network activity; polling starts
+  inside `initialize()` and stops at `shutdown()`.
+
+### Added
+
+- **Scope-managed Optimizely construction** (#208). `OptimizelyProvider.scoped(...)` and the (now scope-owning)
+  `layer(...)` shut the provider down — stopping datafile polling and the SDK's HTTP client, with a bounded
+  finalizer — when the surrounding scope closes, even if the provider never reached a `FeatureFlags` layer or its
+  initialization failed.
+- **`OptimizelyProviderConfig`** (#208) with `pollingInterval` and `blockingTimeout` knobs (SDK defaults: 5 minutes
+  / 10 seconds), so tests and operators no longer need to hand-roll `HttpProjectConfigManager` construction to tune
+  polling.
+
 ## [0.9.1] — 2026-06-04
 
 ### Fixed

--- a/docs/optimizely.md
+++ b/docs/optimizely.md
@@ -68,7 +68,7 @@ object MyApp extends ZIOAppDefault:
 
 What this does on startup:
 
-1. `OptimizelyProvider.make(sdkKey)` validates the key shape (non-empty, allowed characters, not a placeholder) and constructs an `Optimizely` client wired to the public CDN at `https://cdn.optimizely.com/datafiles/<sdkKey>.json`.
+1. `OptimizelyProvider.make(sdkKey)` validates the key shape (non-empty, allowed characters, not a placeholder) and constructs an `Optimizely` client wired to the public CDN at `https://cdn.optimizely.com/datafiles/<sdkKey>.json`. Construction performs no network activity and starts no background polling — the datafile poller runs only between `initialize()` and `shutdown()`. A provider you build owns a polling executor and an HTTP client, so pair `make` with something that shuts it down (a `FeatureFlags` layer does), or use `OptimizelyProvider.scoped` / `OptimizelyProvider.layer`, which release it when the surrounding scope closes. `OptimizelyProviderConfig` exposes `pollingInterval` and `blockingTimeout` when the SDK defaults (5 min / 10 s) don't fit.
 2. `FeatureFlags.fromProviderAsync(provider)` starts the provider in the background, watches for the first datafile load, and uses the default **30 s `initTimeout`** as an upper bound. If the datafile never arrives, `providerStatus` transitions to `Fatal` — your evaluations stop hanging.
 3. On every subsequent datafile revision (typically every 30 s for the SDK's default polling interval), the provider emits `ProviderEvent.ConfigurationChanged` — call `FeatureFlags.onConfigurationChanged(handler)` if you want to react.
 

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
@@ -31,7 +31,11 @@ import scala.util.Try
   *     Subsequent fires emit OpenFeature `PROVIDER_CONFIGURATION_CHANGED` events.
   *   - If the datafile never arrives within `initWait`, `initialize()` throws — propagated by the OpenFeature SDK as a
   *     failed init.
-  *   - `shutdown()` removes the notification handler and closes the underlying client.
+  *   - `shutdown()` removes the notification handler and closes the underlying client (which stops datafile polling and
+  *     the HTTP client for factory-built providers).
+  *   - Factory-built providers (via `OptimizelyProvider.make`/`scoped`/`layer`) perform no network activity and run no
+  *     background polling until `initialize()` — a provider that is constructed but never registered does not fetch,
+  *     retry, or log against an unreachable CDN.
   *
   * '''Decision mapping:'''
   *   - Boolean: returns `decision.getEnabled`.
@@ -46,7 +50,11 @@ import scala.util.Try
 final class OptimizelyFeatureProvider private[optimizely] (
   optimizely: Optimizely,
   initWait: java.time.Duration,
-  closeOnShutdown: Boolean
+  closeOnShutdown: Boolean,
+  // Present for factory-built providers: datafile polling is deliberately NOT running at construction
+  // (see OptimizelyProvider.buildClient); initialize() starts it, and shutdown() stops it via
+  // Optimizely.close(). Caller-managed clients (fromOptimizelyClient) own their polling lifecycle.
+  configManager: Option[com.optimizely.ab.config.HttpProjectConfigManager] = None
 ) extends EventProvider {
 
   // Public construction is via the OptimizelyProvider factory in this package — the constructor is private to keep
@@ -83,6 +91,10 @@ final class OptimizelyFeatureProvider private[optimizely] (
       )
     }
     notificationHandle.set(handlerId)
+
+    // Start datafile polling only now that the update handler is registered, so the first
+    // datafile-load notification cannot be missed. Construction performs no network activity.
+    configManager.foreach(_.start())
 
     if (optimizely.isValid) initLatch.countDown()
 

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
@@ -4,6 +4,7 @@ import com.optimizely.ab.Optimizely
 import com.optimizely.ab.config.HttpProjectConfigManager
 import zio._
 import zio.openfeature.FeatureFlagError
+import java.util.concurrent.TimeUnit
 
 /** Scala-friendly factories for an Optimizely-backed OpenFeature provider.
   *
@@ -49,6 +50,28 @@ import zio.openfeature.FeatureFlagError
   * Construction validates the SDK key (and URL, where applicable) before touching the Optimizely SDK; failures surface
   * as `FeatureFlagError.InvalidConfiguration` at layer build time, not at first evaluation.
   */
+/** Configuration for a factory-built Optimizely provider.
+  *
+  * @param sdkKey
+  *   Optimizely SDK key (validated — see [[OptimizelyProvider.make]])
+  * @param datafileUrl
+  *   Optional self-hosted datafile URL (Optimizely Agent); `None` uses the public CDN
+  * @param initWait
+  *   How long `initialize()` waits for the first datafile load before failing
+  * @param pollingInterval
+  *   Datafile poll interval; `None` uses the SDK default (5 minutes). Tests that need fast revision pickup (or
+  *   effectively none) can tune this instead of hand-rolling client construction.
+  * @param blockingTimeout
+  *   Upper bound on the SDK's internal blocking `getConfig()` waits; `None` uses the SDK default (10 seconds)
+  */
+final case class OptimizelyProviderConfig(
+  sdkKey: String,
+  datafileUrl: Option[String] = None,
+  initWait: java.time.Duration = OptimizelyProvider.DefaultInitWait,
+  pollingInterval: Option[java.time.Duration] = None,
+  blockingTimeout: Option[java.time.Duration] = None
+)
+
 object OptimizelyProvider {
 
   /** Default time the underlying `OptimizelyFeatureProvider.initialize()` will wait for the first datafile load before
@@ -82,16 +105,57 @@ object OptimizelyProvider {
     datafileUrl: Option[String],
     initWait: java.time.Duration
   ): IO[FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
+    make(OptimizelyProviderConfig(sdkKey, datafileUrl, initWait))
+
+  /** Validate the configuration and construct a provider.
+    *
+    * Construction performs no network activity and starts no background polling: the datafile poller is created paused
+    * and only starts inside `initialize()`. The returned provider owns a polling executor and an HTTP client — the
+    * caller is responsible for `shutdown()` (registering it with a `FeatureFlags` layer counts: the layer's finalizer
+    * shuts the provider down). Prefer [[scoped]] or [[layer]] to make that ownership explicit.
+    */
+  def make(config: OptimizelyProviderConfig): IO[FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
     for {
-      validKey <- validateSdkKey(sdkKey)
-      validUrl <- datafileUrl match {
+      validKey <- validateSdkKey(config.sdkKey)
+      validUrl <- config.datafileUrl match {
         case Some(u) => validateDatafileUrl(u).map(Some(_))
         case None    => ZIO.succeed(None: Option[String])
       }
-      client <- ZIO
-        .attempt(buildClient(validKey, validUrl))
+      _ <- validatePositive("pollingInterval", config.pollingInterval)
+      _ <- validatePositive("blockingTimeout", config.blockingTimeout)
+      pair <- ZIO
+        .attempt(buildClient(validKey, validUrl, config.pollingInterval, config.blockingTimeout))
         .mapError(t => FeatureFlagError.InvalidConfiguration(s"Optimizely client build failed: ${t.getMessage}"))
-    } yield new OptimizelyFeatureProvider(client, initWait, closeOnShutdown = true)
+    } yield new OptimizelyFeatureProvider(
+      pair._1,
+      config.initWait,
+      closeOnShutdown = true,
+      configManager = Some(pair._2)
+    )
+
+  /** [[make]] with scope-managed shutdown: when the surrounding `Scope` closes, the provider is shut down (bounded),
+    * stopping datafile polling and closing the SDK's HTTP client — even if the provider was never registered with a
+    * `FeatureFlags` layer or its initialization failed. This is the recommended construction for tests and for any
+    * composition where the provider might not reach a layer that owns its lifecycle.
+    */
+  def scoped(
+    config: OptimizelyProviderConfig
+  ): ZIO[Scope, FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
+    ZIO.acquireRelease(make(config))(releaseProvider)
+
+  /** [[scoped]] for the common CDN-only case. */
+  def scoped(sdkKey: String): ZIO[Scope, FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
+    scoped(OptimizelyProviderConfig(sdkKey))
+
+  /** Upper bound on provider teardown. `shutdown()` is `shutdownNow`-based and normally returns in milliseconds; the
+    * bound exists so a pathological close (e.g. an HTTP client wedged mid-request) cannot hang scope teardown — the
+    * SDK's polling and evictor threads are daemon, so the JVM can still exit either way.
+    */
+  private val ShutdownTimeout: zio.Duration = 10.seconds
+
+  private def releaseProvider(provider: OptimizelyFeatureProvider): UIO[Unit] =
+    // `.disconnect` because finalizers run uninterruptibly and the timeout must still fire.
+    ZIO.attemptBlocking(provider.shutdown()).disconnect.timeout(ShutdownTimeout).ignore
 
   /** Escape hatch for callers who already manage an `Optimizely` client lifecycle (e.g. they want their own polling
     * interval, event handler, or user profile service). The returned provider does NOT close the client on shutdown;
@@ -100,20 +164,33 @@ object OptimizelyProvider {
   def fromOptimizelyClient(client: Optimizely): UIO[OptimizelyFeatureProvider] =
     ZIO.succeed(new OptimizelyFeatureProvider(client, DefaultInitWait, closeOnShutdown = false))
 
-  /** ZLayer convenience that wraps [[make(String)]] for the common CDN-only case. */
+  /** ZLayer for the common CDN-only case. The layer owns the provider lifecycle: its finalizer shuts the provider down
+    * (stopping datafile polling and the HTTP client) when the layer is released.
+    */
   def layer(sdkKey: String): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
-    ZLayer.fromZIO(make(sdkKey))
+    layer(OptimizelyProviderConfig(sdkKey))
 
-  /** ZLayer convenience that wraps [[make(String, String)]]. */
+  /** ZLayer for a self-hosted datafile URL. Owns the provider lifecycle — see [[layer(String)]]. */
   def layer(
     sdkKey: String,
     datafileUrl: String
   ): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
-    ZLayer.fromZIO(make(sdkKey, datafileUrl))
+    layer(OptimizelyProviderConfig(sdkKey, datafileUrl = Some(datafileUrl)))
+
+  /** ZLayer from a full [[OptimizelyProviderConfig]]. Owns the provider lifecycle — see [[layer(String)]]. */
+  def layer(
+    config: OptimizelyProviderConfig
+  ): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
+    ZLayer.scoped(scoped(config))
 
   // Construction
 
-  private def buildClient(sdkKey: String, datafileUrl: Option[String]): Optimizely = {
+  private def buildClient(
+    sdkKey: String,
+    datafileUrl: Option[String],
+    pollingInterval: Option[java.time.Duration],
+    blockingTimeout: Option[java.time.Duration]
+  ): (Optimizely, HttpProjectConfigManager) = {
     // Share a single NotificationCenter between the polling config manager and the Optimizely client. Without this,
     // the manager fires UpdateConfigNotification on its own private NotificationCenter and handlers registered via
     // `Optimizely.addUpdateConfigNotificationHandler` (the public API our provider uses) never see subsequent datafile
@@ -123,8 +200,23 @@ object OptimizelyProvider {
     val notificationCenter = new com.optimizely.ab.notification.NotificationCenter()
     val configBuilder = HttpProjectConfigManager.builder().withSdkKey(sdkKey).withNotificationCenter(notificationCenter)
     datafileUrl.foreach(configBuilder.withUrl)
-    val configManager = configBuilder.build()
-    Optimizely.builder().withConfigManager(configManager).withNotificationCenter(notificationCenter).build()
+    pollingInterval.foreach(d =>
+      configBuilder.withPollingInterval(java.lang.Long.valueOf(d.toMillis), TimeUnit.MILLISECONDS)
+    )
+    blockingTimeout.foreach(d =>
+      configBuilder.withBlockingTimeout(java.lang.Long.valueOf(d.toMillis), TimeUnit.MILLISECONDS)
+    )
+    // `build()` (no-arg) would start polling AND block up to the SDK's blocking timeout (default 10s) waiting for
+    // the first datafile — with an unreachable CDN, construction stalls and then a background poller retries
+    // forever. `build(true)` skips the blocking wait but still calls `start()`, so we `stop()` immediately:
+    // construction performs no network activity, and `initialize()` starts polling once the update handler is in
+    // place. The first scheduled fetch may be submitted in the instant before `stop()` cancels it
+    // (`cancel(mayInterrupt = true)` on a daemon thread) — at most one aborted request, no lingering activity.
+    val configManager = configBuilder.build(true)
+    configManager.stop()
+    val optimizely =
+      Optimizely.builder().withConfigManager(configManager).withNotificationCenter(notificationCenter).build()
+    (optimizely, configManager)
   }
 
   // Validation
@@ -168,6 +260,16 @@ object OptimizelyProvider {
       else ZIO.succeed(trimmed)
     }
   }
+
+  private def validatePositive(
+    name: String,
+    value: Option[java.time.Duration]
+  ): IO[FeatureFlagError.InvalidConfiguration, Unit] =
+    ZIO.foreachDiscard(value.toList) { d =>
+      ZIO
+        .fail(FeatureFlagError.InvalidConfiguration(s"Optimizely $name must be positive: $d"))
+        .when(d.isNegative || d.isZero)
+    }
 
   private val AllowedDatafileSchemes = Set("http", "https")
 

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyPollingLifecycleSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyPollingLifecycleSpec.scala
@@ -1,0 +1,157 @@
+package zio.openfeature.optimizely
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import dev.openfeature.sdk.ImmutableContext
+import zio._
+import zio.test._
+
+/** Pins the datafile-polling lifecycle fixed in #208: a factory-built provider performs no network activity at
+  * construction, polls only between `initialize()` and `shutdown()`/scope close, and is therefore resilient to an
+  * unreachable CDN or bad keys (403): no background retry loop survives the provider's lifecycle.
+  */
+object OptimizelyPollingLifecycleSpec extends ZIOSpecDefault {
+
+  private val DatafilePath  = "/datafiles/polling-key.json"
+  private val ValidDatafile = readResource("/test-datafile-with-flag.json")
+  private val emptyContext  = new ImmutableContext()
+
+  private def readResource(path: String): String =
+    scala.io.Source.fromInputStream(getClass.getResourceAsStream(path)).mkString
+
+  // ZIO-friendly variant of the other specs' `withMockServer`: those run synchronous bodies, but here the
+  // bodies are effects — the server must live until the effect completes, not until the builder returns.
+  private def withMockServer[R, A](body: WireMockServer => ZIO[R, Any, A]): ZIO[R, Any, A] =
+    ZIO.acquireReleaseWith(
+      ZIO.attemptBlocking {
+        val server = new WireMockServer(WireMockConfiguration.options().dynamicPort())
+        server.start()
+        server
+      }
+    )(server => ZIO.attemptBlocking(server.stop()).ignore)(body)
+
+  private def datafileUrl(server: WireMockServer): String =
+    s"http://localhost:${server.port()}$DatafilePath"
+
+  private def requestCount(server: WireMockServer): Int =
+    server.getAllServeEvents.size()
+
+  private def sleepBlocking(d: Duration): UIO[Unit] =
+    ZIO.attemptBlocking(Thread.sleep(d.toMillis)).orDie
+
+  private def tryInit(provider: OptimizelyFeatureProvider): Either[Throwable, Unit] =
+    try { provider.initialize(emptyContext); Right(()) }
+    catch { case t: Throwable => Left(t) }
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("Optimizely datafile polling lifecycle (#208)")(
+    test("make performs no datafile fetch and does not block, even against a 403 CDN") {
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(aResponse().withStatus(403)))
+        for {
+          start <- ZIO.succeed(java.lang.System.nanoTime())
+          provider <- OptimizelyProvider.make(
+            "polling-key-1",
+            Some(datafileUrl(server)),
+            java.time.Duration.ofSeconds(1)
+          )
+          tookMs = (java.lang.System.nanoTime() - start) / 1000000L
+          // Give any (buggy) background poller a chance to fire before asserting silence
+          _        <- sleepBlocking(500.millis)
+          requests <- ZIO.succeed(requestCount(server))
+          _        <- ZIO.succeed(provider.shutdown())
+        } yield assertTrue(
+          // The old construction path blocked up to the SDK's 10s getConfig timeout
+          tookMs < 5000L,
+          requests == 0
+        )
+      }
+    },
+    test("polling runs only between initialize and shutdown") {
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafile)))
+        val config = OptimizelyProviderConfig(
+          sdkKey = "polling-key-2",
+          datafileUrl = Some(datafileUrl(server)),
+          initWait = java.time.Duration.ofSeconds(3),
+          pollingInterval = Some(java.time.Duration.ofMillis(200))
+        )
+        for {
+          provider   <- OptimizelyProvider.make(config)
+          beforeInit <- ZIO.succeed(requestCount(server))
+          initResult <- ZIO.succeed(tryInit(provider))
+          // pollingInterval is honored: several polls land within the window
+          _           <- sleepBlocking(1.second)
+          whileActive <- ZIO.succeed(requestCount(server))
+          _           <- ZIO.succeed(provider.shutdown())
+          afterStop   <- ZIO.succeed(requestCount(server))
+          _           <- sleepBlocking(700.millis)
+          afterWait   <- ZIO.succeed(requestCount(server))
+        } yield assertTrue(
+          beforeInit == 0,
+          initResult.isRight,
+          whileActive >= 3,
+          afterWait == afterStop
+        )
+      }
+    },
+    test("scoped releases the provider even when initialization failed against a 403 CDN") {
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(aResponse().withStatus(403)))
+        val config = OptimizelyProviderConfig(
+          sdkKey = "polling-key-3",
+          datafileUrl = Some(datafileUrl(server)),
+          initWait = java.time.Duration.ofMillis(400),
+          pollingInterval = Some(java.time.Duration.ofMillis(150))
+        )
+        for {
+          initResult <- ZIO.scoped {
+            for {
+              provider <- OptimizelyProvider.scoped(config)
+              result   <- ZIO.succeed(tryInit(provider))
+            } yield result
+          }
+          // Scope is closed: the failed provider must not keep retrying the 403 endpoint in the background
+          duringInit <- ZIO.succeed(requestCount(server))
+          _          <- sleepBlocking(700.millis)
+          afterClose <- ZIO.succeed(requestCount(server))
+        } yield assertTrue(
+          initResult.isLeft, // datafile never loaded
+          duringInit >= 1,   // polling genuinely ran during the init window
+          afterClose == duringInit
+        )
+      }
+    },
+    test("layer finalizer shuts polling down on release") {
+      withMockServer { server =>
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafile)))
+        val config = OptimizelyProviderConfig(
+          sdkKey = "polling-key-4",
+          datafileUrl = Some(datafileUrl(server)),
+          initWait = java.time.Duration.ofSeconds(3),
+          pollingInterval = Some(java.time.Duration.ofMillis(200))
+        )
+        for {
+          _ <- ZIO.scoped {
+            OptimizelyProvider.layer(config).build.flatMap { env =>
+              val provider = env.get[OptimizelyFeatureProvider]
+              ZIO.succeed(tryInit(provider)) *> sleepBlocking(500.millis)
+            }
+          }
+          afterRelease <- ZIO.succeed(requestCount(server))
+          _            <- sleepBlocking(700.millis)
+          afterWait    <- ZIO.succeed(requestCount(server))
+        } yield assertTrue(afterRelease >= 1, afterWait == afterRelease)
+      }
+    },
+    test("non-positive pollingInterval is rejected at construction") {
+      val config = OptimizelyProviderConfig(
+        sdkKey = "polling-key-5",
+        pollingInterval = Some(java.time.Duration.ZERO)
+      )
+      OptimizelyProvider.make(config).exit.map { exit =>
+        assertTrue(exit.isFailure)
+      }
+    }
+  ) @@ TestAspect.sequential @@ TestAspect.withLiveClock
+}


### PR DESCRIPTION
## Summary

Reported from a real project: with the Optimizely CDN unreachable (403 — bad/missing key or no egress), a test that merely *instantiated* the provider left a background datafile poller retrying forever and the build hung at exit. Verified against our dependency set from bytecode (full analysis in #208):

- `HttpProjectConfigManager.builder().build()` is `build(false)`: it unconditionally `start()`s polling **and blocks up to the SDK's 10s `getConfig` timeout** at construction. Our `make` therefore both stalled and began background fetching before any `initialize()` — contradicting its own ScalaDoc.
- `OptimizelyProvider.layer` registered no finalizer, so a provider that never reached a `FeatureFlags` layer leaked its poller and HTTP client for the JVM's lifetime.
- Mitigating facts in 4.2.2/httpclient 4.5.14: the poll thread and Apache's connection evictor are daemon, `close()` is `shutdownNow`-based, and no JVM shutdown hooks exist — the reporter's literal exit-hang needs their older/wrapped SDK, but the construction block, leak, and endless 403 retry-spam are fully real here.

**On the proposed solutions:** `pollIntervalSecs(Int.MaxValue)` is a stopgap (the first poll still fires immediately at `scheduleAtFixedRate` delay 0, it disables refresh if copied to prod, and lifecycle stays unowned) — though the underlying need for a polling-interval knob is legitimate and now met. The `ZLayer.scoped` + shutdown-finalizer proposal is correct and adopted, with a bounded finalizer. The daemon-thread-factory suggestion is already guaranteed by SDK 4.2.2 (it forces `setDaemon(true)` on any supplied factory); the real defense-in-depth for us is not starting polling at construction at all.

## Changes

- `buildClient` uses `build(true)` (skips the blocking `getConfig`) and immediately `stop()`s the manager — construction performs **no network activity**. `initialize()` starts polling after the datafile-update handler is registered (so the first load notification can't be missed); `shutdown()` stops it via `Optimizely.close()`.
- New `OptimizelyProviderConfig(sdkKey, datafileUrl, initWait, pollingInterval, blockingTimeout)` with validation (positive durations); existing `make` overloads delegate.
- New `OptimizelyProvider.scoped(...)`; `layer(...)` is now `ZLayer.scoped` and owns the provider lifecycle with a bounded (10s, disconnected) `shutdown()` finalizer — teardown happens even when the provider never registered or its init failed. Public layer types unchanged.
- Correctness under unreachable CDN / bad keys is preserved: the datafile never loads, `initialize` fails after `initWait`, sync layers fail the build, async layers go `Fatal` — evaluations fail with typed errors, never silently wrong values.
- CHANGELOG + docs/optimizely.md updated; the ScalaDoc claim "construction makes no network calls" is now actually true.

## Tests

New `OptimizelyPollingLifecycleSpec` (WireMock):
- `make` against a 403 CDN completes fast and performs **zero** datafile requests (the old path blocked ~10s and fetched — the pre-fix behavior is also why the existing structural test had to stub the CDN)
- polling runs only between `initialize` and `shutdown`, and `pollingInterval` is honored (several 200ms polls observed, none after stop)
- `scoped` stops the 403 retry loop at scope close even though initialization failed
- `layer` finalizer stops polling on release
- non-positive `pollingInterval` is rejected at construction

Full optimizely suite (47 tests) green.

Note: overlaps with PR #203 (lifecycle state machine) in `OptimizelyFeatureProvider.initialize` — whichever merges second needs a trivial rebase.

Fixes #208