### PR TITLE
Fix flaky Optimizely polling lifecycle test

### DIFF
--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyPollingLifecycleSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyPollingLifecycleSpec.scala
@@ -56,14 +56,17 @@ object OptimizelyPollingLifecycleSpec extends ZIOSpecDefault {
             java.time.Duration.ofSeconds(1)
           )
           tookMs = (java.lang.System.nanoTime() - start) / 1000000L
-          // Give any (buggy) background poller a chance to fire before asserting silence
+          // Give any (buggy) background poller a chance to fire before asserting near-silence
           _        <- sleepBlocking(500.millis)
           requests <- ZIO.succeed(requestCount(server))
           _        <- ZIO.succeed(provider.shutdown())
         } yield assertTrue(
           // The old construction path blocked up to the SDK's 10s getConfig timeout
           tookMs < 5000L,
-          requests == 0
+          // `buildClient` uses `build(true)` then `stop()`; the SDK's first scheduled fetch may be submitted in the
+          // instant before `stop()` cancels it, so the contract is "at most one aborted request" — not zero. Asserting
+          // `== 0` raced that window and flaked across both Scala versions (see #211).
+          requests <= 1
         )
       }
     },


### PR DESCRIPTION
Fixes #211.

## Problem

`OptimizelyPollingLifecycleSpec` line 66 asserts `requests == 0` after `OptimizelyProvider.make(...)` (construction only, no `initialize()`). This flakes across both Scala versions with `✗ 1 was not equal to 0` — observed in CI run 27469360245 (3.3.4 cell) and 27471042052 (2.13.16 cell).

## Root cause

`OptimizelyProvider.buildClient` documents the exact behavior: `build(true)` calls `start()`, and the immediate `stop()` races the SDK's first scheduled fetch — *"at most one aborted request, no lingering activity."* So the contract is **≤ 1**, not **0**. The test asserted an invariant the implementation deliberately does not provide.

## Fix

Relax the assertion to `requests <= 1` (the documented contract) with a comment tying it to the `build(true)` + `stop()` race. No product change — the behavior is intentional.

## Verification

`sbt optimizely/testOnly zio.openfeature.optimizely.OptimizelyPollingLifecycleSpec` → 5/5 pass.