### PR TITLE
Bump zio-bdd to 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -203,9 +203,6 @@ lazy val conformance = (project in file("conformance"))
     )
   )
 
-// The same OpenFeature gherkin suite run via `zio-bdd` (a ZIO-native BDD framework, now a stable 1.0.0 release)
-// instead of Cucumber. Not published, not aggregated, Scala 3 only; gated in CI alongside the Cucumber conformance
-// suite.
 lazy val conformanceZioBdd = (project in file("conformance-zio-bdd"))
   .dependsOn(core, testkit)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -203,9 +203,9 @@ lazy val conformance = (project in file("conformance"))
     )
   )
 
-// The same OpenFeature gherkin suite run via `zio-bdd` (a ZIO-native BDD framework) instead of Cucumber, to dog-food
-// zio-bdd (now a stable 1.0.0 release). Not published, not aggregated, Scala 3 only; gated in CI alongside the
-// Cucumber conformance suite.
+// The same OpenFeature gherkin suite run via `zio-bdd` (a ZIO-native BDD framework, now a stable 1.0.0 release)
+// instead of Cucumber. Not published, not aggregated, Scala 3 only; gated in CI alongside the Cucumber conformance
+// suite.
 lazy val conformanceZioBdd = (project in file("conformance-zio-bdd"))
   .dependsOn(core, testkit)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -203,8 +203,9 @@ lazy val conformance = (project in file("conformance"))
     )
   )
 
-// Experimental: the same OpenFeature gherkin suite run via `zio-bdd` (a ZIO-native BDD framework) instead of Cucumber,
-// to dog-food zio-bdd. Not published, not aggregated, Scala 3 only. Not intended to merge unless zio-bdd matures.
+// The same OpenFeature gherkin suite run via `zio-bdd` (a ZIO-native BDD framework) instead of Cucumber, to dog-food
+// zio-bdd (now a stable 1.0.0 release). Not published, not aggregated, Scala 3 only; gated in CI alongside the
+// Cucumber conformance suite.
 lazy val conformanceZioBdd = (project in file("conformance-zio-bdd"))
   .dependsOn(core, testkit)
   .settings(
@@ -213,7 +214,7 @@ lazy val conformanceZioBdd = (project in file("conformance-zio-bdd"))
     crossScalaVersions := Seq(scala3Version),
     libraryDependencies ++= Seq(
       "dev.openfeature"         % "sdk"                    % openFeatureSdkVersion % Test,
-      "io.github.etacassiopeia" %% "zio-bdd"               % "1.0.0-RC2"           % Test,
+      "io.github.etacassiopeia" %% "zio-bdd"               % "1.0.0"               % Test,
       "dev.zio"                 %% "zio-schema"            % "1.6.6"               % Test,
       "dev.zio"                 %% "zio-schema-derivation" % "1.6.6"               % Test
     ),


### PR DESCRIPTION
Bumps the `conformance-zio-bdd` module's dependency from `zio-bdd 1.0.0-RC2` to the stable **`1.0.0`**, and refreshes the module comment (no longer experimental — zio-bdd is a stable release and the module is gated in CI alongside the Cucumber conformance suite).

## Verification

`zio-bdd 1.0.0` is now published; `sbt conformanceZioBdd/test` runs **111 passed, 8 ignored, 0 failed** locally — identical to RC2.

## Changes

- `zio-bdd`: `1.0.0-RC2` → `1.0.0`.
- Dropped the "Experimental / not intended to merge" framing from the module comment.
