### PR TITLE
[Experiment — do not merge] OpenFeature conformance via zio-bdd

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -203,6 +203,23 @@ lazy val conformance = (project in file("conformance"))
     )
   )
 
+// Experimental: the same OpenFeature gherkin suite run via `zio-bdd` (a ZIO-native BDD framework) instead of Cucumber,
+// to dog-food zio-bdd. Not published, not aggregated, Scala 3 only. Not intended to merge unless zio-bdd matures.
+lazy val conformanceZioBdd = (project in file("conformance-zio-bdd"))
+  .dependsOn(core, testkit)
+  .settings(
+    name               := "zio-openfeature-conformance-zio-bdd",
+    publish / skip     := true,
+    crossScalaVersions := Seq(scala3Version),
+    libraryDependencies ++= Seq(
+      "dev.openfeature"         % "sdk"                    % openFeatureSdkVersion % Test,
+      "io.github.etacassiopeia" %% "zio-bdd"               % "0.1.0"               % Test,
+      "dev.zio"                 %% "zio-schema"            % "1.6.6"               % Test,
+      "dev.zio"                 %% "zio-schema-derivation" % "1.6.6"               % Test
+    ),
+    Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
+  )
+
 // Reference applications. Not published; their value is staying compilable so the README and `examples/README.md`
 // snippets are guaranteed to work against the current public API.
 lazy val examplesCommon = Seq(

--- a/conformance-zio-bdd/README.md
+++ b/conformance-zio-bdd/README.md
@@ -1,0 +1,64 @@
+# Experimental: OpenFeature conformance via zio-bdd
+
+This module is a **dog-food experiment**: the same OpenFeature gherkin conformance suite that
+`conformance/` runs via Cucumber, re-implemented against [`zio-bdd`](https://github.com/EtaCassiopeia/zio-bdd)
+(0.1.0) — a ZIO-native BDD framework. **Not intended to merge** unless zio-bdd matures enough for
+real use. Not aggregated by root; Scala 3 only.
+
+Run: `sbt conformanceZioBdd/test`
+
+## What works (and reads nicely)
+
+The zio-bdd model is a good fit where it works:
+
+- **Native ZIO step bodies** — no `Unsafe.run` bridge (the Cucumber version needs one). Steps return
+  `RIO[R with State[S], Unit]` and run on zio-bdd's own runtime.
+- **`ScenarioContext`** (FiberRef-isolated per scenario) holds typed state. It can hold opaque
+  references (the live `FeatureFlags`, recorder `Ref`s) since it only needs a `Default`, not a Schema.
+- **`table[T]`** maps a gherkin data table to `List[T]` via a zio-schema record — clean for the
+  metadata/hook tables.
+- Provider setup, Scenario Outline + Examples, and the `@Suite` annotation all work.
+
+Currently green: `metadata.feature` (5 scenarios) and the first two scenarios of `hooks.feature`
+(including the `FLAG_NOT_FOUND` → error-hook case, which exercises the §4.4.6 alignment).
+
+## What's blocked (zio-bdd gaps found — see filed issues)
+
+The `.feature` files here are **modified** from the verbatim upstream copies in `conformance/`
+(Examples names stripped, hooks reduced to 2 scenarios) to work around parser gaps. The originals
+that don't parse are kept under `blocked/` as repro evidence.
+
+Gaps surfaced during this migration (filed against zio-bdd):
+
+1. **Gherkin parser — named `Examples:` blocks** (`Examples: Boolean evaluations`) are rejected
+   (`expected "|"`). Standard Gherkin allows an Examples description.
+2. **Gherkin parser — tags with `-`/`.`** (`@spec-1.3.1.1`, `@error-handling`) stop tokenizing at the
+   hyphen. Blocks all of `evaluation_v2.feature`.
+3. **Gherkin parser — tags on `Examples:` blocks** (`@transaction` above an Examples table) →
+   `expected end-of-input`. Blocks `contextMerging.feature`.
+4. **Gherkin parser — 3+ scenarios each ending in a data table** → `expected end-of-input` at the
+   third table. Blocks the full `hooks.feature` (2 scenarios parse, 3 don't).
+5. **`table[T]` requires a header row** and there's no raw-`DataTable` access in a step signature, so
+   the headerless "levels of increasing precedence" table can't be consumed.
+6. **Minor** — the `@Suite` default `reporters = {"console"}` warns `Unknown reporter 'console'`; and
+   the README's `ScenarioContext.get.map(_ => assertTrue(...))` discards the assertion effect (should
+   be `flatMap`, else assertions never run).
+
+Filed against zio-bdd: parser gaps
+[#36](https://github.com/EtaCassiopeia/zio-bdd/issues/36) (named Examples),
+[#37](https://github.com/EtaCassiopeia/zio-bdd/issues/37) (hyphen/dot tags),
+[#38](https://github.com/EtaCassiopeia/zio-bdd/issues/38) (Examples-block tags),
+[#39](https://github.com/EtaCassiopeia/zio-bdd/issues/39) (3+ table scenarios);
+[#40](https://github.com/EtaCassiopeia/zio-bdd/issues/40) (headerless tables);
+[#41](https://github.com/EtaCassiopeia/zio-bdd/issues/41) (reporter default + docs).
+
+## Comparison with the Cucumber suite
+
+| Aspect | Cucumber (`conformance/`) | zio-bdd (this module) |
+|---|---|---|
+| Effect model | `Unsafe.run` bridge in every step | native ZIO |
+| Per-scenario state | mutable `var`s in glue class | typed `ScenarioContext` (FiberRef) |
+| Feature-file fidelity | verbatim, all 4 files, 110 scenarios | modified; 2 files, 7 scenarios (parser gaps) |
+| Maturity | production | experimental (0.1.0) |
+
+The ergonomics are promising; the blocker is the gherkin parser's coverage of standard syntax.

--- a/conformance-zio-bdd/blocked/contextMerging.feature
+++ b/conformance-zio-bdd/blocked/contextMerging.feature
@@ -1,0 +1,128 @@
+Feature: Context merging precedence
+
+  Background:
+    Given a stable provider with retrievable context is registered
+
+  Scenario Outline: A context entry is added to a single level
+    Given A context entry with key "key" and value "value" is added to the "<level>" level
+    When Some flag was evaluated
+    Then The merged context contains an entry with key "key" and value "value"
+
+    @transaction
+    Examples:
+      | level       |
+      | API         |
+      | Transaction |
+      | Client      |
+      | Invocation  |
+
+    @hooks
+    Examples:
+      | level        |
+      | API          |
+      | Client       |
+      | Invocation   |
+      | Before Hooks |
+
+    @hooks @transaction
+    Examples:
+      | level        |
+      | API          |
+      | Transaction  |
+      | Client       |
+      | Invocation   |
+      | Before Hooks |
+
+  @transaction
+  Scenario: For a transaction, a context entry is added to each level with different keys
+    Given A context entry with key "API" and value "API value" is added to the "API" level
+    And A context entry with key "Transaction" and value "Transaction value" is added to the "Transaction" level
+    And A context entry with key "Client" and value "Client value" is added to the "Client" level
+    And A context entry with key "Invocation" and value "Invocation value" is added to the "Invocation" level
+    When Some flag was evaluated
+    Then The merged context contains an entry with key "API" and value "API value"
+    And The merged context contains an entry with key "Transaction" and value "Transaction value"
+    And The merged context contains an entry with key "Client" and value "Client value"
+    And The merged context contains an entry with key "Invocation" and value "Invocation value"
+
+  @hooks
+  Scenario: For a hook, a context entry is added to each level with different keys
+    Given A context entry with key "API" and value "API value" is added to the "API" level
+    And A context entry with key "Client" and value "Client value" is added to the "Client" level
+    And A context entry with key "Invocation" and value "Invocation value" is added to the "Invocation" level
+    And A context entry with key "Before Hooks" and value "Before Hooks value" is added to the "Before Hooks" level
+    When Some flag was evaluated
+    Then The merged context contains an entry with key "API" and value "API value"
+    And The merged context contains an entry with key "Client" and value "Client value"
+    And The merged context contains an entry with key "Invocation" and value "Invocation value"
+    And The merged context contains an entry with key "Before Hooks" and value "Before Hooks value"
+
+  @hooks @transaction
+  Scenario: For a transaction and a hook, a context entry is added to each level with different keys
+    Given A context entry with key "API" and value "API value" is added to the "API" level
+    And A context entry with key "Transaction" and value "Transaction value" is added to the "Transaction" level
+    And A context entry with key "Client" and value "Client value" is added to the "Client" level
+    And A context entry with key "Invocation" and value "Invocation value" is added to the "Invocation" level
+    And A context entry with key "Before Hooks" and value "Before Hooks value" is added to the "Before Hooks" level
+    When Some flag was evaluated
+    Then The merged context contains an entry with key "API" and value "API value"
+    And The merged context contains an entry with key "Transaction" and value "Transaction value"
+    And The merged context contains an entry with key "Client" and value "Client value"
+    And The merged context contains an entry with key "Invocation" and value "Invocation value"
+    And The merged context contains an entry with key "Before Hooks" and value "Before Hooks value"
+
+  @transaction
+  Scenario Outline: For a transaction, a context entry in one level overwrites values with the same key from preceding levels
+    Given A table with levels of increasing precedence
+      | API         |
+      | Transaction |
+      | Client      |
+      | Invocation  |
+    And Context entries for each level from API level down to the "<level>" level, with key "key" and value "<level>"
+    When Some flag was evaluated
+    Then The merged context contains an entry with key "key" and value "<level>"
+
+    Examples:
+      | level       |
+      | API         |
+      | Transaction |
+      | Client      |
+      | Invocation  |
+
+  @hooks
+  Scenario Outline: For a hook, a context entry in one level overwrites values with the same key from preceding levels
+    Given A table with levels of increasing precedence
+      | API          |
+      | Client       |
+      | Invocation   |
+      | Before Hooks |
+    And Context entries for each level from API level down to the "<level>" level, with key "key" and value "<level>"
+    When Some flag was evaluated
+    Then The merged context contains an entry with key "key" and value "<level>"
+
+    Examples:
+      | level        |
+      | API          |
+      | Client       |
+      | Invocation   |
+      | Before Hooks |
+
+  @hooks @transaction
+  Scenario Outline: For a transaction and a hook, context entry in one level overwrites values with the same key from preceding levels
+    Given A table with levels of increasing precedence
+      | API          |
+      | Transaction  |
+      | Client       |
+      | Invocation   |
+      | Before Hooks |
+    And Context entries for each level from API level down to the "<level>" level, with key "key" and value "<level>"
+    When Some flag was evaluated
+    Then The merged context contains an entry with key "key" and value "<level>"
+
+    Examples:
+      | level        |
+      | API          |
+      | Transaction  |
+      | Client       |
+      | Invocation   |
+      | Before Hooks |

--- a/conformance-zio-bdd/blocked/evaluation_v2.feature
+++ b/conformance-zio-bdd/blocked/evaluation_v2.feature
@@ -1,0 +1,596 @@
+Feature: Flag Evaluations - Complete OpenFeature Specification Coverage
+  # This comprehensive test suite covers all OpenFeature specification requirements
+  # for flag evaluation, including error handling, provider states, and edge cases.
+
+    Background:
+    # Implicitly tests spec 1.1.2.1 (provider mutator) and 1.7.3 (READY status after initialize)
+        Given a stable provider
+
+  # Spec 1.3.1.1 & 1.4.1.1: Basic typed flag evaluation with detailed evaluation
+  # Testing: getBooleanValue, getStringValue, getIntegerValue, getFloatValue methods
+  # Implicitly tests: 1.1.6 (client creation), 1.1.7 (client creation no throw), 1.4.3 (value field), 1.4.10 (no exceptions)
+    @spec-1.3.1.1 @spec-1.4.1.1 @spec-1.1.6 @spec-1.1.7 @spec-1.4.3 @spec-1.4.10
+    Scenario Outline: Resolve values
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        When the flag was evaluated with details
+        Then the resolved details value should be "<resolved_value>"
+        @booleans
+        Examples:
+            | key          | type    | default | resolved_value |
+            | boolean-flag | Boolean | false   | true           |
+        @strings
+        Examples:
+            | key         | type   | default | resolved_value |
+            | string-flag | String | bye     | hi             |
+        @numbers
+        Examples:
+            | key          | type    | default | resolved_value |
+            | integer-flag | Integer | 1       | 10             |
+            | float-flag   | Float   | 0.1     | 0.5            |
+        @objects
+        Examples:
+            | key         | type   | default | resolved_value                                                                     |
+            | object-flag | Object | {}      | {\"showImages\": true,\"title\": \"Check out these pics!\",\"imagesPerPage\": 100} |
+
+  # Spec 1.4.7: Testing reason field population in normal execution
+  # Testing: evaluation details structure contains correct reason
+    @spec-1.4.7
+    Scenario Outline: Resolves zero value
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        When the flag was evaluated with details
+        Then the resolved details value should be "<resolved_value>"
+        And the reason should be "STATIC"
+
+        @booleans
+        Examples:
+            | key               | type    | default | resolved_value |
+            | boolean-zero-flag | Boolean | true    | false          |
+
+        @strings
+        Examples:
+            | key              | type   | default | resolved_value |
+            | string-zero-flag | String | hi      |                |
+
+        @numbers
+        Examples:
+            | key               | type    | default | resolved_value |
+            | integer-zero-flag | Integer | 1       | 0              |
+            | float-zero-flag   | Float   | 0.1     | 0.0            |
+
+        @objects
+        Examples:
+            | key              | type   | default | resolved_value                                                                     |
+            | object-zero-flag | Object | {\"a\": 1} | {}                                                                                 |
+
+  # Spec 1.4.7: Testing TARGETING_MATCH reason with evaluation context
+  # Testing: dynamic context paradigm with targeting rules
+    @targeting @spec-1.4.7
+    Scenario Outline: Resolves zero value with targeting
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        And a context containing a key "email", with type "String" and with value "ballmer@macrosoft.com"
+        When the flag was evaluated with details
+        Then the resolved details value should be "<resolved_value>"
+        And the reason should be "TARGETING_MATCH"
+
+        @booleans
+        Examples:
+            | key                        | type    | default | resolved_value |
+            | boolean-targeted-zero-flag | Boolean | true    | false          |
+
+        @strings
+        Examples:
+            | key                       | type   | default | resolved_value |
+            | string-targeted-zero-flag | String | hi      |                |
+
+        @numbers
+        Examples:
+            | key                        | type    | default | resolved_value |
+            | integer-targeted-zero-flag | Integer | 1       | 0              |
+            | float-targeted-zero-flag   | Float   | 0.1     | 0.0            |
+
+        @objects
+        Examples:
+            | key                       | type   | default    | resolved_value |
+            | object-targeted-zero-flag | Object | {\"a\": 1} | {}             |
+
+  # Spec 1.4.7: Testing DEFAULT reason when targeting doesn't match
+  # Testing: fallback to default value when context doesn't match targeting rules
+    @targeting @spec-1.4.7
+    Scenario Outline: Resolves zero value with targeting using default
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        And a context containing a key "email", with type "String" and with value "ballmer@none.com"
+        When the flag was evaluated with details
+        Then the resolved details value should be "<resolved_value>"
+        And the reason should be "DEFAULT"
+
+        @booleans
+        Examples:
+            | key                        | type    | default | resolved_value |
+            | boolean-targeted-zero-flag | Boolean | true    | false          |
+
+        @strings
+        Examples:
+            | key                       | type   | default | resolved_value |
+            | string-targeted-zero-flag | String | hi      |                |
+
+        @numbers
+        Examples:
+            | key                        | type    | default | resolved_value |
+            | integer-targeted-zero-flag | Integer | 1       | 0              |
+            | float-targeted-zero-flag   | Float   | 0.1     | 0.0            |
+
+        @objects
+        Examples:
+            | key                       | type   | default    | resolved_value |
+            | object-targeted-zero-flag | Object | {\"a\": 1} | {}             |
+
+  # Spec 1.4.8 & 1.4.9 & 1.4.13: Testing FLAG_NOT_FOUND error code in abnormal execution
+  # Testing: client must return default value and error code when flag doesn't exist
+  # Implicitly tests: 1.4.10 (client never throws exceptions - returns default instead)
+    @error-handling @error-handling-not-found @spec-1.4.8 @spec-1.4.9 @spec-1.4.10 @spec-1.4.13
+    Scenario Outline: Flag not found error
+        Given a <type>-flag with key "non-existent-flag" and a fallback value "<default>"
+        When the flag was evaluated with details
+        Then the resolved details value should be "<default>"
+        And the reason should be "ERROR"
+        And the error-code should be "FLAG_NOT_FOUND"
+
+        @booleans
+        Examples:
+            | type    | default |
+            | Boolean | false   |
+
+        @strings
+        Examples:
+            | type   | default |
+            | String | bye     |
+
+        @numbers
+        Examples:
+            | type    | default |
+            | Integer | 1       |
+            | Float   | 0.1     |
+
+        @objects
+        Examples:
+            | type   | default    |
+            | Object | {\"a\": 1} |
+
+  # Spec 1.3.4: Testing type mismatch handling - wrong type evaluation
+  # Testing: client should return default value when provider returns wrong type
+  # Note: Test data setup ensures the flag returns wrong type, triggering type mismatch
+  # Implicitly tests: 1.4.10 (client never throws exceptions - returns default instead)
+    @error-handling @error-handling-types @spec-1.3.4 @spec-1.4.10
+    Scenario Outline: Type mismatch error
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        When the flag was evaluated with details
+        Then the resolved details value should be "<default>"
+        And the reason should be "ERROR"
+        And the error-code should be "TYPE_MISMATCH"
+
+        @booleans
+        Examples:
+            | key          | type    | default |
+            | string-flag  | Boolean | false   |
+
+        @strings
+        Examples:
+            | key          | type   | default |
+            | boolean-flag | String | bye     |
+
+        @numbers
+        Examples:
+            | key          | type    | default |
+            | boolean-flag | Integer | 1       |
+            | boolean-flag | Float   | 0.1     |
+
+        @objects
+        Examples:
+            | key          | type   | default    |
+            | boolean-flag | Object | {\"a\": 1} |
+
+  # Spec 1.7.6: Testing PROVIDER_NOT_READY error when provider isn't initialized
+  # Testing: client must short-circuit and return error when provider not ready
+  # Implicitly tests: 1.4.10 (client never throws exceptions - returns default instead)
+    @provider-status @spec-1.7.6 @spec-1.4.10
+    Scenario Outline: Provider not ready error
+        Given a not ready provider
+        And a <type>-flag with key "<key>" and a fallback value "<default>"
+        When the flag was evaluated with details
+        Then the resolved details value should be "<default>"
+        And the reason should be "ERROR"
+        And the error-code should be "PROVIDER_NOT_READY"
+
+        @booleans
+        Examples:
+            | key          | type    | default |
+            | boolean-flag | Boolean | false   |
+
+        @strings
+        Examples:
+            | key         | type   | default |
+            | string-flag | String | bye     |
+
+        @numbers
+        Examples:
+            | key          | type    | default |
+            | integer-flag | Integer | 1       |
+            | float-flag   | Float   | 0.1     |
+
+        @objects
+        Examples:
+            | key         | type   | default    |
+            | object-flag | Object | {\"a\": 1} |
+
+  # Spec 1.7.7: Testing PROVIDER_FATAL error when provider is in fatal state
+  # Testing: client must short-circuit and return error when provider is fatal
+  # Implicitly tests: 1.4.10 (client never throws exceptions - returns default instead), 1.7.5 (FATAL status)
+    @provider-status @provider-status-fatal @spec-1.7.7 @spec-1.4.10 @spec-1.7.5
+    Scenario Outline: Provider in fatal state error
+        Given a fatal provider
+        And a <type>-flag with key "<key>" and a fallback value "<default>"
+        When the flag was evaluated with details
+        Then the resolved details value should be "<default>"
+        And the reason should be "ERROR"
+        And the error-code should be "PROVIDER_FATAL"
+
+        @booleans
+        Examples:
+            | key          | type    | default |
+            | boolean-flag | Boolean | false   |
+
+        @strings
+        Examples:
+            | key         | type   | default |
+            | string-flag | String | bye     |
+
+        @numbers
+        Examples:
+            | key          | type    | default |
+            | integer-flag | Integer | 1       |
+            | float-flag   | Float   | 0.1     |
+
+        @objects
+        Examples:
+            | key         | type   | default    |
+            | object-flag | Object | {\"a\": 1} |
+
+  # Spec 1.4.3, 1.4.5, 1.4.6: Testing complete evaluation details structure
+  # Testing: evaluation details must contain value, flagKey, and variant fields
+    @evaluation-details @spec-1.4.3 @spec-1.4.5 @spec-1.4.6
+    Scenario Outline: Complete evaluation details structure
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        When the flag was evaluated with details
+        Then the resolved details value should be "<resolved_value>"
+        And the flag key should be "<key>"
+        And the variant should be "<expected_variant>"
+        And the reason should be "STATIC"
+        @booleans
+        Examples:
+            | key          | type    | default | resolved_value | expected_variant |
+            | boolean-flag | Boolean | false   | true           | on               |
+
+        @strings
+        Examples:
+            | key         | type   | default | resolved_value | expected_variant |
+            | string-flag | String | bye     | hi             | greeting         |
+
+        @numbers
+        Examples:
+            | key          | type    | default | resolved_value | expected_variant |
+            | integer-flag | Integer | 1       | 10             | ten              |
+            | float-flag   | Float   | 0.1     | 0.5            | half             |
+
+        @objects
+        Examples:
+            | key         | type   | default | resolved_value                        | expected_variant |
+            | object-flag | Object | {}      | {\"showImages\": true,\"title\": \"Check out these pics!\",\"imagesPerPage\": 100} | template         |
+
+  # Spec 1.4.14: Testing flag metadata field in evaluation details
+  # Testing: flag metadata must be included in evaluation details if present
+  # Note: Test data setup ensures these flags have metadata configured
+    @evaluation-details @metadata @spec-1.4.14
+    Scenario: Flag metadata in evaluation details
+        Given a Boolean-flag with key "metadata-flag" and a fallback value "true"
+        When the flag was evaluated with details
+        Then the resolved metadata should contain
+            | key     | metadata_type | value |
+            | string  | String        | 1.0.2 |
+            | integer | Integer       | 2     |
+            | float   | Float         | 0.1   |
+            | boolean | Boolean       | true  |
+
+
+  # Spec 1.3.1.1: Testing evaluation with empty context
+  # Testing: targeting rules should fall back to default when context is empty
+    @context-handling @spec-1.3.1.1
+    Scenario Outline: Empty evaluation context
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        When the flag was evaluated with details
+        Then the resolved details value should be "<value>"
+        And the reason should be "DEFAULT"
+
+        @booleans
+        Examples:
+            | key                        | type    | value | default |
+            | boolean-targeted-zero-flag | Boolean | false | true    |
+
+        @strings
+        Examples:
+            | key                       | type   | value | default |
+            | string-targeted-zero-flag | String |       | str     |
+
+        @numbers
+        Examples:
+            | key                        | type    | value | default |
+            | integer-targeted-zero-flag | Integer | 0     | 1       |
+            | float-targeted-zero-flag   | Float   | 0.0   | 1.0     |
+
+        @objects
+        Examples:
+            | key                       | type   | value | default    |
+            | object-targeted-zero-flag | Object | {}    | {\"a\": 1} |
+
+
+  # Spec 1.3.1.1: Testing evaluation with null context values
+  # Testing: targeting rules should handle null values gracefully
+    @context-handling @spec-1.3.1.1
+    Scenario Outline: Null context values
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        And a context containing a key "email" with null value
+        When the flag was evaluated with details
+        Then the resolved details value should be "<value>"
+        And the reason should be "DEFAULT"
+
+        @booleans
+        Examples:
+            | key                        | type    | value | default |
+            | boolean-targeted-zero-flag | Boolean | false | true    |
+
+        @strings
+        Examples:
+            | key                       | type   | value | default |
+            | string-targeted-zero-flag | String |       | str     |
+
+        @numbers
+        Examples:
+            | key                        | type    | value | default |
+            | integer-targeted-zero-flag | Integer | 0     | 1       |
+            | float-targeted-zero-flag   | Float   | 0.0   | 1.0     |
+
+        @objects
+        Examples:
+            | key                       | type   | value | default    |
+            | object-targeted-zero-flag | Object | {}    | {\"a\": 1} |
+
+
+  # Spec 1.3.1.1: Testing evaluation with multiple context attributes
+  # Testing: complex targeting rules with multiple context fields
+    @context-handling @targeting @spec-1.3.1.1
+    Scenario: Multiple context attributes targeting
+        Given a String-flag with key "complex-targeted" and a fallback value "default"
+        And a context containing a key "email", with type "String" and with value "ballmer@macrosoft.com"
+        And a context containing a key "role", with type "String" and with value "admin"
+        And a context containing a key "age", with type "Integer" and with value "65"
+        And a context containing a key "customer", with type "Boolean" and with value "false"
+        When the flag was evaluated with details
+        Then the resolved details value should be "INTERNAL"
+        And the reason should be "TARGETING_MATCH"
+
+  # Spec 1.3.1.1: Testing structure/object flag evaluation
+  # Testing: structured data evaluation using existing steps with JSON data
+    @data-types @spec-1.3.1.1
+    Scenario: Structure flag evaluation
+        Given a Object-flag with key "object-flag" and a fallback value "{}"
+        When the flag was evaluated with details
+        Then the resolved details value should be "{\"showImages\": true,\"title\": \"Check out these pics!\",\"imagesPerPage\": 100}"
+        And the reason should be "STATIC"
+
+  # Spec 1.4.6: Testing variant field population in evaluation details
+  # Testing: variant field must contain provider's variant value
+    @variants @spec-1.4.6
+    Scenario Outline: Variant field population
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        When the flag was evaluated with details
+        Then the variant should be "<expected_variant>"
+
+        @booleans
+        Examples:
+            | key          | type    | default | expected_variant |
+            | boolean-flag | Boolean | false   | on               |
+
+        @strings
+        Examples:
+            | key         | type   | default | expected_variant |
+            | string-flag | String | bye     | greeting         |
+
+        @numbers
+        Examples:
+            | key          | type    | default | expected_variant |
+            | integer-flag | Integer | 1       | ten              |
+
+            | float-flag   | Float   | 0.1     | half             |
+
+        @objects
+        Examples:
+            | key         | type   | default | expected_variant |
+            | object-flag | Object | {}      | template         |
+
+
+  # Spec 1.4.7: Testing CACHED reason code
+  # Testing: provider can return CACHED reason for performance optimization
+    @reason-codes @reason-codes-cached @spec-1.4.7
+    Scenario Outline: CACHED reason
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        When the flag was evaluated with details
+        And the flag was evaluated with details
+        Then the reason should be "CACHED"
+        Examples:
+            | key          | type    | default |
+            | boolean-flag | Boolean | false   |
+            | string-flag  | String  | bye     |
+
+  # Spec 1.4.7: Testing DISABLED reason code
+  # Testing: provider can return DISABLED reason when flag is turned off
+  # Note: Test data setup ensures these flags are configured as disabled
+    @reason-codes @reason-codes-disabled @spec-1.4.7
+    Scenario Outline: DISABLED reason
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        When the flag was evaluated with details
+        Then the resolved details value should be "<default>"
+        And the reason should be "DISABLED"
+
+        @booleans
+        Examples:
+            | key                   | type    | default |
+            | boolean-disabled-flag | Boolean | false   |
+
+        @strings
+        Examples:
+            | key                  | type   | default |
+            | string-disabled-flag | String | bye     |
+
+        @numbers
+        Examples:
+            | key                   | type    | default |
+            | integer-disabled-flag | Integer | 1       |
+            | float-disabled-flag   | Float   | 0.1     |
+
+        @objects
+        Examples:
+            | key                  | type   | default    |
+            | object-disabled-flag | Object | {\"a\": 1} |
+
+
+  # Spec 1.7.1: Testing provider status accessibility
+  # Testing: client must expose provider status (READY, NOT_READY, ERROR, etc.)
+  # Implicitly tests: 1.7.4 (ERROR status), 1.7.5 (FATAL status)
+    @provider-status @spec-1.7.1 @spec-1.7.4 @spec-1.7.5
+    Scenario Outline: Provider status accessibility
+        Given a <status> provider
+        Then the provider status should be "<status_code>"
+        Examples:
+            | status    | status_code |
+            | stable    | READY       |
+            | not ready | NOT_READY   |
+            | error     | ERROR       |
+            | fatal     | FATAL       |
+            | stale     | STALE       |
+
+  # Spec 1.5.1: Testing evaluation options with hooks
+  # Testing: evaluation options can specify hooks to execute during evaluation
+    @hooks @evaluation-options @spec-1.5.1
+    Scenario: Evaluation options with hooks
+        Given a Boolean-flag with key "boolean-flag" and a fallback value "false"
+        And evaluation options containing specific hooks
+        When the flag was evaluated with details using the evaluation options
+        Then the specified hooks should execute during evaluation
+        And the hook order should be maintained
+
+
+  # Testing immutability requirements (Spec 1.4.15/1.4.15.1)
+  # Testing: flag metadata must be immutable
+    @immutability @spec-1.4.15.1
+    Scenario: Evaluation context immutability
+        Given a Boolean-flag with key "boolean-flag" and a fallback value "false"
+        And an evaluation context with modifiable data
+        When the flag was evaluated with details
+        Then the original evaluation context should remain unmodified
+        And the evaluation details should be immutable
+
+  # Testing async/non-blocking mechanisms (Spec 1.4.12)
+  # Testing: client should provide asynchronous mechanisms for flag evaluation
+    @async @spec-1.4.12
+    Scenario Outline: Asynchronous flag evaluation
+        Given a <type>-flag with key "<key>" and a fallback value "<default>"
+        When the flag was evaluated with details asynchronously
+        Then the evaluation should complete without blocking
+        And the resolved details value should be "<resolved_value>"
+
+        @booleans
+        Examples:
+            | key          | type    | default | resolved_value |
+            | boolean-flag | Boolean | false   | true           |
+
+        @strings
+        Examples:
+            | key         | type   | default | resolved_value |
+            | string-flag | String | bye     | hi             |
+
+        @numbers
+        Examples:
+            | key          | type    | default | resolved_value |
+            | integer-flag | Integer | 1       | 10             |
+            | float-flag   | Float   | 0.1     | 0.5            |
+
+        @objects
+        Examples:
+            | key         | type   | default | resolved_value                                                                     |
+            | object-flag | Object | {}      | {\"showImages\": true,\"title\": \"Check out these pics!\",\"imagesPerPage\": 100} |
+#
+# IMPLICIT SPECIFICATION COVERAGE NOTES:
+#
+# The following OpenFeature specification requirements are tested IMPLICITLY
+# through the behavior of existing scenarios, without requiring dedicated test cases:
+#
+# @spec-1.4.10 - "Client MUST NOT throw exceptions"
+#   → Implicitly tested in ALL error scenarios (FLAG_NOT_FOUND, TYPE_MISMATCH,
+#     PROVIDER_NOT_READY, PROVIDER_FATAL). If exceptions were thrown, these tests
+#     would fail when checking "Then the resolved details value should be <default>".
+#   → Covered by scenarios: Flag not found error, Type mismatch error,
+#     Provider not ready error, Provider in fatal state error
+#
+# @spec-1.1.2.1 - "API MUST define a provider mutator to set default provider"
+#   → Implicitly tested by Background step "Given a stable provider" which
+#     requires the API to set/configure a provider
+#   → Covered by: Background setup in all scenarios
+#
+# @spec-1.1.6 - "API MUST provide function for creating a client"
+#   → Implicitly tested in ALL scenarios that use "When the flag was evaluated"
+#     since flag evaluation requires a client instance
+#   → Covered by: All evaluation scenarios
+#
+# @spec-1.1.7 - "Client creation function MUST NOT throw"
+#   → Implicitly tested in ALL scenarios - if client creation threw exceptions,
+#     no scenarios could proceed to flag evaluation
+#   → Covered by: All scenarios that successfully reach evaluation steps
+#
+# @spec-1.3.1.1 - "Client MUST provide typed flag evaluation methods"
+#   → Implicitly tested by successful evaluation of Boolean, String, Integer, Float types
+#   → Additional coverage: All basic "Resolve values" scenarios demonstrate
+#     the required typed evaluation methods work correctly
+#   → Covered by: All typed evaluation scenarios
+#
+# @spec-1.3.3.1 - "Client SHOULD provide functions for floating-point numbers and integers"
+#   → Implicitly tested by successful evaluation of both Integer and Float flag types
+#   → in the "Resolve values" scenario which evaluates integer-flag and float-flag
+#   → If type distinction wasn't properly implemented, these evaluations would fail
+#   → Covered by: Resolve values scenario with integer-flag and float-flag examples
+#
+# @spec-1.4.3 - "Evaluation details value field MUST contain evaluated flag value"
+#   → Implicitly tested in ALL detailed evaluation scenarios via
+#     "Then the resolved details value should be <value>"
+#   → Covered by: All scenarios using detailed evaluation
+#
+# @spec-1.4.11 - "Client methods SHOULD NOT write log messages"
+#   → Cannot be directly tested via Gherkin, but implicitly verified by
+#     ensuring evaluation methods don't produce unwanted side effects
+#   → Behavioral requirement verified through implementation review
+#
+# @spec-1.7.3 - "Provider status MUST indicate READY after successful initialize"
+#   → Implicitly tested by Background "Given a stable provider" followed by
+#     successful flag evaluations - if provider wasn't READY, evaluations would fail
+#   → Covered by: All scenarios that successfully evaluate flags after stable provider setup
+#
+# @spec-1.7.4 - "Provider status MUST indicate ERROR after failed initialize"
+#   → Implicitly tested by "Given a error provider" scenarios
+#   → Covered by: Provider status accessibility scenarios with error provider
+#
+# @spec-1.7.5 - "Provider status MUST indicate FATAL for PROVIDER_FATAL error"
+#   → Implicitly tested by "Given a fatal provider" scenarios
+#   → Covered by: Provider status accessibility and Provider in fatal state error scenarios
+#
+# Note: These implicit tests provide coverage without requiring additional scenarios,
+# demonstrating that the OpenFeature specification requirements are naturally
+# satisfied by the expected behavior of a compliant implementation.
+#

--- a/conformance-zio-bdd/blocked/hooks.feature
+++ b/conformance-zio-bdd/blocked/hooks.feature
@@ -1,0 +1,49 @@
+@hooks
+Feature: Evaluation details through hooks
+
+# This test suite contains scenarios to test the functionality of hooks.
+
+  Background:
+    Given a stable provider
+
+  Scenario: Passes evaluation details to after and finally hooks
+    Given a client with added hook
+    And a boolean-flag with key "boolean-flag" and a fallback value "false"
+    When the flag was evaluated with details
+    Then the "before" hook should have been executed
+    And the "after, finally" hooks should be called with evaluation details
+      | data_type | key        | value        |
+      | string    | flag_key   | boolean-flag |
+      | boolean   | value      | true         |
+      | string    | variant    | on           |
+      | string    | reason     | STATIC       |
+      | string    | error_code | null         |
+
+  # errors
+  Scenario: Flag not found
+    Given a client with added hook
+    And a string-flag with key "missing-flag" and a fallback value "uh-oh"
+    When the flag was evaluated with details
+    Then the "before" hook should have been executed
+    And the "error" hook should have been executed
+    And the "finally" hooks should be called with evaluation details
+      | data_type | key        | value          |
+      | string    | flag_key   | missing-flag   |
+      | string    | value      | uh-oh          |
+      | string    | variant    | null           |
+      | string    | reason     | ERROR          |
+      | string    | error_code | FLAG_NOT_FOUND |
+
+  Scenario: Type error
+    Given a client with added hook
+    And a boolean-flag with key "wrong-flag" and a fallback value "false"
+    When the flag was evaluated with details
+    Then the "before" hook should have been executed
+    And the "error" hook should have been executed
+    And the "finally" hooks should be called with evaluation details
+      | data_type | key        | value         |
+      | string    | flag_key   | wrong-flag    |
+      | boolean   | value      | false         |
+      | string    | variant    | null          |
+      | string    | reason     | ERROR         |
+      | string    | error_code | TYPE_MISMATCH |

--- a/conformance-zio-bdd/src/test/resources/features/openfeature/hooks.feature
+++ b/conformance-zio-bdd/src/test/resources/features/openfeature/hooks.feature
@@ -1,0 +1,34 @@
+@hooks
+Feature: Evaluation details through hooks
+
+
+  Background:
+    Given a stable provider
+
+  Scenario: Passes evaluation details to after and finally hooks
+    Given a client with added hook
+    And a boolean-flag with key "boolean-flag" and a fallback value "false"
+    When the flag was evaluated with details
+    Then the "before" hook should have been executed
+    And the "after, finally" hooks should be called with evaluation details
+      | data_type | key        | value        |
+      | string    | flag_key   | boolean-flag |
+      | boolean   | value      | true         |
+      | string    | variant    | on           |
+      | string    | reason     | STATIC       |
+      | string    | error_code | null         |
+
+  Scenario: Flag not found
+    Given a client with added hook
+    And a string-flag with key "missing-flag" and a fallback value "uh-oh"
+    When the flag was evaluated with details
+    Then the "before" hook should have been executed
+    And the "error" hook should have been executed
+    And the "finally" hooks should be called with evaluation details
+      | data_type | key        | value          |
+      | string    | flag_key   | missing-flag   |
+      | string    | value      | uh-oh          |
+      | string    | variant    | null           |
+      | string    | reason     | ERROR          |
+      | string    | error_code | FLAG_NOT_FOUND |
+

--- a/conformance-zio-bdd/src/test/resources/features/openfeature/metadata.feature
+++ b/conformance-zio-bdd/src/test/resources/features/openfeature/metadata.feature
@@ -1,0 +1,27 @@
+@Metadata
+Feature: Metadata
+
+  Background:
+    Given a stable provider
+
+  Scenario: Returns metadata
+    Given a Boolean-flag with key "metadata-flag" and a fallback value "true"
+    When the flag was evaluated with details
+    Then the resolved metadata should contain
+      | key     | metadata_type | value |
+      | string  | String        | 1.0.2 |
+      | integer | Integer       | 2     |
+      | float   | Float         | 0.1   |
+      | boolean | Boolean       | true  |
+
+  Scenario Outline: Returns no metadata
+    Given a <flag_type>-flag with key "<key>" and a fallback value "<default_value>"
+    When the flag was evaluated with details
+    Then the resolved metadata is empty
+
+    Examples:
+      | key          | flag_type | default_value |
+      | boolean-flag | Boolean   | true          |
+      | integer-flag | Integer   | 23            |
+      | float-flag   | Float     | 2.3           |
+      | string-flag  | String    | value         |

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
@@ -1,0 +1,352 @@
+package zio.openfeature.conformance.bdd
+
+import zio._
+import zio.bdd.core.Suite
+import zio.bdd.core.Assertions.assertTrue
+import zio.bdd.core.step.{State, ZIOSteps}
+import zio.openfeature._
+// zio-bdd's Hooks trait defines `type FeatureHook = URIO[R, Unit]`, which shadows the OpenFeature hook trait; alias it.
+import zio.openfeature.FeatureHook as OFFeatureHook
+import zio.openfeature.testkit.TestFeatureProvider
+import zio.schema.{DeriveSchema, Schema}
+import dev.openfeature.sdk.{EvaluationContext => OFEvaluationContext, OpenFeatureAPIFactory}
+import dev.openfeature.sdk.providers.memory.InMemoryProvider
+
+/** Data-table row types (zio-bdd's `table[T]` maps a gherkin table to `List[T]` via a zio-schema record). */
+final case class MetaRow(key: String, metadata_type: String, value: String)
+object MetaRow { given Schema[MetaRow] = DeriveSchema.gen[MetaRow] }
+final case class HookRow(data_type: String, key: String, value: String)
+object HookRow { given Schema[HookRow] = DeriveSchema.gen[HookRow] }
+
+/** The OpenFeature gherkin conformance suite run via zio-bdd (experimental dog-food of zio-bdd). Mirrors the Cucumber
+  * suite in `conformance/` but with native ZIO step bodies — no `Unsafe.run` bridge.
+  */
+@Suite(
+  featureDir = "conformance-zio-bdd/src/test/resources/features/openfeature",
+  reporters = Array("pretty"),
+  parallelism = 1,
+  excludeTags = Array("deprecated", "reason-codes-cached", "async", "immutability", "evaluation-options"),
+  logLevel = "warning"
+)
+object ConformanceSpec extends ZIOSteps[Any, World] {
+
+  // Provider setup -------------------------------------------------------------------------------
+
+  private def buildInMemory: ZIO[Any, Throwable, FeatureFlags] =
+    for {
+      statusRef <- Ref.make[ProviderStatus](ProviderStatus.Ready)
+      api    = OpenFeatureAPIFactory.create()
+      domain = s"bdd-${java.util.UUID.randomUUID()}"
+      env <- Scope.global.extend(
+        FeatureFlags
+          .fromProviderWithDomain(new InMemoryProvider(Fixtures.inMemoryFlags), domain, statusRef, api = Some(api))
+          .build
+      )
+    } yield env.get[FeatureFlags]
+
+  private def buildTestProvider: ZIO[Any, Throwable, (TestFeatureProvider, FeatureFlags)] =
+    Scope.global
+      .extend(TestFeatureProvider.layer(Fixtures.testProviderSeed).build)
+      .map(env => (env.get[TestFeatureProvider], env.get[FeatureFlags]))
+
+  private def statusOf(word: String): ProviderStatus = word match {
+    case "not ready" => ProviderStatus.NotReady
+    case "error"     => ProviderStatus.Error
+    case "fatal"     => ProviderStatus.Fatal
+    case "stale"     => ProviderStatus.Stale
+    case other       => throw new IllegalArgumentException(s"unknown provider status: $other")
+  }
+
+  // A "stable" provider needs real variants/reasons → InMemoryProvider; any non-ready status is simulated by the
+  // testkit provider whose status we then flip.
+  Given("a " / string / " provider") { (status: String) =>
+    if (status == "stable")
+      buildInMemory.flatMap(ff => ScenarioContext.update(_.copy(flags = Some(ff), testProvider = None)))
+    else
+      for {
+        tpff <- buildTestProvider
+        _    <- tpff._1.setStatus(statusOf(status))
+        _    <- ScenarioContext.update(_.copy(flags = Some(tpff._2), testProvider = Some(tpff._1)))
+      } yield ()
+  }
+
+  Given("a stable provider with retrievable context is registered") {
+    buildTestProvider.flatMap(tpff =>
+      ScenarioContext.update(_.copy(flags = Some(tpff._2), testProvider = Some(tpff._1)))
+    )
+  }
+
+  // Flag + context -------------------------------------------------------------------------------
+
+  Given("a " / string / "-flag with key " / string / " and a fallback value " / string) {
+    (typ: String, key: String, default: String) =>
+      ScenarioContext.update(_.copy(flagType = typ.toLowerCase, flagKey = key, defaultRaw = default))
+  }
+
+  Given("a context containing a key " / string / ", with type " / string / " and with value " / string) {
+    (key: String, typ: String, value: String) =>
+      val av = typ.toLowerCase match {
+        case "integer" => AttributeValue.IntValue(value.toInt)
+        case "boolean" => AttributeValue.BoolValue(value.toBoolean)
+        case _         => AttributeValue.StringValue(value)
+      }
+      ScenarioContext.update(w => w.copy(ctx = w.ctx.withAttribute(key, av)))
+  }
+
+  // No null attribute in the typed context; an absent key is equivalent (→ DEFAULT).
+  Given("a context containing a key " / string / " with null value") { (_: String) => ZIO.unit }
+
+  // Evaluation -----------------------------------------------------------------------------------
+
+  private def unescape(s: String): String = s.replace("\\\"", "\"")
+
+  private def bridge[A](key: String, e: FeatureFlagError, default: A): FlagResolution[A] =
+    FlagResolution(default, None, ResolutionReason.Error, FlagMetadata.empty, key, Some(FeatureFlagError.toErrorCode(e)), Some(e.message))
+
+  private def evalByType(ff: FeatureFlags, w: World): ZIO[Any, Nothing, FlagResolution[Any]] = {
+    def br[A](io: IO[FeatureFlagError, FlagResolution[A]], default: A): ZIO[Any, Nothing, FlagResolution[Any]] =
+      io.catchAll(e => ZIO.succeed(bridge(w.flagKey, e, default))).map(_.asInstanceOf[FlagResolution[Any]])
+    w.flagType match {
+      case "boolean" => br(ff.booleanDetails(w.flagKey, w.defaultRaw.toBoolean, w.ctx), w.defaultRaw.toBoolean)
+      case "string"  => br(ff.stringDetails(w.flagKey, w.defaultRaw, w.ctx), w.defaultRaw)
+      case "integer" => br(ff.intDetails(w.flagKey, w.defaultRaw.toInt, w.ctx), w.defaultRaw.toInt)
+      case "float"   => br(ff.doubleDetails(w.flagKey, w.defaultRaw.toDouble, w.ctx), w.defaultRaw.toDouble)
+      case "object" =>
+        val d = JsonLite.parseObject(unescape(w.defaultRaw)); br(ff.objDetails(w.flagKey, d, w.ctx), d)
+      case other => ZIO.die(new IllegalArgumentException(s"unknown flag type: $other"))
+    }
+  }
+
+  When("the flag was evaluated with details") {
+    for {
+      w   <- ScenarioContext.get
+      res <- evalByType(w.flags.get, w)
+      _ <- ScenarioContext.update(
+        _.copy(
+          resultValue = res.value,
+          resultReason = reasonName(res.reason),
+          resultErrorCode = res.errorCode.map(errorCodeName),
+          resultVariant = res.variant,
+          resultMetadata = res.metadata,
+          resultFlagKey = res.flagKey
+        )
+      )
+    } yield ()
+  }
+
+  // Result assertions ----------------------------------------------------------------------------
+
+  private def reasonName(r: ResolutionReason): String = r match {
+    case ResolutionReason.Static         => "STATIC"
+    case ResolutionReason.Default        => "DEFAULT"
+    case ResolutionReason.TargetingMatch => "TARGETING_MATCH"
+    case ResolutionReason.Split          => "SPLIT"
+    case ResolutionReason.Cached         => "CACHED"
+    case ResolutionReason.Disabled       => "DISABLED"
+    case ResolutionReason.Unknown        => "UNKNOWN"
+    case ResolutionReason.Stale          => "STALE"
+    case ResolutionReason.Error          => "ERROR"
+  }
+
+  private def errorCodeName(c: ErrorCode): String = c match {
+    case ErrorCode.ProviderNotReady    => "PROVIDER_NOT_READY"
+    case ErrorCode.ProviderFatal       => "PROVIDER_FATAL"
+    case ErrorCode.FlagNotFound        => "FLAG_NOT_FOUND"
+    case ErrorCode.ParseError          => "PARSE_ERROR"
+    case ErrorCode.TypeMismatch        => "TYPE_MISMATCH"
+    case ErrorCode.TargetingKeyMissing => "TARGETING_KEY_MISSING"
+    case ErrorCode.InvalidContext      => "INVALID_CONTEXT"
+    case ErrorCode.General             => "GENERAL"
+  }
+
+  private def valueMatches(w: World, expected: String): Boolean = w.flagType match {
+    case "boolean" => w.resultValue == expected.toBoolean
+    case "string"  => w.resultValue == expected
+    case "integer" => w.resultValue == expected.toInt
+    case "float"   => w.resultValue == expected.toDouble
+    case "object"  => w.resultValue.asInstanceOf[Map[String, Any]] == JsonLite.parseObject(unescape(expected))
+    case _         => false
+  }
+
+  Then("the resolved details value should be " / string) { (expected: String) =>
+    ScenarioContext.get.flatMap(w => assertTrue(valueMatches(w, expected), s"value ${w.resultValue} != '$expected'"))
+  }
+
+  Then("the reason should be " / string) { (expected: String) =>
+    ScenarioContext.get.flatMap(w => assertTrue(w.resultReason == expected, s"reason ${w.resultReason} != $expected"))
+  }
+
+  Then("the error-code should be " / string) { (expected: String) =>
+    ScenarioContext.get.flatMap(w =>
+      assertTrue(w.resultErrorCode.contains(expected), s"error-code ${w.resultErrorCode} != $expected")
+    )
+  }
+
+  Then("the flag key should be " / string) { (expected: String) =>
+    ScenarioContext.get.flatMap(w => assertTrue(w.resultFlagKey == expected, s"flagKey ${w.resultFlagKey} != $expected"))
+  }
+
+  Then("the variant should be " / string) { (expected: String) =>
+    ScenarioContext.get.flatMap { w =>
+      val ok = if (expected == "null") w.resultVariant.isEmpty else w.resultVariant.contains(expected)
+      assertTrue(ok, s"variant ${w.resultVariant} != $expected")
+    }
+  }
+
+  Then("the provider status should be " / string) { (expected: String) =>
+    ScenarioContext.get.flatMap { w =>
+      w.flags.get.providerStatus.flatMap { st =>
+        val actual = st match {
+          case ProviderStatus.Ready        => "READY"
+          case ProviderStatus.NotReady     => "NOT_READY"
+          case ProviderStatus.Error        => "ERROR"
+          case ProviderStatus.Fatal        => "FATAL"
+          case ProviderStatus.Stale        => "STALE"
+          case ProviderStatus.ShuttingDown => "SHUTTING_DOWN"
+        }
+        assertTrue(actual == expected, s"provider status $actual != $expected")
+      }
+    }
+  }
+
+  // Metadata -------------------------------------------------------------------------------------
+
+  private def metaOk(r: MetaRow, m: FlagMetadata): Boolean = r.metadata_type.toLowerCase match {
+    case "string"  => m.getString(r.key).contains(r.value)
+    case "integer" => m.getInt(r.key).contains(r.value.toInt)
+    case "boolean" => m.getBoolean(r.key).contains(r.value.toBoolean)
+    case "float"   => m.get(r.key).contains(MetadataValue.FloatValue(r.value.toFloat))
+    case _         => false
+  }
+
+  Then("the resolved metadata should contain" / table[MetaRow]) { (rows: List[MetaRow]) =>
+    ScenarioContext.get.flatMap { w =>
+      assertTrue(rows.forall(r => metaOk(r, w.resultMetadata)), s"metadata mismatch: ${w.resultMetadata.values}")
+    }
+  }
+
+  Then("the resolved metadata is empty") {
+    ScenarioContext.get.flatMap(w => assertTrue(w.resultMetadata.isEmpty, s"metadata not empty: ${w.resultMetadata.values}"))
+  }
+
+  // Hooks ----------------------------------------------------------------------------------------
+
+  private def recordingHook(stages: Ref[Chunk[String]], details: Ref[Option[FlagResolution[Any]]]): OFFeatureHook =
+    new OFFeatureHook {
+      override def before(c: HookContext, h: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+        stages.update(_ :+ "before").as(None)
+      override def after[A](c: HookContext, d: FlagResolution[A], h: HookHints): UIO[Unit] =
+        stages.update(_ :+ "after") *> details.set(Some(d.asInstanceOf[FlagResolution[Any]]))
+      override def error(c: HookContext, e: FeatureFlagError, h: HookHints): UIO[Unit] =
+        stages.update(_ :+ "error").unit
+      override def finallyAfter(c: HookContext, d: Option[FlagResolution[_]], h: HookHints): UIO[Unit] =
+        stages.update(_ :+ "finally") *> details.update(prev => d.map(_.asInstanceOf[FlagResolution[Any]]).orElse(prev))
+    }
+
+  Given("a client with added hook") {
+    for {
+      stages  <- Ref.make(Chunk.empty[String])
+      details <- Ref.make(Option.empty[FlagResolution[Any]])
+      w       <- ScenarioContext.get
+      _       <- w.flags.get.addHook(recordingHook(stages, details))
+      _       <- ScenarioContext.update(_.copy(hookStages = Some(stages), hookDetails = Some(details)))
+    } yield ()
+  }
+
+  Then("the " / string / " hook should have been executed") { (stage: String) =>
+    ScenarioContext.get.flatMap(w =>
+      w.hookStages.get.get.flatMap(st => assertTrue(st.contains(stage), s"stage '$stage' not in $st"))
+    )
+  }
+
+  private def hookDetailOk(r: HookRow, d: FlagResolution[Any]): Boolean = r.key match {
+    case "flag_key" => d.flagKey == r.value
+    case "value"    => if (r.data_type.toLowerCase == "boolean") d.value == r.value.toBoolean else d.value == r.value
+    case "variant"  => if (r.value == "null") d.variant.isEmpty else d.variant.contains(r.value)
+    case "reason"   => reasonName(d.reason) == r.value
+    case "error_code" =>
+      val actual = d.errorCode.map(errorCodeName)
+      if (r.value == "null") actual.isEmpty else actual.contains(r.value)
+    case _ => false
+  }
+
+  Then("the " / string / " hooks should be called with evaluation details" / table[HookRow]) {
+    (stagesCsv: String, rows: List[HookRow]) =>
+      ScenarioContext.get.flatMap { w =>
+        for {
+          stages  <- w.hookStages.get.get
+          details <- w.hookDetails.get.get
+          stagesOk = stagesCsv.split(",").map(_.trim).forall(stages.contains)
+          detailOk = details.exists(d => rows.forall(r => hookDetailOk(r, d)))
+          _ <- assertTrue(stagesOk && detailOk, s"hook stages=$stages details=$details rows=$rows")
+        } yield ()
+      }
+  }
+
+  // Context merging ------------------------------------------------------------------------------
+
+  private def entryCtx(key: String, value: String): EvaluationContext =
+    EvaluationContext.builder.attribute(key, value).build
+
+  private def addLevelEntry(w: World, key: String, value: String, level: String): World = level match {
+    case "API"          => w.copy(apiCtx = w.apiCtx.merge(entryCtx(key, value)))
+    case "Transaction"  => w.copy(txCtx = Some(w.txCtx.getOrElse(EvaluationContext.empty).merge(entryCtx(key, value))))
+    case "Client"       => w.copy(clientCtx = w.clientCtx.merge(entryCtx(key, value)))
+    case "Invocation"   => w.copy(invocationCtx = w.invocationCtx.merge(entryCtx(key, value)))
+    case "Before Hooks" => w.copy(beforeHookCtx = Some(w.beforeHookCtx.getOrElse(EvaluationContext.empty).merge(entryCtx(key, value))))
+    case _              => w
+  }
+
+  Given("A context entry with key " / string / " and value " / string / " is added to the " / string / " level") {
+    (key: String, value: String, level: String) =>
+      ScenarioContext.update(w => addLevelEntry(w, key, value, level))
+  }
+
+  // zio-bdd's table[T] requires a header row; this gherkin table is headerless (and there is no raw-DataTable access in
+  // the step signature), so we ignore the table and use the canonical precedence order. The span-to-target logic below
+  // is unaffected by including levels a given scenario doesn't set (the target level still wins the merge).
+  Given("A table with levels of increasing precedence") {
+    ScenarioContext.update(_.copy(levelOrder = List("API", "Transaction", "Client", "Invocation", "Before Hooks")))
+  }
+
+  Given("Context entries for each level from API level down to the " / string / " level, with key " / string / " and value " / string) {
+    (target: String, key: String, _ : String) =>
+      ScenarioContext.update { w =>
+        val upTo = w.levelOrder.span(_ != target) match {
+          case (before, t :: _) => before :+ t
+          case (before, Nil)    => before
+        }
+        upTo.foldLeft(w)((acc, level) => addLevelEntry(acc, key, level, level))
+      }
+  }
+
+  private def ctxHook(ctx: EvaluationContext): OFFeatureHook = new OFFeatureHook {
+    override def before(c: HookContext, h: HookHints): UIO[Option[(EvaluationContext, HookHints)]] = ZIO.some((ctx, h))
+  }
+
+  When("Some flag was evaluated") {
+    for {
+      w  <- ScenarioContext.get
+      ff = w.flags.get
+      _  <- ff.setGlobalContext(w.apiCtx)
+      _  <- ff.setClientContext(w.clientCtx)
+      _  <- ZIO.foreachDiscard(w.beforeHookCtx)(c => ff.addHook(ctxHook(c)))
+      eval = ff.booleanDetails("merge-flag", false, w.invocationCtx)
+      run = w.txCtx match {
+        case Some(tx) => ff.transaction(context = tx)(eval).unit.orDieWith(e => new RuntimeException(String.valueOf(e)))
+        case None     => eval.unit.orDieWith(e => new RuntimeException(String.valueOf(e)))
+      }
+      _      <- run
+      merged <- w.testProvider.get.getEvaluations.map(_.last._2)
+      _      <- ScenarioContext.update(_.copy(mergedCtx = Some(merged)))
+    } yield ()
+  }
+
+  Then("The merged context contains an entry with key " / string / " and value " / string) {
+    (key: String, value: String) =>
+      ScenarioContext.get.flatMap { w =>
+        val actual = w.mergedCtx.flatMap(c => Option(c.getValue(key)).flatMap(v => Option(v.asString())))
+        assertTrue(actual.contains(value), s"merged $key = $actual != $value")
+      }
+  }
+}

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/Fixtures.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/Fixtures.scala
@@ -1,0 +1,134 @@
+package zio.openfeature.conformance.bdd
+
+import dev.openfeature.sdk.{EvaluationContext => OFEvaluationContext, ImmutableMetadata, Structure, Value}
+import dev.openfeature.sdk.providers.memory.{ContextEvaluator, Flag}
+
+import scala.jdk.CollectionConverters._
+
+/** Flag fixtures mirroring the spec's `specification/assets/gherkin/test-flags.json` (upstream main @ 203c25f93495),
+  * built for the Java SDK's `InMemoryProvider`. Targeted flags use hardcoded [[ContextEvaluator]] lambdas (the JEXL
+  * `contextEvaluator` strings are not interpreted, matching the Java SDK's own e2e harness): an evaluator returns the
+  * matched variant's value, or `null` to fall back to the default variant (reason `DEFAULT`).
+  */
+object Fixtures {
+
+  private val TargetEmail = "ballmer@macrosoft.com"
+
+  private def emailMatches(ctx: OFEvaluationContext): Boolean =
+    Option(ctx.getValue("email")).flatMap(v => Option(v.asString())).contains(TargetEmail)
+
+  private def anyToObject(value: Any): Object = value match {
+    case b: Boolean => java.lang.Boolean.valueOf(b)
+    case s: String  => s
+    case i: Int     => java.lang.Integer.valueOf(i)
+    case d: Double  => java.lang.Double.valueOf(d)
+    case other      => other.toString
+  }
+
+  private def structValue(map: Map[String, Any]): Value =
+    new Value(Structure.mapToStructure(map.map { case (k, v) => k -> anyToObject(v) }.asJava))
+
+  private val templateObject: Map[String, Any] =
+    Map("showImages" -> true, "title" -> "Check out these pics!", "imagesPerPage" -> 100)
+
+  private def emailTargeted[T <: AnyRef](matched: T): ContextEvaluator[T] =
+    new ContextEvaluator[T] {
+      def evaluate(flag: Flag[_], ctx: OFEvaluationContext): T =
+        if (emailMatches(ctx)) matched else null.asInstanceOf[T]
+    }
+
+  private def flag[T](
+    variants: Map[String, T],
+    defaultVariant: String,
+    disabled: Boolean = false,
+    metadata: Option[ImmutableMetadata] = None,
+    evaluator: Option[ContextEvaluator[T]] = None
+  ): Flag[T] = {
+    val builder = Flag.builder[T]()
+    variants.foreach { case (k, v) => builder.variant(k, v.asInstanceOf[Object]) }
+    builder.defaultVariant(defaultVariant).disabled(disabled)
+    metadata.foreach(builder.flagMetadata)
+    evaluator.foreach(builder.contextEvaluator)
+    builder.build()
+  }
+
+  private val metadataFlagMetadata: ImmutableMetadata =
+    ImmutableMetadata
+      .builder()
+      .addString("string", "1.0.2")
+      .addInteger("integer", 2)
+      .addBoolean("boolean", true)
+      .addFloat("float", 0.1f)
+      .build()
+
+  private def complexTargetingEvaluator: ContextEvaluator[String] =
+    new ContextEvaluator[String] {
+      def evaluate(flag: Flag[_], ctx: OFEvaluationContext): String = {
+        val email    = Option(ctx.getValue("email")).flatMap(v => Option(v.asString()))
+        val customer = Option(ctx.getValue("customer")).flatMap(v => Option(v.asBoolean())).map(_.booleanValue())
+        val age = Option(ctx.getValue("age")).flatMap { v =>
+          Option(v.asInteger()).map(_.intValue()).orElse(Option(v.asDouble()).map(_.intValue()))
+        }
+        if (!customer.getOrElse(false) && email.contains(TargetEmail) && age.exists(_ > 10)) "INTERNAL"
+        else null
+      }
+    }
+
+  /** The full fixture set keyed by flag name, ready for `new InMemoryProvider(_)`. */
+  val inMemoryFlags: java.util.Map[String, Flag[_]] = {
+    val bool: Map[String, java.lang.Boolean]     = Map("on" -> true, "off" -> false)
+    val zeroBool: Map[String, java.lang.Boolean] = Map("zero" -> false, "non-zero" -> true)
+    val str: Map[String, String]                 = Map("greeting" -> "hi", "parting" -> "bye")
+    val zeroStr: Map[String, String]             = Map("zero" -> "", "non-zero" -> "str")
+    val int: Map[String, java.lang.Integer]      = Map("one" -> 1, "ten" -> 10)
+    val zeroInt: Map[String, java.lang.Integer]  = Map("zero" -> 0, "non-zero" -> 1)
+    val dbl: Map[String, java.lang.Double]       = Map("tenth" -> 0.1, "half" -> 0.5)
+    val zeroDbl: Map[String, java.lang.Double]   = Map("zero" -> 0.0, "non-zero" -> 1.0)
+    val obj: Map[String, Value]     = Map("empty" -> structValue(Map.empty), "template" -> structValue(templateObject))
+    val zeroObj: Map[String, Value] = Map("zero" -> structValue(Map.empty), "non-zero" -> structValue(templateObject))
+
+    Map[String, Flag[_]](
+      "boolean-flag"               -> flag(bool, "on"),
+      "boolean-disabled-flag"      -> flag(bool, "on", disabled = true),
+      "boolean-zero-flag"          -> flag(zeroBool, "zero"),
+      "boolean-targeted-zero-flag" -> flag(zeroBool, "zero", evaluator = Some(emailTargeted(java.lang.Boolean.FALSE))),
+      "string-flag"                -> flag(str, "greeting"),
+      "string-disabled-flag"       -> flag(str, "greeting", disabled = true),
+      "string-zero-flag"           -> flag(zeroStr, "zero"),
+      "string-targeted-zero-flag"  -> flag(zeroStr, "zero", evaluator = Some(emailTargeted(""))),
+      "integer-flag"               -> flag(int, "ten"),
+      "integer-disabled-flag"      -> flag(int, "ten", disabled = true),
+      "integer-zero-flag"          -> flag(zeroInt, "zero"),
+      "integer-targeted-zero-flag" -> flag(
+        zeroInt,
+        "zero",
+        evaluator = Some(emailTargeted(java.lang.Integer.valueOf(0)))
+      ),
+      "float-flag"          -> flag(dbl, "half"),
+      "float-disabled-flag" -> flag(dbl, "half", disabled = true),
+      "float-zero-flag"     -> flag(zeroDbl, "zero"),
+      "float-targeted-zero-flag" -> flag(
+        zeroDbl,
+        "zero",
+        evaluator = Some(emailTargeted(java.lang.Double.valueOf(0.0)))
+      ),
+      "object-flag"               -> flag(obj, "template"),
+      "object-disabled-flag"      -> flag(obj, "template", disabled = true),
+      "object-zero-flag"          -> flag(zeroObj, "zero"),
+      "object-targeted-zero-flag" -> flag(zeroObj, "zero", evaluator = Some(emailTargeted(structValue(Map.empty)))),
+      "metadata-flag"             -> flag(bool, "on", metadata = Some(metadataFlagMetadata)),
+      "wrong-flag"                -> flag(Map("one" -> "uno", "two" -> "dos"), "one"),
+      "complex-targeted" -> flag(
+        Map("internal" -> "INTERNAL", "external" -> "EXTERNAL"),
+        "external",
+        evaluator = Some(complexTargetingEvaluator)
+      )
+    ).asJava
+  }
+
+  /** Plain-value seed for the testkit `TestFeatureProvider` (used by context-merging and provider-status scenarios,
+    * which only need a flag to exist — not variants/reasons).
+    */
+  val testProviderSeed: Map[String, Any] =
+    Map("boolean-flag" -> true, "string-flag" -> "hi", "integer-flag" -> 10, "float-flag" -> 0.5, "merge-flag" -> true)
+}

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/JsonLite.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/JsonLite.scala
@@ -1,0 +1,119 @@
+package zio.openfeature.conformance.bdd
+
+/** Minimal JSON parser for the object literals that appear in the gherkin (`{}`, `{"a": 1}`, the flat template object).
+  * Numbers are parsed to `Double` to match how the wrapper decodes provider object values, so parsed expectations and
+  * resolved values compare by `==`. Not a general-purpose parser — just enough for the conformance object scenarios.
+  */
+object JsonLite {
+
+  def parseObject(input: String): Map[String, Any] =
+    parse(input) match {
+      case m: Map[_, _] => m.asInstanceOf[Map[String, Any]]
+      case other        => throw new IllegalArgumentException(s"Expected a JSON object, got: $other from '$input'")
+    }
+
+  def parse(input: String): Any = {
+    val p = new Parser(input)
+    val v = p.parseValue()
+    p.skipWs()
+    if (!p.atEnd) throw new IllegalArgumentException(s"Trailing content in JSON: '$input'")
+    v
+  }
+
+  final private class Parser(s: String) {
+    private var i = 0
+
+    def atEnd: Boolean = i >= s.length
+    def skipWs(): Unit = while (i < s.length && s(i).isWhitespace) i += 1
+
+    def parseValue(): Any = {
+      skipWs()
+      s(i) match {
+        case '{'                        => parseObj()
+        case '['                        => parseArr()
+        case '"'                        => parseStr()
+        case 't' | 'f'                  => parseBool()
+        case 'n'                        => parseNull()
+        case c if c == '-' || c.isDigit => parseNum()
+        case c                          => throw new IllegalArgumentException(s"Unexpected character '$c' in JSON")
+      }
+    }
+
+    private def parseObj(): Map[String, Any] = {
+      i += 1 // {
+      skipWs()
+      if (s(i) == '}') { i += 1; return Map.empty }
+      val b        = Map.newBuilder[String, Any]
+      var continue = true
+      while (continue) {
+        skipWs()
+        val key = parseStr()
+        skipWs()
+        require(s(i) == ':', "expected ':' in JSON object"); i += 1
+        b += (key -> parseValue())
+        skipWs()
+        s(i) match {
+          case ',' => i += 1
+          case '}' => i += 1; continue = false
+          case c   => throw new IllegalArgumentException(s"Unexpected '$c' in JSON object")
+        }
+      }
+      b.result()
+    }
+
+    private def parseArr(): List[Any] = {
+      i += 1 // [
+      skipWs()
+      if (s(i) == ']') { i += 1; return Nil }
+      val b        = List.newBuilder[Any]
+      var continue = true
+      while (continue) {
+        b += parseValue()
+        skipWs()
+        s(i) match {
+          case ',' => i += 1
+          case ']' => i += 1; continue = false
+          case c   => throw new IllegalArgumentException(s"Unexpected '$c' in JSON array")
+        }
+      }
+      b.result()
+    }
+
+    private def parseStr(): String = {
+      require(s(i) == '"', "expected '\"' starting a JSON string"); i += 1
+      val sb = new StringBuilder
+      while (s(i) != '"') {
+        if (s(i) == '\\') {
+          i += 1
+          s(i) match {
+            case '"'  => sb.append('"')
+            case '\\' => sb.append('\\')
+            case '/'  => sb.append('/')
+            case 'n'  => sb.append('\n')
+            case 't'  => sb.append('\t')
+            case 'r'  => sb.append('\r')
+            case c    => sb.append(c)
+          }
+        } else sb.append(s(i))
+        i += 1
+      }
+      i += 1 // closing "
+      sb.toString
+    }
+
+    private def parseBool(): Boolean =
+      if (s.startsWith("true", i)) { i += 4; true }
+      else if (s.startsWith("false", i)) { i += 5; false }
+      else throw new IllegalArgumentException("invalid JSON boolean")
+
+    private def parseNull(): Null =
+      if (s.startsWith("null", i)) { i += 4; null }
+      else throw new IllegalArgumentException("invalid JSON null")
+
+    private def parseNum(): Double = {
+      val start = i
+      while (i < s.length && (s(i).isDigit || "-+.eE".contains(s(i)))) i += 1
+      s.substring(start, i).toDouble
+    }
+  }
+}

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/World.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/World.scala
@@ -1,0 +1,42 @@
+package zio.openfeature.conformance.bdd
+
+import zio._
+import zio.openfeature._
+import zio.openfeature.testkit.TestFeatureProvider
+import zio.bdd.core.Default
+import dev.openfeature.sdk.{EvaluationContext => OFEvaluationContext}
+
+/** Per-scenario state for the zio-bdd conformance suite. zio-bdd isolates this via a `FiberRef`, so it can hold opaque
+  * references (the live `FeatureFlags`, recorder `Ref`s) that have no schema — it only needs a [[Default]] instance.
+  */
+final case class World(
+  flags: Option[FeatureFlags] = None,
+  testProvider: Option[TestFeatureProvider] = None,
+  // evaluation inputs
+  flagKey: String = "",
+  flagType: String = "",
+  defaultRaw: String = "",
+  ctx: EvaluationContext = EvaluationContext.empty,
+  // captured result
+  resultValue: Any = (),
+  resultReason: String = "",
+  resultErrorCode: Option[String] = None,
+  resultVariant: Option[String] = None,
+  resultMetadata: FlagMetadata = FlagMetadata.empty,
+  resultFlagKey: String = "",
+  // hooks
+  hookStages: Option[Ref[Chunk[String]]] = None,
+  hookDetails: Option[Ref[Option[FlagResolution[Any]]]] = None,
+  // context merging
+  apiCtx: EvaluationContext = EvaluationContext.empty,
+  clientCtx: EvaluationContext = EvaluationContext.empty,
+  invocationCtx: EvaluationContext = EvaluationContext.empty,
+  txCtx: Option[EvaluationContext] = None,
+  beforeHookCtx: Option[EvaluationContext] = None,
+  levelOrder: List[String] = Nil,
+  mergedCtx: Option[OFEvaluationContext] = None
+)
+
+object World {
+  given Default[World] = new Default[World] { def default: World = World() }
+}


### PR DESCRIPTION
**Draft / experimental — not intended to merge** unless zio-bdd matures enough for real use. Dog-foods [`zio-bdd`](https://github.com/EtaCassiopeia/zio-bdd) 0.1.0 by re-implementing the OpenFeature gherkin conformance suite against it (native ZIO) instead of Cucumber.

Based on `test/spec-conformance-suite` (PR #210), so this diff is just the experimental `conformance-zio-bdd` module on top of the Cucumber suite.

Run: `sbt conformanceZioBdd/test`

## What works
- **Native ZIO step bodies** (no `Unsafe.run` bridge), typed `ScenarioContext` (FiberRef-isolated), `table[T]`, Scenario Outlines, `@Suite` discovery.
- **7 scenarios green**: `metadata.feature` (5) + first two of `hooks.feature` (2) — including `FLAG_NOT_FOUND` → error-hook (the §4.4.6 alignment holds in this path too).

## What's blocked
All blockers are zio-bdd **gherkin-parser** gaps (parse-time, not execution). The `.feature` files here are modified to work around them; originals kept under `conformance-zio-bdd/blocked/` as repros. The module README documents everything.

## Issues filed against zio-bdd
Parser bugs: #36 (named Examples), #37 (hyphen/dot tags), #38 (Examples-block tags), #39 (3+ table scenarios), #40 (headerless tables), #41 (reporter default + docs).
Design/API: #42 (per-scenario resource lifecycle), #43 (step extractors + ambiguity), #44 (assertions as TestResult), #45 (tag expressions), #46 (parse resilience + file:line errors).

## Assessment
Step ergonomics are genuinely nicer than the Cucumber `Unsafe.run` bridge. The gating work is parser correctness (#36–39) and per-scenario resources (#42); once those land, this module is close to a drop-in.