### PR TITLE
Deflake CachingProvider config-changed cache-invalidation test

### DIFF
--- a/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
@@ -337,11 +337,13 @@ object CachingProviderSpec extends ZIOSpecDefault {
           _          <- ZIO.attemptBlocking(cached.initialize(ctx))
           _          <- ZIO.attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx))
           r2         <- ZIO.attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx))
-          _          <- ZIO.succeed(underlying.fireConfigChanged())
-          // The emission runs on the delegate's emitter executor; poll until the cache misses again
-          _ <- ZIO
-            .attemptBlocking(cached.getBooleanEvaluation("flag", false, ctx))
-            .repeatUntil(_.getReason != "CACHED")
+          // The emission runs on the delegate's async emitter executor; a single emit can occasionally be delayed or
+          // dropped under load, so re-fire on each (spaced) poll until the cache misses, bounded by the timeout.
+          _ <- (ZIO.attemptBlocking {
+            underlying.fireConfigChanged()
+            cached.getBooleanEvaluation("flag", false, ctx).getReason
+          } <* ZIO.sleep(100.millis))
+            .repeatUntil(_ != "CACHED")
             .timeoutFail(new RuntimeException("cache was never invalidated"))(10.seconds)
         } yield assertTrue(r2.getReason == "CACHED", underlying.evaluationCount.get() >= 2)
       },


### PR DESCRIPTION
The `CachingProvider` › "delegate CONFIGURATION_CHANGED invalidates the cache" test flaked on `build-matrix (21, 3.3.4)` (`cache was never invalidated`, 10s timeout). Unrelated to the Optimizely/release work — a pre-existing async-event flake surfaced.

## Cause

`CachingProvider.onDelegateEvent` invalidates the cache when the delegate emits `PROVIDER_CONFIGURATION_CHANGED`, but emission → listener goes through the OpenFeature SDK's **async emitter executor**. The test fired the event **once** and then polled; a single emission can occasionally be delayed (or dropped under the hub's `dropping(256)` policy) and never land within the window.

## Fix

Re-fire `fireConfigChanged()` on each (100ms-spaced) poll iteration until the cache misses, still bounded by the 10s timeout. A delayed/dropped first emission is now simply retried — deterministic instead of relying on a single async delivery. No production change; the assertions (`r2` was CACHED, delegate evaluated ≥2×) are unchanged.

## Verification

`CachingProviderSpec` run 5× locally — 26/26 each, no flake.