### PR TITLE
Document the Optimizely flag-matrix test pattern

### DIFF
--- a/docs/optimizely.md
+++ b/docs/optimizely.md
@@ -197,7 +197,9 @@ val provider = Unsafe.unsafe { implicit u =>
 When you want to verify application behavior (not just provider wiring) across several rollout configurations — kill-switch on/off, a string variant changing, an audience rule gating a variable — the library's own test suites give two worked examples of doing that without hand-rolling stub-swap logic:
 
 - **`RecommendationServiceSpec`** (`optimizely/src/test/scala/.../matrix/`) is plain `zio-test`. Each `test(...)` block spins up its own `WireMockServer` stubbing the Optimizely CDN endpoint with a named datafile fixture (`optimizely/src/test/resources/datafiles/*.json`), builds a real `OptimizelyProvider` against it, and asserts on a toy `RecommendationService` reading multiple flags.
-- **`FlagMatrixSpec`** (`conformance-zio-bdd/src/test/scala/.../matrix/`) does the same thing as a `zio-bdd` Gherkin suite. Scenarios are tagged with `@flags(datafile=<name>)`, and `flagLayer` (a zio-bdd hook called once per `@flags(...)` tag occurrence) maps that tag to a datafile via `MatrixHarness.layerForDatafile`:
+- **`FlagMatrixSpec`** (`conformance-zio-bdd/src/test/scala/.../matrix/`) does the same thing as a `zio-bdd` Gherkin suite, tagging scenarios with `@flags(datafile=<name>)`. See [Testkit → Behavior-Matrix Testing with zio-bdd]({{ site.baseurl }}/testkit) for how the `@flags(...)` tag / `flagLayer` mechanism works in general — this section covers only what's Optimizely-specific.
+
+The Optimizely-specific piece is `MatrixHarness.layerForDatafile`, the `flagLayer` implementation used by `FlagMatrixSpec`:
 
 ```scala
 override def flagLayer(meta: ScenarioMetadata, flags: Map[String, String]): ZLayer[Any, Throwable, FeatureFlags] = {
@@ -206,7 +208,7 @@ override def flagLayer(meta: ScenarioMetadata, flags: Map[String, String]): ZLay
 }
 ```
 
-`MatrixHarness.layerForDatafile` builds a fresh `WireMockServer` + `OptimizelyProvider` per call, scoped so both are torn down when the scenario ends — no stub-swap between scenarios, no polling wait, and `scenarioParallelism > 1` is safe since nothing is shared. Each `@flags(...)` tag is its own isolated run:
+It builds a fresh `WireMockServer` + `OptimizelyProvider` per call, scoped so both are torn down when the scenario ends — no stub-swap between scenarios, no polling wait, and `scenarioParallelism > 1` is safe since nothing is shared:
 
 ```gherkin
 @flags(datafile=kill-switch-off)
@@ -220,7 +222,7 @@ Scenario: Datafile and plan overrides combined in a single @flags tag
   And the rate limit is 100
 ```
 
-A single tag with comma-separated keys (`@flags(datafile=X, plan=Y)`) expands to **one** run with both overrides applied together — `plan` is seeded via `FeatureFlags.setGlobalContext` before the scenario starts, relying on the spec's automatic global-context merge rather than a "with plan" step. Stacking two separate tags on one scenario (`@flags(datafile=X)` / `@flags(datafile=Y)` on consecutive lines) instead produces **two** independent runs, each with its own isolated provider — see `flag_matrix.feature` for the full set of scenarios this pattern covers.
+`plan` is seeded via `FeatureFlags.setGlobalContext` before the scenario starts, relying on the spec's automatic global-context merge rather than a "with plan" step. See `flag_matrix.feature` for the full set of scenarios this pattern covers.
 
 ---
 

--- a/docs/optimizely.md
+++ b/docs/optimizely.md
@@ -150,7 +150,7 @@ The breaker counts *infrastructure* errors (timeouts, connection failures, `Gene
 
 ## 6. Testing your app
 
-Two patterns, both supported:
+Three patterns, all supported:
 
 ### Unit-testing application code without touching Optimizely
 
@@ -191,6 +191,36 @@ val provider = Unsafe.unsafe { implicit u =>
   Runtime.default.unsafe.run(OptimizelyProvider.fromOptimizelyClient(opt)).getOrThrow()
 }
 ```
+
+### Running the same SUT against a matrix of datafiles
+
+When you want to verify application behavior (not just provider wiring) across several rollout configurations — kill-switch on/off, a string variant changing, an audience rule gating a variable — the library's own test suites give two worked examples of doing that without hand-rolling stub-swap logic:
+
+- **`RecommendationServiceSpec`** (`optimizely/src/test/scala/.../matrix/`) is plain `zio-test`. Each `test(...)` block spins up its own `WireMockServer` stubbing the Optimizely CDN endpoint with a named datafile fixture (`optimizely/src/test/resources/datafiles/*.json`), builds a real `OptimizelyProvider` against it, and asserts on a toy `RecommendationService` reading multiple flags.
+- **`FlagMatrixSpec`** (`conformance-zio-bdd/src/test/scala/.../matrix/`) does the same thing as a `zio-bdd` Gherkin suite. Scenarios are tagged with `@flags(datafile=<name>)`, and `flagLayer` (a zio-bdd hook called once per `@flags(...)` tag occurrence) maps that tag to a datafile via `MatrixHarness.layerForDatafile`:
+
+```scala
+override def flagLayer(meta: ScenarioMetadata, flags: Map[String, String]): ZLayer[Any, Throwable, FeatureFlags] = {
+  val datafile = flags.getOrElse("datafile", "empty")
+  MatrixHarness.layerForDatafile(datafile, plan = flags.get("plan"))
+}
+```
+
+`MatrixHarness.layerForDatafile` builds a fresh `WireMockServer` + `OptimizelyProvider` per call, scoped so both are torn down when the scenario ends — no stub-swap between scenarios, no polling wait, and `scenarioParallelism > 1` is safe since nothing is shared. Each `@flags(...)` tag is its own isolated run:
+
+```gherkin
+@flags(datafile=kill-switch-off)
+Scenario: Kill-switch is off and variant is alpha — full recommendation
+  Then the recommendation service returns kind "alpha"
+
+@flags(datafile=audience-premium, plan=premium)
+Scenario: Datafile and plan overrides combined in a single @flags tag
+  When a recommendation is requested
+  Then the recommendation kind is "alpha"
+  And the rate limit is 100
+```
+
+A single tag with comma-separated keys (`@flags(datafile=X, plan=Y)`) expands to **one** run with both overrides applied together — `plan` is seeded via `FeatureFlags.setGlobalContext` before the scenario starts, relying on the spec's automatic global-context merge rather than a "with plan" step. Stacking two separate tags on one scenario (`@flags(datafile=X)` / `@flags(datafile=Y)` on consecutive lines) instead produces **two** independent runs, each with its own isolated provider — see `flag_matrix.feature` for the full set of scenarios this pattern covers.
 
 ---
 

--- a/docs/testkit.md
+++ b/docs/testkit.md
@@ -490,6 +490,52 @@ test("tracks evaluations") {
 
 ---
 
+## Behavior-Matrix Testing with zio-bdd
+
+This pattern works with any `FeatureFlags` layer — `TestFeatureProvider`, `OptimizelyProvider`, OFREP, or your own provider. It's a feature of the [`zio-bdd`](https://github.com/EtaCassiopeia/zio-bdd) test framework's layer-injection hooks, not something specific to this testkit module, so it's documented here rather than on a provider-specific page.
+
+### The layer-injection hook tiers
+
+A `zio-bdd` suite (`object MySpec extends ZIOSteps[R, S]`) builds its environment through four overridable hooks, each one tier more specific than the last. Override exactly one — the others delegate down to it by default:
+
+| Hook | Called | Default |
+|:-----|:-------|:--------|
+| `applicationLayer` | Once per test run | — |
+| `featureLayer(meta)` | Once per `.feature` file | delegates to `applicationLayer` |
+| `scenarioLayer(meta)` | Once per scenario | delegates to `featureLayer` |
+| `flagLayer(meta, flags)` | Once per `@flags(...)` tag occurrence on a scenario | delegates to `scenarioLayer` |
+
+```scala
+override def scenarioLayer(meta: ScenarioMetadata): ZLayer[Any, Throwable, R] =
+  if (meta.tags.contains("use-mock")) mockHttpLayer else realHttpLayer
+```
+
+### `@flags(...)` tags
+
+`flagLayer` is the hook to override when a scenario needs different flag values per run. Tag a scenario with `@flags(key=value, ...)`, and the framework parses the tag into a `Map[String, String]` before calling `flagLayer(meta, flags)`:
+
+```scala
+override def flagLayer(meta: ScenarioMetadata, flags: Map[String, String]): ZLayer[Any, Throwable, FeatureFlags] =
+  environment >>> FlagConfig.layer(flags)
+```
+
+Two things to know about how tags expand into runs:
+
+- **One tag, multiple keys → one run.** `@flags(datafile=X, plan=Y)` parses to a single `Map("datafile" -> "X", "plan" -> "Y")` and calls `flagLayer` once, with both keys present together.
+- **Multiple tags → multiple runs.** Two separate tag occurrences on the same scenario — written on consecutive lines:
+  ```gherkin
+  @flags(datafile=X)
+  @flags(datafile=Y)
+  Scenario: ...
+  ```
+  expand into two independent runs, each calling `flagLayer` once with only that tag's own map (not merged) — the scenario body executes twice, against two separately-built environments.
+
+A blank line between or around `@flags(...)` tags is fine. A blank line inside the free-text description directly under `Feature:` is not — it silently drops the whole feature instead of raising a parse error; see [zio-bdd#87](https://github.com/EtaCassiopeia/zio-bdd/issues/87).
+
+See [Optimizely → Testing your app]({{ site.baseurl }}/optimizely) for a worked example applying this to a real provider, with datafile fixtures driving the `@flags(datafile=...)` values.
+
+---
+
 ## Best Practices
 
 ### 1. Use Descriptive Flag Names


### PR DESCRIPTION
## Summary
- Adds a "Running the same SUT against a matrix of datafiles" subsection to docs/optimizely.md, documenting RecommendationServiceSpec (optimizely) and FlagMatrixSpec (conformance-zio-bdd), added in #234.
- Covers the WireMock-per-call isolation in MatrixHarness, and the two @flags(...) tag shapes: combined keys in one tag vs. stacked tags producing independent runs.

## Test plan
- [x] Docs-only change; no code/build impact.