### PR TITLE
Fork test JVMs so leaked threads can't hang sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,6 +90,12 @@ lazy val crossVersionSourceDirs = Seq(
 
 lazy val commonSettings = Seq(
   testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+  // Run tests in a forked JVM. A forked test run is a child process that sbt force-terminates when the `test` task
+  // completes, so a leaked non-daemon thread (a poller, a WireMock/Jetty pool, anything) can't block exit the way it
+  // can in-process. This is the categorical fix for #217 and #229: both issues are repeated instances of "some
+  // non-daemon thread outlived the test run and hung the JVM," and chasing each individual leak source (already done
+  // across several merged PRs) only closes the specific case found, not the class of bug.
+  Test / fork := true,
   libraryDependencies ++= Seq(
     "dev.zio" %% "zio-test"     % zioVersion % Test,
     "dev.zio" %% "zio-test-sbt" % zioVersion % Test


### PR DESCRIPTION
## Summary

#217 and #229 are the same class of bug: the test JVM intermittently never exits after a `test` run finishes, hanging the CI job until a timeout kills it. Over several merged PRs (#220, #221, #225, #227, #228) we repeatedly found and closed individual leaked non-daemon threads (Optimizely poller, WireMock client, OFREP's default executor, test concurrency pools). Each was a real leak, but none of them closed the issues, because the underlying bug class isn't "thread X leaks" — it's "any non-daemon thread that outlives the test run blocks JVM exit," and there's always another candidate (a dependency's internal pool, sbt's own framework pool, a future test).

#217 itself names the categorical fix and never applied it: `Test / fork := true`. A forked test run executes in a child JVM that sbt force-terminates once the `test` task completes, so a lingering non-daemon thread in that child can no longer block the parent JVM (sbt's own) from exiting — independent of which thread it is. #229's own investigation comment reaches the same conclusion from the other direction: the evidence pointed away from a single app-level leak and toward JVM exit semantics, which is exactly what forking controls.

## Changes

- `build.sbt`: add `Test / fork := true` to `commonSettings`, applied to `core`, `extras`, `ofrep`, `optimizely`, `testkit` (every module that runs zio-test). `conformance`/`conformance-zio-bdd` are untouched — they run via JUnit/Cucumber, which forks independently.

No test logic changed.

## Test plan

- [x] `sbt scalafmtAll`
- [x] `sbt compile`
- [x] `sbt optimizely/test`, `sbt ofrep/test`, `sbt extras/test` — all pass, sbt returns immediately (no hang)
- [x] `sbt test` (full aggregate) — all pass
- [x] `sbt "++2.13.16 test"` and `sbt "++3.3.4 test"` — cross-version sanity matching CI's build-matrix

Closes #217
Closes #229