### PR TITLE
Add Optimizely flag-matrix tests across datafile configurations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -211,6 +211,10 @@ lazy val conformance = (project in file("conformance"))
 
 lazy val conformanceZioBdd = (project in file("conformance-zio-bdd"))
   .dependsOn(core, testkit)
+  // "test->test" on optimizely additionally pulls its test classpath (not just main), so the
+  // Optimizely flag-matrix suite below can reuse `RecommendationService`/`RecommendationResult`
+  // from optimizely's own test sources instead of duplicating that toy SUT here.
+  .dependsOn(optimizely % "test->test;compile->compile")
   .settings(
     name               := "zio-openfeature-conformance-zio-bdd",
     publish / skip     := true,
@@ -219,7 +223,8 @@ lazy val conformanceZioBdd = (project in file("conformance-zio-bdd"))
       "dev.openfeature"         % "sdk"                    % openFeatureSdkVersion % Test,
       "io.github.etacassiopeia" %% "zio-bdd"               % "1.0.0"               % Test,
       "dev.zio"                 %% "zio-schema"            % "1.6.6"               % Test,
-      "dev.zio"                 %% "zio-schema-derivation" % "1.6.6"               % Test
+      "dev.zio"                 %% "zio-schema-derivation" % "1.6.6"               % Test,
+      "org.wiremock"             % "wiremock"              % "3.10.0"              % Test
     ),
     Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
   )

--- a/conformance-zio-bdd/src/test/resources/features/optimizely/flag_matrix.feature
+++ b/conformance-zio-bdd/src/test/resources/features/optimizely/flag_matrix.feature
@@ -54,3 +54,36 @@ Feature: Optimizely flag matrix — behaviour under different datafile configura
     When user "user-alice" with plan "premium" requests a recommendation
     Then the recommendation kind is "degraded"
     And the rate limit is 0
+
+  # ---------------------------------------------------------------------------
+  # Combining multiple keys in a single @flags(...) tag
+  #
+  # A single tag with comma-separated key=value pairs expands to ONE flagLayer
+  # call carrying both keys in one Map — one run, both overrides applied
+  # together. Here "plan" is seeded as global context (MatrixHarness ->
+  # setGlobalContext) instead of being passed as step text, so there is no
+  # "with plan" wording in this scenario at all — it's entirely tag-driven.
+  # ---------------------------------------------------------------------------
+
+  @flags(datafile=audience-premium, plan=premium)
+  Scenario: Datafile and plan overrides combined in a single @flags tag
+    When a recommendation is requested
+    Then the recommendation kind is "alpha"
+    And the rate limit is 100
+
+  # ---------------------------------------------------------------------------
+  # Stacking multiple separate @flags(...) tags on one scenario
+  #
+  # Two distinct tag occurrences — not two keys in one tag — expand into two
+  # independent runs, each calling flagLayer once with only that tag's own
+  # Map. Each run gets its own isolated WireMock server + Optimizely provider
+  # (per MatrixHarness), so this is two full scenario executions, not one
+  # execution choosing between two configs. kill-switch-off and
+  # audience-premium happen to agree on "alpha" under the default (no-plan)
+  # context, so the same assertion holds for both runs even though the
+  # underlying datafile — and provider instance — differs each time.
+  # ---------------------------------------------------------------------------
+
+  @flags(datafile=kill-switch-off) @flags(datafile=audience-premium)
+  Scenario: Stacking two separate @flags tags runs the scenario twice, once per tag
+    Then the recommendation service returns kind "alpha"

--- a/conformance-zio-bdd/src/test/resources/features/optimizely/flag_matrix.feature
+++ b/conformance-zio-bdd/src/test/resources/features/optimizely/flag_matrix.feature
@@ -1,0 +1,56 @@
+Feature: Optimizely flag matrix — behaviour under different datafile configurations
+
+  Each scenario is annotated with @flags(datafile=X).  zio-bdd expands every @flags(...) tag
+  into an independent scenario run and calls flagLayer with Map("datafile" -> "X"), which builds
+  a fresh WireMock server + Optimizely provider scoped to that scenario.  No stub-swap, no
+  polling wait — each run has its own isolated provider that is torn down when the scenario ends.
+
+  # ---------------------------------------------------------------------------
+  # Basic kill-switch / variant matrix — one @flags tag per expected outcome.
+  # zio-bdd names each run "Scenario name [datafile=X]" in the report.
+  # ---------------------------------------------------------------------------
+
+  @flags(datafile=empty)
+  Scenario: No flags configured — service returns the safe default
+    Then the recommendation service returns kind "default"
+
+  @flags(datafile=kill-switch-off)
+  Scenario: Kill-switch is off and variant is alpha — full recommendation
+    Then the recommendation service returns kind "alpha"
+
+  @flags(datafile=kill-switch-on)
+  Scenario: Kill-switch is on — service returns degraded response
+    Then the recommendation service returns kind "degraded"
+
+  @flags(datafile=variant-beta)
+  Scenario: Kill-switch is off and variant is beta — beta recommendation
+    Then the recommendation service returns kind "beta"
+
+  # ---------------------------------------------------------------------------
+  # Audience-gated integer variable — premium vs standard plan
+  #
+  # The "audience-premium" datafile has three flags:
+  #   • recommendation_kill_switch  — on for all users
+  #   • recommendation_variant      — "alpha" for all users
+  #   • recommendation_rate_limit   — integer variable:
+  #       100  when user attribute plan = "premium" (audience rule fires)
+  #        10  for all other users (audience miss → FlagNotFound → default)
+  # ---------------------------------------------------------------------------
+
+  @flags(datafile=audience-premium)
+  Scenario: Premium user receives elevated rate limit from audience-gated variable
+    When user "user-alice" with plan "premium" requests a recommendation
+    Then the recommendation kind is "alpha"
+    And the rate limit is 100
+
+  @flags(datafile=audience-premium)
+  Scenario: Standard user falls through audience rule and receives conservative rate limit
+    When user "user-bob" with plan "standard" requests a recommendation
+    Then the recommendation kind is "alpha"
+    And the rate limit is 10
+
+  @flags(datafile=kill-switch-on)
+  Scenario: Kill-switch overrides all flags — degraded result regardless of plan attribute
+    When user "user-alice" with plan "premium" requests a recommendation
+    Then the recommendation kind is "degraded"
+    And the rate limit is 0

--- a/conformance-zio-bdd/src/test/resources/features/optimizely/flag_matrix.feature
+++ b/conformance-zio-bdd/src/test/resources/features/optimizely/flag_matrix.feature
@@ -84,6 +84,7 @@ Feature: Optimizely flag matrix — behaviour under different datafile configura
   # underlying datafile — and provider instance — differs each time.
   # ---------------------------------------------------------------------------
 
-  @flags(datafile=kill-switch-off) @flags(datafile=audience-premium)
+  @flags(datafile=kill-switch-off)
+  @flags(datafile=audience-premium)
   Scenario: Stacking two separate @flags tags runs the scenario twice, once per tag
     Then the recommendation service returns kind "alpha"

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/FlagMatrixSpec.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/FlagMatrixSpec.scala
@@ -1,0 +1,88 @@
+package zio.openfeature.conformance.bdd.matrix
+
+import zio._
+import zio.bdd.core.Suite
+import zio.bdd.core.Assertions.assertTrue
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.gherkin.ScenarioMetadata
+import zio.openfeature._
+import zio.openfeature.optimizely.matrix.{RecommendationResult, RecommendationService}
+
+/** Flag-matrix BDD suite driven by @flags(datafile=X) scenario expansion.
+  *
+  * == How it works ==
+  *
+  * Each scenario is annotated with one or more @flags(datafile=<name>) tags. zio-bdd expands
+  * each tag into a separate scenario run and calls flagLayer(meta, Map("datafile" -> "<name>")).
+  * That layer builds a fresh WireMock server + Optimizely provider scoped to that scenario —
+  * no global harness, no stub-swap between scenarios, no polling wait in step bodies.
+  *
+  * Isolation guarantees:
+  *   - Each run gets its own WireMock on an ephemeral port and its own Optimizely client.
+  *   - WireMock and the client are shut down when the scenario scope closes.
+  *   - scenarioParallelism > 1 is safe: providers don't share state.
+  *
+  * Lives in `conformance-zio-bdd` (rather than its own module) so this stays a single zio-bdd
+  * home instead of a third Scala-3-only test module; `RecommendationService` itself is reused
+  * from `optimizely`'s test sources via a test->test dependency in build.sbt, so the
+  * decision logic under test has exactly one definition.
+  */
+@Suite(
+  featureDirs         = Array("conformance-zio-bdd/src/test/resources/features/optimizely"),
+  reporters           = Array("pretty"),
+  parallelism         = 1,
+  scenarioParallelism = 1,
+  logLevel            = "warning"
+)
+object FlagMatrixSpec extends ZIOSteps[FeatureFlags, World] {
+
+  /** Build a per-scenario FeatureFlags layer from the "datafile" flag value.
+    * Called once per @flags(datafile=X) expansion — each run gets an isolated provider.
+    */
+  override def flagLayer(meta: ScenarioMetadata, flags: Map[String, String]): ZLayer[Any, Throwable, FeatureFlags] = {
+    val datafile = flags.getOrElse("datafile", "empty")
+    MatrixHarness.layerForDatafile(datafile)
+  }
+
+  // ── Assertions ──────────────────────────────────────────────────────────
+
+  Then("the recommendation service returns kind " / string) { (expected: String) =>
+    ZIO.serviceWithZIO[FeatureFlags] { ff =>
+      val svc = new RecommendationService(ff)
+      for {
+        kind <- svc.recommend
+        _    <- assertTrue(kind == expected, s"recommendation kind '$kind' != '$expected'")
+      } yield ()
+    }
+  }
+
+  Then("the recommendation kind is " / string) { (expected: String) =>
+    for {
+      world <- ScenarioContext.get
+      result = world.lastResult.getOrElse(RecommendationResult("__none__", -1))
+      _     <- assertTrue(result.kind == expected, s"kind '${result.kind}' != '$expected'")
+    } yield ()
+  }
+
+  And("the rate limit is " / int) { (expected: Int) =>
+    for {
+      world <- ScenarioContext.get
+      result = world.lastResult.getOrElse(RecommendationResult("__none__", -1))
+      _     <- assertTrue(result.rateLimit == expected, s"rateLimit ${result.rateLimit} != $expected")
+    } yield ()
+  }
+
+  // ── User-context step (audience-gated scenarios) ─────────────────────────
+
+  When("user " / string / " with plan " / string / " requests a recommendation") {
+    (userId: String, plan: String) =>
+      ZIO.serviceWithZIO[FeatureFlags] { ff =>
+        val svc = new RecommendationService(ff)
+        val ctx = EvaluationContext(userId).withAttribute("plan", AttributeValue.StringValue(plan))
+        for {
+          result <- svc.recommendWithContext(ctx)
+          _      <- ScenarioContext.update(_.copy(lastResult = Some(result)))
+        } yield ()
+      }
+  }
+}

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/FlagMatrixSpec.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/FlagMatrixSpec.scala
@@ -36,12 +36,16 @@ import zio.openfeature.optimizely.matrix.{RecommendationResult, RecommendationSe
 )
 object FlagMatrixSpec extends ZIOSteps[FeatureFlags, World] {
 
-  /** Build a per-scenario FeatureFlags layer from the "datafile" flag value.
-    * Called once per @flags(datafile=X) expansion — each run gets an isolated provider.
+  /** Build a per-scenario FeatureFlags layer from the tag's flag values.
+    *
+    * Called once per `@flags(...)` tag occurrence on a scenario — not once per key inside a tag.
+    * A single `@flags(datafile=X, plan=Y)` tag therefore produces one call with both keys in
+    * `flags`, while two separate `@flags(datafile=X) @flags(datafile=Y)` tags on the same scenario
+    * produce two independent calls (one per tag), each running the scenario body once.
     */
   override def flagLayer(meta: ScenarioMetadata, flags: Map[String, String]): ZLayer[Any, Throwable, FeatureFlags] = {
     val datafile = flags.getOrElse("datafile", "empty")
-    MatrixHarness.layerForDatafile(datafile)
+    MatrixHarness.layerForDatafile(datafile, plan = flags.get("plan"))
   }
 
   // ── Assertions ──────────────────────────────────────────────────────────
@@ -70,6 +74,18 @@ object FlagMatrixSpec extends ZIOSteps[FeatureFlags, World] {
       result = world.lastResult.getOrElse(RecommendationResult("__none__", -1))
       _     <- assertTrue(result.rateLimit == expected, s"rateLimit ${result.rateLimit} != $expected")
     } yield ()
+  }
+
+  // ── Tag-driven context (no plan in step text — sourced from @flags(plan=...)) ────────────
+
+  When("a recommendation is requested") {
+    ZIO.serviceWithZIO[FeatureFlags] { ff =>
+      val svc = new RecommendationService(ff)
+      for {
+        result <- svc.recommendWithContext(EvaluationContext("test-user"))
+        _      <- ScenarioContext.update(_.copy(lastResult = Some(result)))
+      } yield ()
+    }
   }
 
   // ── User-context step (audience-gated scenarios) ─────────────────────────

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/MatrixHarness.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/MatrixHarness.scala
@@ -1,0 +1,61 @@
+package zio.openfeature.conformance.bdd.matrix
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import zio._
+import zio.openfeature._
+import zio.openfeature.optimizely.{OptimizelyProvider, OptimizelyProviderConfig}
+
+/** Builds a per-scenario ZLayer[Any, Throwable, FeatureFlags] from a named datafile fixture.
+  *
+  * Each layer acquisition:
+  *   1. Starts a fresh WireMock server on an ephemeral port.
+  *   2. Stubs the Optimizely CDN endpoint to serve the named datafile fixture.
+  *   3. Initialises an OptimizelyProvider synchronously (blocks until the datafile is fetched).
+  *   4. Builds a FeatureFlags service wired to that provider.
+  *
+  * The layer is scoped: WireMock and the Optimizely client are shut down when the scenario ends,
+  * so each scenario is fully isolated — no stub-swap, no polling wait, no shared state.
+  *
+  * This is the intended companion to @flags(datafile=X) scenario expansion: zio-bdd calls
+  * `flagLayer(meta, Map("datafile" -> "X"))` once per scenario and provides the resulting layer
+  * as the scenario's R environment.
+  */
+object MatrixHarness {
+
+  private val SdkKey       = "test-matrix-key"
+  private val DatafilePath = s"/datafiles/$SdkKey.json"
+
+  private def loadDatafile(name: String): String = {
+    val path = s"/datafiles/$name.json"
+    val is   = getClass.getResourceAsStream(path)
+    require(is != null, s"Datafile fixture not found on classpath: $path")
+    scala.io.Source.fromInputStream(is).mkString
+  }
+
+  /** A scoped ZLayer that owns one WireMock server + one Optimizely provider for the named datafile. */
+  def layerForDatafile(name: String): ZLayer[Any, Throwable, FeatureFlags] =
+    ZLayer.scoped {
+      for {
+        server <- ZIO.acquireRelease(
+                    ZIO.succeed {
+                      val s = new WireMockServer(WireMockConfiguration.options().dynamicPort())
+                      s.start()
+                      s.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(loadDatafile(name))))
+                      s
+                    }
+                  )(s => ZIO.succeed(s.stop()))
+        dataUrl  = s"http://localhost:${server.port()}$DatafilePath"
+        config   = OptimizelyProviderConfig(
+                     sdkKey          = SdkKey,
+                     datafileUrl     = Some(dataUrl),
+                     initWait        = java.time.Duration.ofSeconds(5),
+                     pollingInterval = Some(java.time.Duration.ofSeconds(3600)), // no polling in tests
+                     blockingTimeout = Some(java.time.Duration.ofSeconds(2))
+                   )
+        provider <- OptimizelyProvider.scoped(config).mapError(e => RuntimeException(e.message))
+        env      <- FeatureFlags.fromProvider(provider).build
+      } yield env.get[FeatureFlags]
+    }
+}

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/MatrixHarness.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/MatrixHarness.scala
@@ -34,8 +34,15 @@ object MatrixHarness {
     scala.io.Source.fromInputStream(is).mkString
   }
 
-  /** A scoped ZLayer that owns one WireMock server + one Optimizely provider for the named datafile. */
-  def layerForDatafile(name: String): ZLayer[Any, Throwable, FeatureFlags] =
+  /** A scoped ZLayer that owns one WireMock server + one Optimizely provider for the named datafile.
+    *
+    * `plan`, when present, is seeded as a global-context attribute (via `setGlobalContext`) before the
+    * layer is handed to the scenario. The OpenFeature spec merges global context into every invocation
+    * automatically (API -> Transaction -> Client -> Invocation), so a single `@flags(datafile=X, plan=Y)`
+    * tag can combine a provider swap with a context override in one `flagLayer` call — no separate
+    * "with plan" step text required.
+    */
+  def layerForDatafile(name: String, plan: Option[String] = None): ZLayer[Any, Throwable, FeatureFlags] =
     ZLayer.scoped {
       for {
         server <- ZIO.acquireRelease(
@@ -56,6 +63,8 @@ object MatrixHarness {
                    )
         provider <- OptimizelyProvider.scoped(config).mapError(e => RuntimeException(e.message))
         env      <- FeatureFlags.fromProvider(provider).build
-      } yield env.get[FeatureFlags]
+        ff        = env.get[FeatureFlags]
+        _        <- ZIO.foreachDiscard(plan)(p => ff.setGlobalContext(EvaluationContext.empty.withAttribute("plan", AttributeValue.StringValue(p))))
+      } yield ff
     }
 }

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/World.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/World.scala
@@ -1,0 +1,13 @@
+package zio.openfeature.conformance.bdd.matrix
+
+import zio.bdd.core.Default
+import zio.openfeature.optimizely.matrix.RecommendationResult
+
+/** Per-scenario state for the flag-matrix BDD suite. */
+final case class World(
+  lastResult: Option[RecommendationResult] = None
+)
+
+object World {
+  given Default[World] = Default.from(World())
+}

--- a/optimizely/src/test/resources/datafiles/audience-premium.json
+++ b/optimizely/src/test/resources/datafiles/audience-premium.json
@@ -1,0 +1,125 @@
+{
+  "version": "4",
+  "accountId": "test",
+  "projectId": "test",
+  "revision": "5",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "attributes": [
+    { "id": "600", "key": "plan" }
+  ],
+  "audiences": [
+    {
+      "id": "700",
+      "name": "premium users",
+      "conditions": "[\"and\", {\"name\": \"plan\", \"match\": \"exact\", \"type\": \"custom_attribute\", \"value\": \"premium\"}]"
+    }
+  ],
+  "typedAudiences": [
+    {
+      "id": "700",
+      "name": "premium users",
+      "conditions": ["and", {"name": "plan", "match": "exact", "type": "custom_attribute", "value": "premium"}]
+    }
+  ],
+  "featureFlags": [
+    {
+      "id": "100",
+      "key": "recommendation_kill_switch",
+      "rolloutId": "200",
+      "experimentIds": [],
+      "variables": []
+    },
+    {
+      "id": "101",
+      "key": "recommendation_variant",
+      "rolloutId": "201",
+      "experimentIds": [],
+      "variables": [
+        { "id": "500", "key": "value", "type": "string", "defaultValue": "alpha" }
+      ]
+    },
+    {
+      "id": "102",
+      "key": "recommendation_rate_limit",
+      "rolloutId": "202",
+      "experimentIds": [],
+      "variables": [
+        { "id": "501", "key": "value", "type": "integer", "defaultValue": "10" }
+      ]
+    }
+  ],
+  "rollouts": [
+    {
+      "id": "200",
+      "experiments": [
+        {
+          "id": "300",
+          "key": "rollout-kill-switch-off-premium",
+          "status": "Running",
+          "layerId": "200",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "400", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "400",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "201",
+      "experiments": [
+        {
+          "id": "301",
+          "key": "rollout-variant-alpha-premium",
+          "status": "Running",
+          "layerId": "201",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "401", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "401",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [{ "id": "500", "value": "alpha" }]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "202",
+      "experiments": [
+        {
+          "id": "302",
+          "key": "rollout-rate-limit-premium",
+          "status": "Running",
+          "layerId": "202",
+          "audienceIds": ["700"],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "402", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "402",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [{ "id": "501", "value": "100" }]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "groups": [],
+  "variables": [],
+  "events": []
+}

--- a/optimizely/src/test/resources/datafiles/empty.json
+++ b/optimizely/src/test/resources/datafiles/empty.json
@@ -1,0 +1,18 @@
+{
+  "version": "4",
+  "accountId": "test",
+  "projectId": "test",
+  "revision": "1",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "featureFlags": [],
+  "rollouts": [],
+  "audiences": [],
+  "typedAudiences": [],
+  "groups": [],
+  "attributes": [],
+  "variables": [],
+  "events": []
+}

--- a/optimizely/src/test/resources/datafiles/kill-switch-off.json
+++ b/optimizely/src/test/resources/datafiles/kill-switch-off.json
@@ -1,0 +1,80 @@
+{
+  "version": "4",
+  "accountId": "test",
+  "projectId": "test",
+  "revision": "2",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "featureFlags": [
+    {
+      "id": "100",
+      "key": "recommendation_kill_switch",
+      "rolloutId": "200",
+      "experimentIds": [],
+      "variables": []
+    },
+    {
+      "id": "101",
+      "key": "recommendation_variant",
+      "rolloutId": "201",
+      "experimentIds": [],
+      "variables": [
+        { "id": "500", "key": "value", "type": "string", "defaultValue": "alpha" }
+      ]
+    }
+  ],
+  "rollouts": [
+    {
+      "id": "200",
+      "experiments": [
+        {
+          "id": "300",
+          "key": "rollout-kill-switch-off",
+          "status": "Running",
+          "layerId": "200",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "400", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "400",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "201",
+      "experiments": [
+        {
+          "id": "301",
+          "key": "rollout-variant-alpha",
+          "status": "Running",
+          "layerId": "201",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "401", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "401",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [{ "id": "500", "value": "alpha" }]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "audiences": [],
+  "typedAudiences": [],
+  "groups": [],
+  "attributes": [],
+  "variables": [],
+  "events": []
+}

--- a/optimizely/src/test/resources/datafiles/kill-switch-on.json
+++ b/optimizely/src/test/resources/datafiles/kill-switch-on.json
@@ -1,0 +1,80 @@
+{
+  "version": "4",
+  "accountId": "test",
+  "projectId": "test",
+  "revision": "3",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "featureFlags": [
+    {
+      "id": "100",
+      "key": "recommendation_kill_switch",
+      "rolloutId": "200",
+      "experimentIds": [],
+      "variables": []
+    },
+    {
+      "id": "101",
+      "key": "recommendation_variant",
+      "rolloutId": "201",
+      "experimentIds": [],
+      "variables": [
+        { "id": "500", "key": "value", "type": "string", "defaultValue": "alpha" }
+      ]
+    }
+  ],
+  "rollouts": [
+    {
+      "id": "200",
+      "experiments": [
+        {
+          "id": "300",
+          "key": "rollout-kill-switch-on",
+          "status": "Running",
+          "layerId": "200",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "400", "endOfRange": 0 }],
+          "variations": [
+            {
+              "id": "400",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "201",
+      "experiments": [
+        {
+          "id": "301",
+          "key": "rollout-variant-alpha-v3",
+          "status": "Running",
+          "layerId": "201",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "401", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "401",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [{ "id": "500", "value": "alpha" }]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "audiences": [],
+  "typedAudiences": [],
+  "groups": [],
+  "attributes": [],
+  "variables": [],
+  "events": []
+}

--- a/optimizely/src/test/resources/datafiles/variant-beta.json
+++ b/optimizely/src/test/resources/datafiles/variant-beta.json
@@ -1,0 +1,80 @@
+{
+  "version": "4",
+  "accountId": "test",
+  "projectId": "test",
+  "revision": "4",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "featureFlags": [
+    {
+      "id": "100",
+      "key": "recommendation_kill_switch",
+      "rolloutId": "200",
+      "experimentIds": [],
+      "variables": []
+    },
+    {
+      "id": "101",
+      "key": "recommendation_variant",
+      "rolloutId": "201",
+      "experimentIds": [],
+      "variables": [
+        { "id": "500", "key": "value", "type": "string", "defaultValue": "alpha" }
+      ]
+    }
+  ],
+  "rollouts": [
+    {
+      "id": "200",
+      "experiments": [
+        {
+          "id": "300",
+          "key": "rollout-kill-switch-off-v4",
+          "status": "Running",
+          "layerId": "200",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "400", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "400",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "201",
+      "experiments": [
+        {
+          "id": "301",
+          "key": "rollout-variant-beta",
+          "status": "Running",
+          "layerId": "201",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "401", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "401",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [{ "id": "500", "value": "beta" }]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "audiences": [],
+  "typedAudiences": [],
+  "groups": [],
+  "attributes": [],
+  "variables": [],
+  "events": []
+}

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/matrix/RecommendationService.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/matrix/RecommendationService.scala
@@ -1,0 +1,72 @@
+package zio.openfeature.optimizely.matrix
+
+import zio._
+import zio.openfeature._
+
+/** Toy system-under-test: reads feature flags and produces a recommendation response.
+  *
+  * `recommend` (original, single-user context): reads two flags and returns a kind string.
+  *
+  * `recommendWithContext` (extended): reads three flags against a caller-supplied user context, returning a
+  * [[RecommendationResult]] that also carries a rate-limit integer variable. The third flag,
+  * `recommendation_rate_limit`, is audience-gated — only users with `plan = "premium"` receive the elevated limit;
+  * everyone else gets the default.
+  *
+  * Decision logic (shared across both methods):
+  *   - `recommendation_kill_switch` boolean — FlagNotFound → no opinion; any other error → degraded.
+  *   - `recommendation_variant` string — FlagNotFound or error → "default".
+  *   - Kill-switch explicitly off (enabled=false) → degraded, rateLimit = 0.
+  *   - Kill-switch absent or on → serve variant (or "default" if also absent).
+  *   - `recommendation_rate_limit` integer variable — audience-gated; FlagNotFound → 10 (conservative default).
+  *
+  * NOTE: The OpenFeature SDK + Optimizely provider surface FLAG_NOT_FOUND as a *successful* `FlagResolution` carrying
+  * `errorCode = Some(ErrorCode.FlagNotFound)` with the default value, not as a ZIO failure. We therefore use `*Details`
+  * methods and inspect `resolution.errorCode`.
+  */
+final class RecommendationService(flags: FeatureFlags) {
+
+  private val defaultUserCtx = EvaluationContext("test-user")
+
+  def recommend: UIO[String] =
+    recommendWithContext(defaultUserCtx).map(_.kind)
+
+  def recommendWithContext(userCtx: EvaluationContext): UIO[RecommendationResult] =
+    for {
+      killResolution <- flags
+        .booleanDetails("recommendation_kill_switch", default = false, userCtx)
+        .catchAll(_ =>
+          ZIO.succeed(
+            FlagResolution.error("recommendation_kill_switch", false, ErrorCode.General, "provider error")
+          )
+        )
+      killEnabled = killResolution.errorCode match {
+        case Some(ErrorCode.FlagNotFound) => None        // absent → no opinion
+        case Some(_)                      => Some(false) // other error → degrade
+        case None                         => Some(killResolution.value)
+      }
+      result <- killEnabled match {
+        case Some(false) =>
+          ZIO.succeed(RecommendationResult(kind = "degraded", rateLimit = 0))
+        case _ =>
+          for {
+            variantResult <- flags
+              .stringDetails("recommendation_variant", default = "__absent__", userCtx)
+              .map { r =>
+                if (r.errorCode.contains(ErrorCode.FlagNotFound)) "default"
+                else if (r.value == "__absent__") "default"
+                else r.value
+              }
+              .catchAll(_ => ZIO.succeed("default"))
+            rateLimitResult <- flags
+              .intDetails("recommendation_rate_limit", default = 10, userCtx)
+              .map { r =>
+                if (r.errorCode.contains(ErrorCode.FlagNotFound)) 10
+                else r.value
+              }
+              .catchAll(_ => ZIO.succeed(10))
+          } yield RecommendationResult(kind = variantResult, rateLimit = rateLimitResult)
+      }
+    } yield result
+}
+
+final case class RecommendationResult(kind: String, rateLimit: Int)

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/matrix/RecommendationServiceSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/matrix/RecommendationServiceSpec.scala
@@ -1,0 +1,154 @@
+package zio.openfeature.optimizely.matrix
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import zio._
+import zio.openfeature._
+import zio.openfeature.optimizely.{OptimizelyProvider, OptimizelyProviderConfig}
+import zio.test._
+
+/** Standalone ZIO test that exercises the RecommendationService against each datafile fixture without going through the
+  * zio-bdd harness.
+  */
+object RecommendationServiceSpec extends ZIOSpecDefault {
+
+  private val SdkKey       = "test-matrix-key"
+  private val DatafilePath = s"/datafiles/$SdkKey.json"
+
+  private def loadDatafile(name: String): String = {
+    val path = s"/datafiles/$name.json"
+    val is   = getClass.getResourceAsStream(path)
+    require(is != null, s"Datafile not found: $path")
+    scala.io.Source.fromInputStream(is).mkString
+  }
+
+  private def withProvider[A](
+    datafileName: String
+  )(body: RecommendationService => ZIO[Any, Throwable, A]): ZIO[Any, Throwable, A] =
+    ZIO.scoped {
+      for {
+        server <- ZIO.acquireRelease(ZIO.succeed {
+          val s = new WireMockServer(WireMockConfiguration.options().dynamicPort())
+          s.start()
+          s.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(loadDatafile(datafileName))))
+          s
+        })(s => ZIO.succeed(s.stop()))
+        dataUrl = s"http://localhost:${server.port()}$DatafilePath"
+        config = OptimizelyProviderConfig(
+          sdkKey = SdkKey,
+          datafileUrl = Some(dataUrl),
+          initWait = java.time.Duration.ofSeconds(5),
+          pollingInterval = Some(java.time.Duration.ofSeconds(3600)),
+          blockingTimeout = Some(java.time.Duration.ofSeconds(2))
+        )
+        provider <- OptimizelyProvider.scoped(config).mapError(e => new RuntimeException(e.message))
+        // Use fromProvider (synchronous init) so the provider is READY before the first evaluation.
+        env <- FeatureFlags.fromProvider(provider).build
+        ff  = env.get[FeatureFlags]
+        svc = new RecommendationService(ff)
+        result <- body(svc)
+      } yield result
+    }
+
+  def spec = suite("RecommendationService")(
+    suite("basic flag matrix")(
+      test("empty datafile → default") {
+        withProvider("empty") { svc =>
+          svc.recommend.map(kind => assertTrue(kind == "default"))
+        }
+      },
+      test("kill-switch-off → alpha") {
+        withProvider("kill-switch-off") { svc =>
+          svc.recommend.map(kind => assertTrue(kind == "alpha"))
+        }
+      },
+      test("kill-switch-on → degraded") {
+        withProvider("kill-switch-on") { svc =>
+          svc.recommend.map(kind => assertTrue(kind == "degraded"))
+        }
+      },
+      test("variant-beta → beta") {
+        withProvider("variant-beta") { svc =>
+          svc.recommend.map(kind => assertTrue(kind == "beta"))
+        }
+      }
+    ),
+
+    // -----------------------------------------------------------------------
+    // Complex matrix: audience-gated integer variable + multi-flag interaction
+    //
+    // The "audience-premium" datafile enables three flags:
+    //   • recommendation_kill_switch  — on for all users (100% rollout, no audience)
+    //   • recommendation_variant      — "alpha" for all users (100% rollout, no audience)
+    //   • recommendation_rate_limit   — integer variable "value":
+    //       100  when user attribute `plan = "premium"` (audience rule fires)
+    //        10  for everyone else (audience does not match → FlagNotFound path → default)
+    //
+    // This demonstrates:
+    //   1. Per-user context carrying arbitrary attributes
+    //   2. Audience-targeted integer variable evaluation
+    //   3. Graceful default when audience rule does not match
+    //   4. Parallel evaluation of independent flags (kind + rateLimit read concurrently)
+    //   5. Kill-switch interaction with the richer RecommendationResult return type
+    // -----------------------------------------------------------------------
+    suite("audience-gated rate-limit variable")(
+      test("premium user gets elevated rate limit") {
+        val premiumCtx = EvaluationContext("user-premium")
+          .withAttribute("plan", AttributeValue.StringValue("premium"))
+        withProvider("audience-premium") { svc =>
+          svc.recommendWithContext(premiumCtx).map { result =>
+            assertTrue(result.kind == "alpha") &&
+            assertTrue(result.rateLimit == 100)
+          }
+        }
+      },
+      test("standard user gets conservative rate limit") {
+        val standardCtx = EvaluationContext("user-standard")
+          .withAttribute("plan", AttributeValue.StringValue("standard"))
+        withProvider("audience-premium") { svc =>
+          svc.recommendWithContext(standardCtx).map { result =>
+            assertTrue(result.kind == "alpha") &&
+            assertTrue(result.rateLimit == 10)
+          }
+        }
+      },
+      test("unauthenticated user (no attributes) gets conservative rate limit") {
+        val anonCtx = EvaluationContext("user-anon")
+        withProvider("audience-premium") { svc =>
+          svc.recommendWithContext(anonCtx).map { result =>
+            assertTrue(result.kind == "alpha") &&
+            assertTrue(result.rateLimit == 10)
+          }
+        }
+      },
+      test("kill-switch overrides rate limit — degraded result has rateLimit = 0") {
+        // kill-switch-on datafile: kill switch fires (enabled=false), variant and rate-limit
+        // are never consulted — result is degraded with rateLimit=0 regardless of plan attribute.
+        val premiumCtx = EvaluationContext("user-premium")
+          .withAttribute("plan", AttributeValue.StringValue("premium"))
+        withProvider("kill-switch-on") { svc =>
+          svc.recommendWithContext(premiumCtx).map { result =>
+            assertTrue(result.kind == "degraded") &&
+            assertTrue(result.rateLimit == 0)
+          }
+        }
+      },
+      test("multiple users evaluated against the same provider instance are independent") {
+        // Ensures no shared mutable state bleeds across EvaluationContext calls on one provider.
+        val premiumCtx  = EvaluationContext("user-p").withAttribute("plan", AttributeValue.StringValue("premium"))
+        val standardCtx = EvaluationContext("user-s").withAttribute("plan", AttributeValue.StringValue("standard"))
+        withProvider("audience-premium") { svc =>
+          for {
+            results <- svc
+              .recommendWithContext(premiumCtx)
+              .zipPar(svc.recommendWithContext(standardCtx))
+            (premiumResult, standardResult) = results
+          } yield assertTrue(premiumResult.rateLimit == 100) &&
+            assertTrue(standardResult.rateLimit == 10) &&
+            assertTrue(premiumResult.kind == standardResult.kind)
+        }
+      }
+    )
+  ) @@ TestAspect.sequential @@ TestAspect.timeout(60.seconds) @@ TestAspect.withLiveClock
+}


### PR DESCRIPTION
## Summary
- Adds plain zio-test coverage (`RecommendationServiceSpec`) to the `optimizely` module: a toy recommendation service exercised against fresh WireMock-served datafiles per scenario (kill-switch, variant, audience-gated rate-limit variable).
- Adds an equivalent zio-bdd scenario suite (`FlagMatrixSpec` + `flag_matrix.feature`) to `conformance-zio-bdd`, using `@flags(datafile=X)` scenario expansion — each run gets its own isolated WireMock server + Optimizely provider, no stub-swap or polling wait.
- `conformance-zio-bdd` now depends on `optimizely % "test->test;compile->compile"` so the BDD suite reuses `RecommendationService` from `optimizely`'s test sources instead of duplicating it.

## Test plan
- [x] `sbt scalafmtCheckAll`
- [x] `sbt optimizely/test` (both Scala 2.13 and 3 cross-builds)
- [x] `sbt conformanceZioBdd/test`