### PR TITLE
Fix Optimizely test datafile-poller thread leak

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,14 +169,7 @@ lazy val optimizely = (project in file("optimizely"))
       "com.optimizely.ab" % "core-api"             % "4.2.2",
       "com.optimizely.ab" % "core-httpclient-impl" % "4.2.2",
       "org.wiremock"      % "wiremock"             % "3.10.0" % Test
-    ),
-    // Optimizely's datafile poller uses Apache HttpClient with non-daemon threads. A shutdown/teardown race in the
-    // WireMock concurrency suite can leave a retry thread alive after all tests have passed; in-process that
-    // non-daemon thread keeps the test JVM from exiting and hangs `sbt test` until CI's 20-min timeout (#212). The
-    // ZIO `TestAspect.timeout` on the suite can't help — the fibers have already completed; it's the JVM that won't
-    // die. Forking the test JVM makes sbt terminate it after the run regardless of leaked threads, turning a
-    // potential hang into a clean exit.
-    Test / fork := true
+    )
   )
 
 // Testkit module - testing utilities

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderConcurrencySpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderConcurrencySpec.scala
@@ -37,19 +37,26 @@ object OptimizelyProviderConcurrencySpec extends ZIOSpecDefault {
   private def datafileUrl(server: WireMockServer): String =
     s"http://localhost:${server.port()}$DatafilePath"
 
+  // Build the client the same way `OptimizelyProvider.buildClient` does: `build(true)` skips the blocking initial
+  // fetch and does NOT leave a running poller — `mgr.stop()` ensures construction performs no network activity. The
+  // poller is owned by the provider (started by `initialize()`, stopped by `shutdown()` via `Optimizely.close()`), so
+  // it can never become an orphaned "retries forever" thread. The old no-arg `.build()` started a live poller at
+  // construction; when WireMock stopped, its Apache HttpClient retried against the dead socket on a thread that
+  // outlived every test and kept the (even forked) JVM from exiting — hanging `sbt test` until CI's timeout.
   private def buildClient(
     server: WireMockServer,
     blockingTimeout: java.time.Duration = java.time.Duration.ofSeconds(2),
     pollingInterval: java.time.Duration = java.time.Duration.ofSeconds(3600)
-  ): Optimizely = {
+  ): (Optimizely, HttpProjectConfigManager) = {
     val mgr = HttpProjectConfigManager
       .builder()
       .withSdkKey("concurrency-key")
       .withUrl(datafileUrl(server))
       .withBlockingTimeout(blockingTimeout.toMillis, TimeUnit.MILLISECONDS)
       .withPollingInterval(pollingInterval.toSeconds, TimeUnit.SECONDS)
-      .build()
-    Optimizely.builder().withConfigManager(mgr).build()
+      .build(true)
+    mgr.stop()
+    (Optimizely.builder().withConfigManager(mgr).build(), mgr)
   }
 
   @scala.annotation.nowarn("msg=deprecated")
@@ -93,8 +100,14 @@ object OptimizelyProviderConcurrencySpec extends ZIOSpecDefault {
     test("N concurrent boolean evaluations after init return consistent results without exceptions") {
       withMockServer { server =>
         server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafile)))
+        val (client, mgr) = buildClient(server)
         val provider =
-          new OptimizelyFeatureProvider(buildClient(server), java.time.Duration.ofSeconds(3), closeOnShutdown = true)
+          new OptimizelyFeatureProvider(
+            client,
+            java.time.Duration.ofSeconds(3),
+            closeOnShutdown = true,
+            configManager = Some(mgr)
+          )
         try {
           provider.initialize(new ImmutableContext())
           val N    = 1000
@@ -116,8 +129,14 @@ object OptimizelyProviderConcurrencySpec extends ZIOSpecDefault {
     test("N concurrent mixed-type evaluations don't trip over each other") {
       withMockServer { server =>
         server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafile)))
+        val (client, mgr) = buildClient(server)
         val provider =
-          new OptimizelyFeatureProvider(buildClient(server), java.time.Duration.ofSeconds(3), closeOnShutdown = true)
+          new OptimizelyFeatureProvider(
+            client,
+            java.time.Duration.ofSeconds(3),
+            closeOnShutdown = true,
+            configManager = Some(mgr)
+          )
         try {
           provider.initialize(new ImmutableContext())
           val N    = 500
@@ -145,8 +164,14 @@ object OptimizelyProviderConcurrencySpec extends ZIOSpecDefault {
           get(urlEqualTo(DatafilePath))
             .willReturn(okJson(ValidDatafile).withFixedDelay(200))
         )
+        val (client, mgr) = buildClient(server)
         val provider =
-          new OptimizelyFeatureProvider(buildClient(server), java.time.Duration.ofSeconds(2), closeOnShutdown = true)
+          new OptimizelyFeatureProvider(
+            client,
+            java.time.Duration.ofSeconds(2),
+            closeOnShutdown = true,
+            configManager = Some(mgr)
+          )
         try {
           val N           = 200
           val initStarted = new CountDownLatch(1)
@@ -177,8 +202,14 @@ object OptimizelyProviderConcurrencySpec extends ZIOSpecDefault {
     test("evaluations racing shutdown never throw — they surface PROVIDER_NOT_READY") {
       withMockServer { server =>
         server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafile)))
+        val (client, mgr) = buildClient(server)
         val provider =
-          new OptimizelyFeatureProvider(buildClient(server), java.time.Duration.ofSeconds(3), closeOnShutdown = true)
+          new OptimizelyFeatureProvider(
+            client,
+            java.time.Duration.ofSeconds(3),
+            closeOnShutdown = true,
+            configManager = Some(mgr)
+          )
         val pool = Executors.newFixedThreadPool(32)
         try {
           provider.initialize(new ImmutableContext())


### PR DESCRIPTION
## Problem

`build-matrix` cells intermittently hang and get cancelled at the 20-min CI timeout (e.g. both JDK 21 cells on the post-merge `main` run). The optimizely test JVM prints `49 tests passed` and then **refuses to exit for ~8 min** until cancelled, leaving an orphaned `java` process. The hang correlates with JDK 21 and is non-deterministic (one run it lands on one cell, the next on two; sometimes none).

## Root cause

`OptimizelyProviderConcurrencySpec.buildClient` built the SDK client with the no-arg `HttpProjectConfigManager.builder()….build()`, which **starts a live datafile poller at construction**. When the test's WireMock server stops, that poller's Apache HttpClient keeps retrying against the dead socket on a thread that outlives the test and is never reaped — keeping the JVM alive (`RetryExec` retry spam in the logs, then an orphan `java` process at cleanup).

The production factory (`OptimizelyProvider.buildClient`) already documents and avoids exactly this: it uses `build(true)` + `stop()` so construction does no network activity, and hands the manager to the provider, which owns the poller lifecycle (started by `initialize()`, stopped by `shutdown()` via `Optimizely.close()`). The test bypassed all of that.

A prior attempt added `Test / fork := true`, on the theory that sbt would `System.exit` the forked JVM after tests. The CI logs disproved it: on sbt 1.10.6 the **forked** test JVM also waits on the non-daemon thread and hangs. That change is reverted here.

## Fix

- Build the test client the same way production does — `build(true)` + `stop()`, returning `(Optimizely, HttpProjectConfigManager)` — and pass `configManager = Some(mgr)` to the provider so it owns start/stop. No live poller is ever left running.
- Revert the ineffective `Test / fork := true`.
- (Retained from the earlier fix) deterministic worker-pool reaping in the concurrency spec.

## Verification

Local, **without fork** (so any leak would hang sbt):
- `optimizely/test` run 4× back-to-back — 49/49 each, sbt exits in ~34s every time.
- Full aggregate `sbt test` — 769/769 across all modules, clean exit in 37s.

CI on this PR is the real-world confirmation across the JDK 17/21 × Scala 2.13/3.3 matrix.
