### PR TITLE
Fix Optimizely concurrency test JVM hang

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,14 @@ lazy val optimizely = (project in file("optimizely"))
       "com.optimizely.ab" % "core-api"             % "4.2.2",
       "com.optimizely.ab" % "core-httpclient-impl" % "4.2.2",
       "org.wiremock"      % "wiremock"             % "3.10.0" % Test
-    )
+    ),
+    // Optimizely's datafile poller uses Apache HttpClient with non-daemon threads. A shutdown/teardown race in the
+    // WireMock concurrency suite can leave a retry thread alive after all tests have passed; in-process that
+    // non-daemon thread keeps the test JVM from exiting and hangs `sbt test` until CI's 20-min timeout (#212). The
+    // ZIO `TestAspect.timeout` on the suite can't help — the fibers have already completed; it's the JVM that won't
+    // die. Forking the test JVM makes sbt terminate it after the run regardless of leaked threads, turning a
+    // potential hang into a clean exit.
+    Test / fork := true
   )
 
 // Testkit module - testing utilities

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderConcurrencySpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderConcurrencySpec.scala
@@ -81,7 +81,10 @@ object OptimizelyProviderConcurrencySpec extends ZIOSpecDefault {
       countdown.await(30, TimeUnit.SECONDS)
       results.toIndexedSeq
     } finally {
+      // Reap worker threads deterministically: `shutdownNow` interrupts, then join so no evaluation thread outlives
+      // the test and races provider/WireMock teardown. `Executors.newFixedThreadPool` threads are non-daemon.
       pool.shutdownNow()
+      pool.awaitTermination(5, TimeUnit.SECONDS)
       ()
     }
   }
@@ -176,41 +179,48 @@ object OptimizelyProviderConcurrencySpec extends ZIOSpecDefault {
         server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafile)))
         val provider =
           new OptimizelyFeatureProvider(buildClient(server), java.time.Duration.ofSeconds(3), closeOnShutdown = true)
-        provider.initialize(new ImmutableContext())
-        val N      = 200
-        val live   = new AtomicInteger(0)
-        val ctxs   = (0 until N).map(i => new ImmutableContext(s"shutdown-racer-$i"))
-        val pool   = Executors.newFixedThreadPool(32)
-        val gate   = new CountDownLatch(1)
-        val done   = new CountDownLatch(N)
-        val errors = new AtomicInteger(0)
-        (0 until N).foreach { i =>
-          pool.submit(new Runnable {
-            override def run(): Unit = {
-              gate.await()
-              try {
-                val e = provider.getBooleanEvaluation(Flag, java.lang.Boolean.FALSE, ctxs(i))
-                if (e.getErrorCode == null && e.getValue == java.lang.Boolean.TRUE) {
-                  val _ = live.incrementAndGet()
-                }
-              } catch { case _: Throwable => val _ = errors.incrementAndGet() }
-              done.countDown()
-            }
-          })
-          ()
+        val pool = Executors.newFixedThreadPool(32)
+        try {
+          provider.initialize(new ImmutableContext())
+          val N      = 200
+          val live   = new AtomicInteger(0)
+          val ctxs   = (0 until N).map(i => new ImmutableContext(s"shutdown-racer-$i"))
+          val gate   = new CountDownLatch(1)
+          val done   = new CountDownLatch(N)
+          val errors = new AtomicInteger(0)
+          (0 until N).foreach { i =>
+            pool.submit(new Runnable {
+              override def run(): Unit = {
+                gate.await()
+                try {
+                  val e = provider.getBooleanEvaluation(Flag, java.lang.Boolean.FALSE, ctxs(i))
+                  if (e.getErrorCode == null && e.getValue == java.lang.Boolean.TRUE) {
+                    val _ = live.incrementAndGet()
+                  }
+                } catch { case _: Throwable => val _ = errors.incrementAndGet() }
+                done.countDown()
+              }
+            })
+            ()
+          }
+          // Fire the racers and call shutdown shortly after — some evaluations land before, some after.
+          gate.countDown()
+          Thread.sleep(5)
+          provider.shutdown()
+          val finished   = done.await(15, TimeUnit.SECONDS)
+          val stateAfter = stateOf(provider)
+          assertTrue(
+            finished,
+            errors.get() == 0,
+            stateAfter == ProviderState.NOT_READY
+          )
+        } finally {
+          // Join our worker threads and ensure the client is closed (idempotent) before WireMock stops, so no
+          // evaluation or HTTP retry thread races the server teardown — even if an assertion above threw.
+          pool.shutdownNow()
+          pool.awaitTermination(5, TimeUnit.SECONDS)
+          provider.shutdown()
         }
-        // Fire the racers and call shutdown shortly after — some evaluations land before, some after.
-        gate.countDown()
-        Thread.sleep(5)
-        provider.shutdown()
-        val finished = done.await(15, TimeUnit.SECONDS)
-        pool.shutdownNow()
-        val stateAfter = stateOf(provider)
-        assertTrue(
-          finished,
-          errors.get() == 0,
-          stateAfter == ProviderState.NOT_READY
-        )
       }
     }
   ) @@ TestAspect.sequential @@ TestAspect.timeout(60.seconds) @@ TestAspect.withLiveClock


### PR DESCRIPTION
## Problem

The `build-matrix (21, 2.13.16)` CI cell intermittently hangs: its test step runs ~19 min and is cancelled at the 20-min `timeout-minutes`, failing the `build` gate. The other three matrix cells finish tests in 60–75s.

Root cause: in `OptimizelyProviderConcurrencySpec`, the *"evaluations racing shutdown"* test passes, but the test **JVM then refuses to exit**. Optimizely's `HttpProjectConfigManager` datafile poller uses Apache HttpClient with **non-daemon** threads; under a shutdown/teardown race, a retry thread is left spinning against the torn-down WireMock socket (`RetryExec: Socket closed ... Retrying request`). In-process (`fork := false`) that lingering non-daemon thread keeps the JVM alive, so `sbt test` never completes. Cleanup confirms it — `Terminate orphan process: pid (java)`.

The suite already carries `@@ TestAspect.timeout(60.seconds)`, but that can't help: the fibers have already completed successfully; it's the JVM that won't die, which is outside any fiber's reach.

It's a non-deterministic race, which is why it lands on one matrix cell at a time rather than a fixed (JDK, Scala) pair.

## Fix

1. **Fork the optimizely test JVM** (`Test / fork := true`). sbt terminates the forked JVM after the run regardless of leaked threads, turning a potential hang into a clean exit. This is the structural guarantee.
2. **Deterministic teardown** in the concurrency spec: wrap the racing-shutdown test's provider/pool in `try/finally`, `awaitTermination` on the worker pool after `shutdownNow`, and ensure the client is closed before WireMock stops — so no evaluation or HTTP retry thread races server teardown, even if an assertion throws. Same `awaitTermination` added to the shared `race` helper.

The in-suite `TestAspect.timeout` stays as a secondary backstop.

## Verification

Local: `optimizely/test` passes (49/49) and sbt exits promptly; ran the concurrency suite 3× back-to-back (~34s each, no hang).