### PR TITLE
Cut v1.0.0 release notes and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-06-17
+
+First stable release. **Upgrading from 0.9.x:** two behavior changes may require action —
+**`FlagType` decoders no longer coerce silently** (strict type decoding, #187) and a **1-second default
+per-evaluation timeout** (bounds hung providers; opt out with `evaluationTimeout = None`). Details in the
+entries below.
+
 ### Added
 
 - **Scope-managed Optimizely construction** (#208). `OptimizelyProvider.scoped(...)` and the (now scope-owning)
@@ -204,6 +211,8 @@ promotes `[Unreleased]` to the new version section when a release tag is cut.
 
 Internal refactors that don't change behaviour or surface area don't need a CHANGELOG entry. When in doubt: write one.
 
-[Unreleased]: https://github.com/EtaCassiopeia/zio-openfeature/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/EtaCassiopeia/zio-openfeature/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/EtaCassiopeia/zio-openfeature/compare/v0.9.1...v1.0.0
+[0.9.1]: https://github.com/EtaCassiopeia/zio-openfeature/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/EtaCassiopeia/zio-openfeature/releases/tag/v0.9.0
 [0.8.0]: https://github.com/EtaCassiopeia/zio-openfeature/releases/tag/v0.8.0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ZIO OpenFeature provides a type-safe, functional interface for feature flag eval
 
 | ZIO OpenFeature | OpenFeature Spec | OpenFeature Java SDK |
 |:----------------|:-----------------|:---------------------|
-| 0.3.x | [v0.8.0](https://github.com/open-feature/spec/releases/tag/v0.8.0) | 1.20.2 |
+| 1.0.x | [v0.8.0](https://github.com/open-feature/spec/releases/tag/v0.8.0) | 1.20.2 |
 
 This library implements the **dynamic-context paradigm** (server-side) of the OpenFeature specification. See [Spec Compliance](https://etacassiopeia.github.io/zio-openfeature/spec-compliance) for details.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -288,10 +288,12 @@ val result = ff.booleanDetails(
 
 | Setting | Scope | Default |
 |:--------|:------|:--------|
-| `fromProvider(provider, evaluationTimeout)` | All evaluations on this instance | `None` (no timeout) |
+| `fromProvider(provider, evaluationTimeout)` | All evaluations on this instance | `Some(1.second)` — `FeatureFlags.DefaultEvaluationTimeout` |
 | `EvaluationOptions.empty.withTimeout(duration)` | Single evaluation call | `None` (uses global) |
 
-Per-call timeout takes precedence over global. If neither is set, no timeout is applied (backward compatible).
+Per-call timeout takes precedence over global. As of 1.0.0 the global default is **1 second** (previously `None`), so
+a hung provider can no longer block a fiber indefinitely out of the box. Pass `evaluationTimeout = Some(largerDuration)`
+to raise the bound, or `evaluationTimeout = None` to disable it entirely.
 
 ### Runtime provider replacement (hot-swap)
 


### PR DESCRIPTION
Release prep for **v1.0.0** — finalizes the changelog and the docs that reference release-version-specific behavior. Docs/build-only; no source changes.

## CHANGELOG

- Promotes `## [Unreleased]` → `## [1.0.0] — 2026-06-17`, leaving a fresh empty `[Unreleased]` on top.
- Adds a short "upgrading from 0.9.x" highlights note flagging the two behavior changes (strict `FlagType` decoding #187, and the 1s default eval timeout).
- Fixes the link references: `[Unreleased]` now compares from `v1.0.0`, adds `[1.0.0]` (`v0.9.1...v1.0.0`) and the previously-missing `[0.9.1]`.

## Docs

- **README** version-compatibility table: stale `0.3.x` row → `1.0.x` (OpenFeature spec v0.8.0 / Java SDK 1.20.2 are unchanged).
- **`docs/providers.md`** evaluation-timeout table corrected — it still claimed the global default was `None` / "no timeout (backward compatible)", which is wrong as of 1.0.0. Now documents the `Some(1.second)` / `FeatureFlags.DefaultEvaluationTimeout` default and how to raise/disable it.

Install snippets keep the `"<version>"` placeholder pattern (the Maven Central badge shows the latest), so they need no per-release edits.

## After this merges

Tagging `v1.0.0` triggers `release.yml` (`sbt +test` → `ci-release` → GitHub release). Follow-up (separate): set `mimaPreviousArtifacts` to `1.0.0` so subsequent releases get binary-compat checks.
