### PR TITLE
Isolate flag-matrix tests on named OpenFeature domains

### DIFF
--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/FlagMatrixSpec.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/FlagMatrixSpec.scala
@@ -31,7 +31,7 @@ import zio.openfeature.optimizely.matrix.{RecommendationResult, RecommendationSe
   featureDirs         = Array("conformance-zio-bdd/src/test/resources/features/optimizely"),
   reporters           = Array("pretty"),
   parallelism         = 1,
-  scenarioParallelism = 1,
+  scenarioParallelism = 8,
   logLevel            = "warning"
 )
 object FlagMatrixSpec extends ZIOSteps[FeatureFlags, World] {

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/MatrixHarness.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/MatrixHarness.scala
@@ -36,6 +36,16 @@ object MatrixHarness {
 
   /** A scoped ZLayer that owns one WireMock server + one Optimizely provider for the named datafile.
     *
+    * Bound to a freshly-generated domain (`FeatureFlags.fromProviderWithDomain`) rather than the plain
+    * `fromProvider` factory. `fromProvider` registers its provider as the *unnamed default* client on
+    * the process-wide `OpenFeatureAPI` singleton — concurrent calls from different scenarios would race
+    * to overwrite that single default slot, and since the OpenFeature SDK looks up the active provider
+    * dynamically on every evaluation (not a frozen reference), one scenario's in-flight evaluations could
+    * start hitting another scenario's datafile mid-run. A named domain gets its own slot on that same
+    * singleton, so concurrently-running scenarios (`scenarioParallelism > 1`) can never collide — this is
+    * the same isolation technique `ConformanceSpec` uses, expressed with the public API so it also works
+    * outside this package.
+    *
     * `plan`, when present, is seeded as a global-context attribute (via `setGlobalContext`) before the
     * layer is handed to the scenario. The OpenFeature spec merges global context into every invocation
     * automatically (API -> Transaction -> Client -> Invocation), so a single `@flags(datafile=X, plan=Y)`
@@ -62,7 +72,8 @@ object MatrixHarness {
                      blockingTimeout = Some(java.time.Duration.ofSeconds(2))
                    )
         provider <- OptimizelyProvider.scoped(config).mapError(e => RuntimeException(e.message))
-        env      <- FeatureFlags.fromProvider(provider).build
+        domain    = s"flag-matrix-${java.util.UUID.randomUUID()}"
+        env      <- FeatureFlags.fromProviderWithDomain(provider, domain).build
         ff        = env.get[FeatureFlags]
         _        <- ZIO.foreachDiscard(plan)(p => ff.setGlobalContext(EvaluationContext.empty.withAttribute("plan", AttributeValue.StringValue(p))))
       } yield ff

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/matrix/RecommendationServiceSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/matrix/RecommendationServiceSpec.scala
@@ -43,8 +43,11 @@ object RecommendationServiceSpec extends ZIOSpecDefault {
           blockingTimeout = Some(java.time.Duration.ofSeconds(2))
         )
         provider <- OptimizelyProvider.scoped(config).mapError(e => new RuntimeException(e.message))
-        // Use fromProvider (synchronous init) so the provider is READY before the first evaluation.
-        env <- FeatureFlags.fromProvider(provider).build
+        // fromProviderWithDomain (not the plain fromProvider) so each call gets its own named slot on
+        // the global OpenFeatureAPI singleton instead of overwriting the shared unnamed default client —
+        // fromProvider would let concurrently-running tests race to swap each other's active provider.
+        domain = s"flag-matrix-${java.util.UUID.randomUUID()}"
+        env <- FeatureFlags.fromProviderWithDomain(provider, domain).build
         ff  = env.get[FeatureFlags]
         svc = new RecommendationService(ff)
         result <- body(svc)


### PR DESCRIPTION
## Summary
- `MatrixHarness` and `RecommendationServiceSpec` built `FeatureFlags` via `fromProvider`, which sets the provider on the global `OpenFeatureAPI` singleton's *unnamed default* slot. Since the OpenFeature SDK resolves the active provider dynamically at evaluation time, concurrently running scenarios sharing that slot could overwrite each other's provider mid-evaluation.
- Switch both to `fromProviderWithDomain(provider, domain)` with a fresh UUID per call, giving each scenario its own isolated slot.
- Raise `FlagMatrixSpec`'s `scenarioParallelism` from 1 to 8 to actually exercise concurrent scenarios and confirm the fix holds.

## Test plan
- [x] `sbt conformanceZioBdd/test` — `FlagMatrixSpec` 10/10
- [x] `sbt optimizely/test` — `RecommendationServiceSpec` 9/9
- [x] `ConformanceSpec` 111/111 unaffected
- [x] `sbt scalafmtCheckAll`