### PR TITLE
CI reliability for v1.0.0: root-cause Optimizely poller fix + timing-flake hardening

### DIFF
--- a/core/src/test/scala/zio/openfeature/BoundedLatencyContractSpec.scala
+++ b/core/src/test/scala/zio/openfeature/BoundedLatencyContractSpec.scala
@@ -84,8 +84,9 @@ object BoundedLatencyContractSpec extends ZIOSpecDefault {
         } yield assertTrue(
           result.isLeft,
           result.left.exists(_.isInstanceOf[FeatureFlagError.ProviderError]),
-          // Must return well before the provider's 2s sleep completes
-          elapsed.toMillis < 1800L
+          // The ProviderError above already proves the 1s timeout fired before the provider's 2s sleep returned;
+          // this only guards against pathological lateness. Generous bound so a slow/loaded CI runner can't flake it.
+          elapsed.toMillis < 1900L
         )
       }
     } @@ withLiveClock,
@@ -132,7 +133,9 @@ object BoundedLatencyContractSpec extends ZIOSpecDefault {
         } yield assertTrue(
           result.isLeft,
           result.left.exists(_.isInstanceOf[FeatureFlagError.ProviderError]),
-          elapsed.toMillis < 1000L
+          // ProviderError proves a timeout fired; `< 1900` proves it was the 100ms per-call timeout, not the 5s
+          // global one (and beat the provider's 2s). Loose enough not to flake on a slow runner.
+          elapsed.toMillis < 1900L
         )
       }
     } @@ withLiveClock,
@@ -147,8 +150,10 @@ object BoundedLatencyContractSpec extends ZIOSpecDefault {
           errors  = results.count(_.isLeft)
         } yield assertTrue(
           errors == 1000,
-          // All 1000 fibers bounded — total elapsed should not be anywhere near 1000 * 2s
-          elapsed.toMillis < 3000L
+          // `errors == 1000` already proves every fiber was bounded (timed out, none ran the full 2s). This guards
+          // against serial execution — serial would be ~1000 × 500ms = 500s — with a very generous bound (the suite's
+          // `timeout(20.seconds)` is the real hang-guard) so thread-pool scheduling on a slow CI runner can't flake it.
+          elapsed.toMillis < 15000L
         )
       }
     } @@ withLiveClock @@ timeout(20.seconds)

--- a/core/src/test/scala/zio/openfeature/ProviderEventShutdownSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderEventShutdownSpec.scala
@@ -85,9 +85,9 @@ object ProviderEventShutdownSpec extends ZIOSpecDefault {
           cancels <- ZIO.foreach(1 to 10) { _ =>
             ff.onProviderReady(_ => counter.update(_ + 1))
           }
-          // Give time for immediate replay to fire
-          _     <- ZIO.sleep(100.millis)
-          count <- counter.get
+          // Poll until all 10 immediate ready-replays have fired, rather than sleeping a fixed window — robust to
+          // async event-dispatch latency on a slow runner (bounded by the suite's 10s timeout below).
+          count <- counter.get.repeatUntil(_ >= 10)
           // Cancel all subscriptions
           _ <- ZIO.foreachDiscard(cancels)(identity)
         } yield assertTrue(count >= 10)

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
@@ -115,6 +115,13 @@ object OptimizelyProvider {
     * shuts the provider down). Prefer [[scoped]] or [[layer]] to make that ownership explicit.
     */
   def make(config: OptimizelyProviderConfig): IO[FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
+    make(config, httpClient = None)
+
+  /** Test seam: [[make]] with an injected HTTP client (see `TestHttpClient` in the test sources). */
+  private[optimizely] def make(
+    config: OptimizelyProviderConfig,
+    httpClient: Option[com.optimizely.ab.OptimizelyHttpClient]
+  ): IO[FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
     for {
       validKey <- validateSdkKey(config.sdkKey)
       validUrl <- config.datafileUrl match {
@@ -124,7 +131,7 @@ object OptimizelyProvider {
       _ <- validatePositive("pollingInterval", config.pollingInterval)
       _ <- validatePositive("blockingTimeout", config.blockingTimeout)
       pair <- ZIO
-        .attempt(buildClient(validKey, validUrl, config.pollingInterval, config.blockingTimeout))
+        .attempt(buildClient(validKey, validUrl, config.pollingInterval, config.blockingTimeout, httpClient))
         .mapError(t => FeatureFlagError.InvalidConfiguration(s"Optimizely client build failed: ${t.getMessage}"))
     } yield new OptimizelyFeatureProvider(
       pair._1,
@@ -141,7 +148,14 @@ object OptimizelyProvider {
   def scoped(
     config: OptimizelyProviderConfig
   ): ZIO[Scope, FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
-    ZIO.acquireRelease(make(config))(releaseProvider)
+    scoped(config, httpClient = None)
+
+  /** Test seam: [[scoped]] with an injected HTTP client (see `TestHttpClient` in the test sources). */
+  private[optimizely] def scoped(
+    config: OptimizelyProviderConfig,
+    httpClient: Option[com.optimizely.ab.OptimizelyHttpClient]
+  ): ZIO[Scope, FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
+    ZIO.acquireRelease(make(config, httpClient))(releaseProvider)
 
   /** [[scoped]] for the common CDN-only case. */
   def scoped(sdkKey: String): ZIO[Scope, FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
@@ -181,7 +195,14 @@ object OptimizelyProvider {
   def layer(
     config: OptimizelyProviderConfig
   ): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
-    ZLayer.scoped(scoped(config))
+    layer(config, httpClient = None)
+
+  /** Test seam: [[layer]] with an injected HTTP client (see `TestHttpClient` in the test sources). */
+  private[optimizely] def layer(
+    config: OptimizelyProviderConfig,
+    httpClient: Option[com.optimizely.ab.OptimizelyHttpClient]
+  ): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OptimizelyFeatureProvider] =
+    ZLayer.scoped(scoped(config, httpClient))
 
   // Construction
 
@@ -189,7 +210,10 @@ object OptimizelyProvider {
     sdkKey: String,
     datafileUrl: Option[String],
     pollingInterval: Option[java.time.Duration],
-    blockingTimeout: Option[java.time.Duration]
+    blockingTimeout: Option[java.time.Duration],
+    // Test seam (see the `private[optimizely]` overloads below): inject a custom HTTP client. Production callers
+    // never set this, so the SDK builds its default client.
+    httpClient: Option[com.optimizely.ab.OptimizelyHttpClient]
   ): (Optimizely, HttpProjectConfigManager) = {
     // Share a single NotificationCenter between the polling config manager and the Optimizely client. Without this,
     // the manager fires UpdateConfigNotification on its own private NotificationCenter and handlers registered via
@@ -206,6 +230,7 @@ object OptimizelyProvider {
     blockingTimeout.foreach(d =>
       configBuilder.withBlockingTimeout(java.lang.Long.valueOf(d.toMillis), TimeUnit.MILLISECONDS)
     )
+    httpClient.foreach(configBuilder.withOptimizelyHttpClient)
     // `build()` (no-arg) would start polling AND block up to the SDK's blocking timeout (default 10s) waiting for
     // the first datafile — with an unreachable CDN, construction stalls and then a background poller retries
     // forever. `build(true)` skips the blocking wait but still calls `start()`, so we `stop()` immediately:

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyConfigChangedEventSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyConfigChangedEventSpec.scala
@@ -104,6 +104,8 @@ object OptimizelyConfigChangedEventSpec extends ZIOSpecDefault {
           .withBlockingTimeout(2000L, TimeUnit.MILLISECONDS)
           .withPollingInterval(1L, TimeUnit.SECONDS)
           .withNotificationCenter(sharedCenter)
+          // Fail-fast HTTP so the 1s poller can't retry against the stopped WireMock and hang the JVM (TestHttpClient).
+          .withOptimizelyHttpClient(TestHttpClient.failFast())
           .build()
         val optimizely =
           Optimizely.builder().withConfigManager(configManager).withNotificationCenter(sharedCenter).build()
@@ -133,6 +135,6 @@ object OptimizelyConfigChangedEventSpec extends ZIOSpecDefault {
           ()
         }
       }
-    } @@ TestAspect.ifEnvNotSet("CI")
+    }
   ) @@ TestAspect.sequential @@ TestAspect.timeout(60.seconds) @@ TestAspect.withLiveClock
 }

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyPollingLifecycleSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyPollingLifecycleSpec.scala
@@ -51,9 +51,12 @@ object OptimizelyPollingLifecycleSpec extends ZIOSpecDefault {
         for {
           start <- ZIO.succeed(java.lang.System.nanoTime())
           provider <- OptimizelyProvider.make(
-            "polling-key-1",
-            Some(datafileUrl(server)),
-            java.time.Duration.ofSeconds(1)
+            OptimizelyProviderConfig(
+              sdkKey = "polling-key-1",
+              datafileUrl = Some(datafileUrl(server)),
+              initWait = java.time.Duration.ofSeconds(1)
+            ),
+            Some(TestHttpClient.failFast())
           )
           tookMs = (java.lang.System.nanoTime() - start) / 1000000L
           // Give any (buggy) background poller a chance to fire before asserting near-silence
@@ -80,7 +83,7 @@ object OptimizelyPollingLifecycleSpec extends ZIOSpecDefault {
           pollingInterval = Some(java.time.Duration.ofMillis(200))
         )
         for {
-          provider   <- OptimizelyProvider.make(config)
+          provider   <- OptimizelyProvider.make(config, Some(TestHttpClient.failFast()))
           beforeInit <- ZIO.succeed(requestCount(server))
           initResult <- ZIO.succeed(tryInit(provider))
           // pollingInterval is honored: several polls land within the window
@@ -110,7 +113,7 @@ object OptimizelyPollingLifecycleSpec extends ZIOSpecDefault {
         for {
           initResult <- ZIO.scoped {
             for {
-              provider <- OptimizelyProvider.scoped(config)
+              provider <- OptimizelyProvider.scoped(config, Some(TestHttpClient.failFast()))
               result   <- ZIO.succeed(tryInit(provider))
             } yield result
           }
@@ -136,7 +139,7 @@ object OptimizelyPollingLifecycleSpec extends ZIOSpecDefault {
         )
         for {
           _ <- ZIO.scoped {
-            OptimizelyProvider.layer(config).build.flatMap { env =>
+            OptimizelyProvider.layer(config, Some(TestHttpClient.failFast())).build.flatMap { env =>
               val provider = env.get[OptimizelyFeatureProvider]
               ZIO.succeed(tryInit(provider)) *> sleepBlocking(500.millis)
             }
@@ -152,7 +155,7 @@ object OptimizelyPollingLifecycleSpec extends ZIOSpecDefault {
         sdkKey = "polling-key-5",
         pollingInterval = Some(java.time.Duration.ZERO)
       )
-      OptimizelyProvider.make(config).exit.map { exit =>
+      OptimizelyProvider.make(config, Some(TestHttpClient.failFast())).exit.map { exit =>
         assertTrue(exit.isFailure)
       }
     }

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderConcurrencySpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderConcurrencySpec.scala
@@ -54,6 +54,8 @@ object OptimizelyProviderConcurrencySpec extends ZIOSpecDefault {
       .withUrl(datafileUrl(server))
       .withBlockingTimeout(blockingTimeout.toMillis, TimeUnit.MILLISECONDS)
       .withPollingInterval(pollingInterval.toSeconds, TimeUnit.SECONDS)
+      // Fail-fast HTTP so an in-flight poll can't retry against a stopped WireMock on a non-daemon thread (TestHttpClient).
+      .withOptimizelyHttpClient(TestHttpClient.failFast())
       .build(true)
     mgr.stop()
     (Optimizely.builder().withConfigManager(mgr).build(), mgr)

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderIntegrationSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderIntegrationSpec.scala
@@ -52,12 +52,14 @@ object OptimizelyProviderIntegrationSpec extends ZIOSpecDefault {
   private def datafileUrl(server: WireMockServer): String =
     s"http://localhost:${server.port()}$DatafilePath"
 
-  /** Build an Optimizely client pointed at WireMock with aggressive timeouts so failure-mode tests fail fast. */
+  /** Build an Optimizely client pointed at WireMock with aggressive timeouts so failure-mode tests fail fast. The
+    * fail-fast HTTP client never retries, so when WireMock is stopped at teardown an in-flight poll fails immediately
+    * instead of looping on a non-daemon thread and hanging the test JVM (see `TestHttpClient`).
+    */
   private def buildClient(
     server: WireMockServer,
     blockingTimeout: java.time.Duration = java.time.Duration.ofMillis(800),
-    pollingInterval: java.time.Duration = java.time.Duration.ofSeconds(3600),
-    keepPolling: Boolean = false
+    pollingInterval: java.time.Duration = java.time.Duration.ofSeconds(3600)
   ): Optimizely = {
     val configManager = HttpProjectConfigManager
       .builder()
@@ -65,11 +67,8 @@ object OptimizelyProviderIntegrationSpec extends ZIOSpecDefault {
       .withUrl(datafileUrl(server))
       .withBlockingTimeout(blockingTimeout.toMillis, TimeUnit.MILLISECONDS)
       .withPollingInterval(pollingInterval.toSeconds, TimeUnit.SECONDS)
+      .withOptimizelyHttpClient(TestHttpClient.failFast())
       .build()
-    // The blocking build() has already attempted the initial datafile fetch. Unless a test specifically exercises
-    // ongoing polling, halt the poller now so it cannot keep retrying against a stopped WireMock server and leave a
-    // non-daemon Apache HttpClient thread that prevents the test JVM from exiting (hanging CI until its timeout).
-    if (!keepPolling) configManager.stop()
     Optimizely.builder().withConfigManager(configManager).build()
   }
 
@@ -144,14 +143,14 @@ object OptimizelyProviderIntegrationSpec extends ZIOSpecDefault {
           get(urlEqualTo(DatafilePath))
             .willReturn(okJson(ValidDatafileV1).withFixedDelay(5000))
         )
-        val client = buildClient(server, blockingTimeout = java.time.Duration.ofMillis(200), keepPolling = true)
+        val client = buildClient(server, blockingTimeout = java.time.Duration.ofMillis(200))
         withProvider(client, initWait = java.time.Duration.ofMillis(300)) { provider =>
           val outcome = tryInit(provider)
           val state   = stateOf(provider)
           assertTrue(outcome.isLeft, state != ProviderState.READY)
         }
       }
-    } @@ TestAspect.ifEnvNotSet("CI"),
+    },
     test("connection reset by peer -> initialize throws") {
       withMockServer { server =>
         server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)))
@@ -177,7 +176,7 @@ object OptimizelyProviderIntegrationSpec extends ZIOSpecDefault {
             .whenScenarioStateIs("v2-served")
             .willReturn(okJson(ValidDatafileV2))
         )
-        val client = buildClient(server, pollingInterval = java.time.Duration.ofSeconds(1), keepPolling = true)
+        val client = buildClient(server, pollingInterval = java.time.Duration.ofSeconds(1))
         withProvider(client) { provider =>
           val outcome = tryInit(provider)
           // Poll for a second request triggered by the SDK's background poller. We bound the wait so a real
@@ -196,6 +195,6 @@ object OptimizelyProviderIntegrationSpec extends ZIOSpecDefault {
           )
         }
       }
-    } @@ TestAspect.ifEnvNotSet("CI")
+    }
   ) @@ TestAspect.sequential @@ TestAspect.timeout(45.seconds) @@ TestAspect.withLiveClock
 }

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderLifecycleSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderLifecycleSpec.scala
@@ -58,11 +58,10 @@ object OptimizelyProviderLifecycleSpec extends ZIOSpecDefault {
       .withUrl(datafileUrl(server))
       .withBlockingTimeout(blockingTimeout.toMillis, TimeUnit.MILLISECONDS)
       .withPollingInterval(pollingInterval.toSeconds, TimeUnit.SECONDS)
+      // Fail-fast HTTP: when WireMock stops at teardown, an in-flight poll fails immediately instead of retrying
+      // forever on a non-daemon thread and hanging the test JVM (see TestHttpClient).
+      .withOptimizelyHttpClient(TestHttpClient.failFast())
       .build()
-    // The blocking build() has already attempted the initial datafile fetch; these lifecycle tests never need ongoing
-    // polling, so halt the poller now — otherwise it keeps retrying against a stopped WireMock and leaves a non-daemon
-    // Apache HttpClient thread that prevents the test JVM from exiting (hanging CI until its timeout).
-    mgr.stop()
     Optimizely.builder().withConfigManager(mgr).build()
   }
 

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/TestHttpClient.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/TestHttpClient.scala
@@ -1,0 +1,29 @@
+package zio.openfeature.optimizely
+
+import com.optimizely.ab.OptimizelyHttpClient
+import org.apache.http.client.HttpRequestRetryHandler
+import org.apache.http.protocol.HttpContext
+import java.io.IOException
+
+/** Fail-fast Optimizely HTTP client for the WireMock-backed tests.
+  *
+  * The SDK's default client retries on I/O errors (sensible against a real CDN with transient blips). In tests the
+  * "CDN" is a WireMock server that is stopped at teardown, so a poll in flight at that moment would otherwise retry
+  * forever against the dead socket on the poller thread, and — combined with a short polling interval re-scheduling new
+  * fetches — keep the test JVM alive until the CI job times out.
+  *
+  * This client never retries and uses a short socket/connect timeout, so a request against a stopped server fails
+  * immediately; the poller thread (which the SDK runs as a daemon) then returns and the JVM can exit. Test-only —
+  * production uses the SDK default so transient CDN failures are still retried.
+  */
+object TestHttpClient {
+  private val noRetry: HttpRequestRetryHandler =
+    (_: IOException, _: Int, _: HttpContext) => false
+
+  def failFast(timeoutMillis: Int = 800): OptimizelyHttpClient =
+    OptimizelyHttpClient
+      .builder()
+      .withRetryHandler(noRetry)
+      .setTimeoutMillis(timeoutMillis)
+      .build()
+}


### PR DESCRIPTION
Pre-v1.0.0 CI-reliability pass — two parts. Verified by simulating CI locally (`CI=true`) with repeated runs.

## 1. Root-cause fix for the Optimizely WireMock poller hang (no tests hidden)

The recurring dangling/hung `build-matrix` jobs were caused by Optimizely's datafile poller: when a test's WireMock server stops at teardown, the SDK's Apache HttpClient keeps **retrying against the dead socket on a non-daemon thread** (and short polling intervals re-schedule fresh fetches), so the test JVM never exits → 20-min job timeout. #221/#225 patched it spec-by-spec (`build(true)+stop`, `mgr.stop`, and `@@ ifEnvNotSet("CI")` gating) — whack-a-mole that kept surfacing in the next spec (`OptimizelyPollingLifecycleSpec` was the latest).

This replaces all of that with one root-cause fix: a **fail-fast test HTTP client** (`TestHttpClient`, never retries + short socket timeout). When WireMock stops, an in-flight poll fails immediately, the (daemon) poller thread returns, and the JVM exits.

- New `TestHttpClient.failFast()`, injected via `HttpProjectConfigManager.withOptimizelyHttpClient(...)` in every WireMock-backed spec (Concurrency, Lifecycle, Integration, ConfigChanged).
- For the factory-based `PollingLifecycleSpec`, a `private[optimizely]` test seam on `OptimizelyProvider.make/scoped/layer` (default `None` → SDK's default retrying client; **no public API change, no production behavior change** — production still retries transient CDN failures).
- **Removed all the workarounds**: the `mgr.stop()` hacks, `keepPolling`, and **every `@@ TestAspect.ifEnvNotSet("CI")` gate**. All optimizely tests now run **in CI** again — nothing hidden.

## 2. Latency/timing flake hardening (the `#222` tests I'd added)

- `BoundedLatencyContractSpec`: loosened the three `elapsed < X` upper-bounds (the `ProviderError`/`errors == 1000` assertions already prove the timeout fired; notably the 1000-concurrent bound `3000 → 15000ms`, with the suite's `timeout(20s)` as the real hang-guard) so a slow CI runner can't flake them.
- `ProviderEventShutdownSpec`: replaced a fixed `ZIO.sleep(100ms)`-then-assert-replay with `repeatUntil(_ >= 10)` (bounded by the suite's `timeout(10s)`).

## Verification

- `CI=true sbt optimizely/test` — **49 passed, 0 ignored**, JVM exits ~34s, run **6×** with no hang.
- `CI=true sbt test` (full aggregate) — all modules green, **0 ignored**, clean exit.
- `PollingLifecycleSpec` alone ×4 and the latency specs ×4 — clean.
