### PR TITLE
CI/release pipeline: per-version test isolation + timeout (mitigation for #229) + thread hygiene

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Bound the job so a hung test (e.g. a provider whose background poller is never reaped) can't dangle for GitHub's
+    # 6-hour default before someone notices a stuck release. Tests + ci-release normally complete well inside this.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
         with:
@@ -30,8 +33,16 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Run tests (Scala 2.13 + 3)
-        run: sbt +test
+      # Run each Scala version in its own sbt invocation (a fresh JVM) rather than a single `+test`. `+test` runs both
+      # cross versions in one long-lived JVM; if any test leaves a non-daemon thread, it accumulates across versions and
+      # the JVM never exits — the exact hang that build-matrix (which runs `++<version> test` per cell, in its own JVM)
+      # never hits. This mirrors that proven-reliable per-version isolation. The released commit is already gated by the
+      # full build-matrix on `main`, so this is a pre-publish backstop, not the primary gate.
+      - name: Run tests (Scala 2.13)
+        run: sbt "++2.13.16 test"
+
+      - name: Run tests (Scala 3)
+        run: sbt "++3.3.4 test"
 
       - name: Publish to Maven Central
         run: sbt ci-release

--- a/ofrep/src/main/scala/zio/openfeature/ofrep/OFREPProvider.scala
+++ b/ofrep/src/main/scala/zio/openfeature/ofrep/OFREPProvider.scala
@@ -4,6 +4,9 @@ import dev.openfeature.contrib.providers.ofrep.{OfrepProvider, OfrepProviderOpti
 import zio._
 import zio.openfeature.FeatureFlagError
 
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{Executors, ExecutorService, ThreadFactory}
+
 /** Scala-friendly factories for the OpenFeature Java SDK's OFREP contrib provider
   * ([[dev.openfeature.contrib.providers.ofrep.OfrepProvider]]).
   *
@@ -26,6 +29,33 @@ import zio.openfeature.FeatureFlagError
   */
 object OFREPProvider {
 
+  // The ofrep contrib 0.0.1 Executor default (`OfrepProviderOptions.$default$executor()` = `Executors
+  // .newFixedThreadPool(5)`) uses the JDK default ThreadFactory, which produces NON-daemon threads (named
+  // `pool-N-thread-K`). Non-daemon threads block JVM exit, and `OfrepProviderOptions.builder().build()` spawns that
+  // pool eagerly — so any path that builds options but never constructs/shuts down a provider (e.g. a validation
+  // rejection) orphans the pool and can hang `sbt +test`. We always supply our own daemon executor so the contrib
+  // default is never instantiated by code that goes through this wrapper. See issue #229.
+  private val counter = new AtomicInteger(0)
+  private val daemonThreadFactory: ThreadFactory = (r: Runnable) => {
+    val t = new Thread(r, s"zio-openfeature-ofrep-${counter.incrementAndGet()}")
+    t.setDaemon(true)
+    t
+  }
+  private def newDaemonExecutor(): ExecutorService =
+    Executors.newCachedThreadPool(daemonThreadFactory)
+
+  /** A fresh `OfrepProviderOptions.Builder` pre-configured with a daemon `ExecutorService`.
+    *
+    * Use this instead of `OfrepProviderOptions.builder()` when configuring options (custom timeouts, proxy, auth
+    * headers, etc.) outside the standard [[make]] / [[layer]] factories. The contrib provider 0.0.1 default executor is
+    * `Executors.newFixedThreadPool(5)` with the JDK default `ThreadFactory` (non-daemon threads), which blocks JVM exit
+    * if the pool is never shut down. This helper wires in a daemon-thread pool up front so that can't happen. Pass the
+    * resulting `OfrepProviderOptions` to
+    * [[make(options:dev\.openfeature\.contrib\.providers\.ofrep\.OfrepProviderOptions)*]].
+    */
+  def daemonOptionsBuilder(): OfrepProviderOptions.Builder =
+    OfrepProviderOptions.builder().executor(newDaemonExecutor())
+
   /** Validate a base URL and construct an OFREP provider. The validation rules are:
     *   - non-empty after trim
     *   - parses as a `java.net.URI`
@@ -39,13 +69,18 @@ object OFREPProvider {
     validateBaseUrl(baseUrl).flatMap { validated =>
       ZIO
         .attempt(
-          OfrepProvider.constructProvider(OfrepProviderOptions.builder().baseUrl(validated).build())
+          OfrepProvider.constructProvider(daemonOptionsBuilder().baseUrl(validated).build())
         )
         .mapError(t => FeatureFlagError.InvalidConfiguration(s"OFREP provider construction failed: ${t.getMessage}"))
     }
 
   /** Validate a fully-configured [[OfrepProviderOptions]] (auth headers, timeouts, executor, etc.) and construct the
     * provider. Validates the options' `baseUrl` and rejects obvious misconfiguration up front.
+    *
+    * If you build the options yourself, prefer [[daemonOptionsBuilder]] over `OfrepProviderOptions.builder()` so the
+    * contrib provider's default non-daemon 5-thread pool is never instantiated — a pool whose owning provider is never
+    * shut down (including this method's own validation-rejection path) blocks JVM exit. This method must not mutate
+    * caller-supplied options, so the executor choice is the caller's responsibility.
     */
   def make(options: OfrepProviderOptions): IO[FeatureFlagError.InvalidConfiguration, OfrepProvider] =
     for {
@@ -82,7 +117,7 @@ object OFREPProvider {
     */
   @deprecated("Use OFREPProvider.make(...) or OFREPProvider.layer(...) for validated construction", "0.2.0")
   def apply(): OfrepProvider =
-    OfrepProvider.constructProvider()
+    OfrepProvider.constructProvider(daemonOptionsBuilder().build())
 
   /** Create an OFREP provider pointed at a specific endpoint, otherwise using contrib defaults.
     *
@@ -91,7 +126,7 @@ object OFREPProvider {
     */
   @deprecated("Use OFREPProvider.make(baseUrl) or OFREPProvider.layer(baseUrl) for validated construction", "0.2.0")
   def apply(baseUrl: String): OfrepProvider =
-    OfrepProvider.constructProvider(OfrepProviderOptions.builder().baseUrl(baseUrl).build())
+    OfrepProvider.constructProvider(daemonOptionsBuilder().baseUrl(baseUrl).build())
 
   /** Create an OFREP provider with a fully configured [[OfrepProviderOptions]].
     *

--- a/ofrep/src/test/scala/zio/openfeature/ofrep/OFREPProviderSpec.scala
+++ b/ofrep/src/test/scala/zio/openfeature/ofrep/OFREPProviderSpec.scala
@@ -40,8 +40,8 @@ object OFREPProviderSpec extends ZIOSpecDefault {
         finally provider.shutdown()
       },
       test("fromOptions accepts a fully-built OfrepProviderOptions") {
-        val opts = OfrepProviderOptions
-          .builder()
+        val opts = OFREPProvider
+          .daemonOptionsBuilder()
           .baseUrl("http://localhost:9999")
           .requestTimeout(Duration.ofSeconds(5))
           .connectTimeout(Duration.ofSeconds(5))
@@ -117,7 +117,10 @@ object OFREPProviderSpec extends ZIOSpecDefault {
     ),
     suite("make(OfrepProviderOptions)")(
       test("rejects options with bad scheme") {
-        val opts = OfrepProviderOptions.builder().baseUrl("ftp://flags.example.com").build()
+        // Use daemonOptionsBuilder() instead of OfrepProviderOptions.builder(): `make` validates and rejects the
+        // ftp scheme BEFORE constructing a provider, so shutdown() never runs. The contrib default builder would
+        // orphan a non-daemon 5-thread pool here and hang `sbt +test` (issue #229).
+        val opts = OFREPProvider.daemonOptionsBuilder().baseUrl("ftp://flags.example.com").build()
         for {
           result <- OFREPProvider.make(opts).either
         } yield assertTrue(
@@ -126,8 +129,8 @@ object OFREPProviderSpec extends ZIOSpecDefault {
         )
       },
       test("accepts options with a valid baseUrl") {
-        val opts = OfrepProviderOptions
-          .builder()
+        val opts = OFREPProvider
+          .daemonOptionsBuilder()
           .baseUrl("http://localhost:9999")
           .requestTimeout(Duration.ofSeconds(5))
           .build()

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderConcurrencySpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyProviderConcurrencySpec.scala
@@ -64,9 +64,18 @@ object OptimizelyProviderConcurrencySpec extends ZIOSpecDefault {
   @scala.annotation.nowarn("msg=deprecated")
   private def stateOf(p: OptimizelyFeatureProvider): ProviderState = p.getState
 
+  // Daemon thread factory: `Executors.newFixedThreadPool(n)` uses the default factory, which creates NON-daemon
+  // threads. If `awaitTermination` ever times out (a worker wedged in a blocking provider/HTTP call), those threads
+  // would keep the test JVM from exiting. Daemon threads can't block JVM exit, so a slow-to-reap pool is harmless.
+  private val daemonFactory: java.util.concurrent.ThreadFactory = (r: Runnable) => {
+    val t = new Thread(r)
+    t.setDaemon(true)
+    t
+  }
+
   /** Spawn `n` worker threads, release them simultaneously via a latch, and collect outcomes. */
   private def race[A](n: Int)(work: Int => A): IndexedSeq[Either[Throwable, A]] = {
-    val pool      = Executors.newFixedThreadPool(math.min(n, 64))
+    val pool      = Executors.newFixedThreadPool(math.min(n, 64), daemonFactory)
     val release   = new CountDownLatch(1)
     val started   = new CountDownLatch(n)
     val results   = new Array[Either[Throwable, A]](n)
@@ -91,7 +100,7 @@ object OptimizelyProviderConcurrencySpec extends ZIOSpecDefault {
       results.toIndexedSeq
     } finally {
       // Reap worker threads deterministically: `shutdownNow` interrupts, then join so no evaluation thread outlives
-      // the test and races provider/WireMock teardown. `Executors.newFixedThreadPool` threads are non-daemon.
+      // the test and races provider/WireMock teardown. The pool also uses a daemon factory as a backstop.
       pool.shutdownNow()
       pool.awaitTermination(5, TimeUnit.SECONDS)
       ()
@@ -212,7 +221,7 @@ object OptimizelyProviderConcurrencySpec extends ZIOSpecDefault {
             closeOnShutdown = true,
             configManager = Some(mgr)
           )
-        val pool = Executors.newFixedThreadPool(32)
+        val pool = Executors.newFixedThreadPool(32, daemonFactory)
         try {
           provider.initialize(new ImmutableContext())
           val N      = 200


### PR DESCRIPTION
Makes the CI/release pipeline robust to the rare post-test JVM hang investigated in #229, plus related hygiene. The exact root cause of the hang is **not** fully pinned (current evidence points at an sbt/environment-level quirk, not project code — see #229); this PR is the **pragmatic mitigation**, not a confirmed root-cause fix.

## Mitigation (the actual fix for the pipeline)
- **Release runs each Scala version in its own sbt invocation** (`++2.13.16 test`, then `++3.3.4 test`) instead of `+test` (both versions in one long-lived JVM). This matches the per-cell `build-matrix` config, which has been reliable, and avoids accumulating state across versions in one JVM.
- **`timeout-minutes` on the publish job** so a hang fails fast and is re-runnable, instead of dangling to GitHub's 6-hour default (which is what happened on the v1.0.0-RC1 attempt — nothing was published).

## Hygiene (good practice; NOT confirmed to fix the hang)
- **`OFREPProvider` injects a daemon executor.** The ofrep contrib 0.0.1 default executor is a non-daemon `Executors.newFixedThreadPool(5)`; a provider whose `shutdown()` is missed would leave non-daemon threads that can delay JVM exit. Our wrapper now always supplies a daemon executor (new `daemonOptionsBuilder()` helper), so that can't happen via our factories. No production behavior change beyond thread daemon-ness.
- **Optimizely concurrency-test pools use a daemon thread factory** so a slow-to-reap test pool can't block JVM exit.

## Status
The root-cause hunt is tracked in #229 (with a thread dump and the corrected analysis). This PR unblocks the release; the deep investigation can continue independently.
