### PR TITLE
Fix Optimizely construction race; add mitmproxy flag-matrix example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -224,7 +224,10 @@ lazy val conformanceZioBdd = (project in file("conformance-zio-bdd"))
       "io.github.etacassiopeia" %% "zio-bdd"               % "1.0.0"               % Test,
       "dev.zio"                 %% "zio-schema"            % "1.6.6"               % Test,
       "dev.zio"                 %% "zio-schema-derivation" % "1.6.6"               % Test,
-      "org.wiremock"             % "wiremock"              % "3.10.0"              % Test
+      "org.wiremock"             % "wiremock"              % "3.10.0"              % Test,
+      // Generic Docker container support, used to run mitmproxy as a forward proxy in front of
+      // WireMock for the proxy-based flag-matrix example (see ProxyFlagMatrixSpec).
+      "org.testcontainers"       % "testcontainers"        % "1.21.4"              % Test
     ),
     Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
   )

--- a/conformance-zio-bdd/src/test/resources/features/optimizely/proxy/proxy_flag_matrix.feature
+++ b/conformance-zio-bdd/src/test/resources/features/optimizely/proxy/proxy_flag_matrix.feature
@@ -1,0 +1,45 @@
+Feature: Optimizely flag matrix over a simulated CDN proxy
+
+  # Every scenario below fetches the SAME "audience-segments" datafile from the SAME
+  # simulated CDN endpoint (one shared WireMock instance, fronted by a mitmproxy container
+  # that intercepts the OptimizelyProvider's request and redirects it to WireMock — see
+  # ProxyMatrixHarness). scenarioParallelism=8 on this suite means these scenarios really do
+  # run concurrently against that one shared pair, each with its own provider instance and
+  # OpenFeature domain so they can't see each other's evaluation context.
+  #
+  # recommendation_rate_limit in that datafile is gated on an audience requiring BOTH
+  # plan = "premium" AND region = "eu" together — so a single @flags(...) tag carrying both
+  # keys is what actually changes the result, not a provider/datafile swap.
+
+  @flags(plan=premium, region=eu)
+  Scenario: Both audience attributes match — elevated rate limit
+    When a recommendation is requested
+    Then the recommendation kind is "alpha"
+    And the rate limit is 250
+
+  @flags(plan=premium, region=us)
+  Scenario: Plan matches but region doesn't — falls through to conservative default
+    When a recommendation is requested
+    Then the recommendation kind is "alpha"
+    And the rate limit is 10
+
+  @flags(plan=standard, region=eu)
+  Scenario: Region matches but plan doesn't — falls through to conservative default
+    When a recommendation is requested
+    Then the recommendation kind is "alpha"
+    And the rate limit is 10
+
+  @flags(plan=standard, region=us)
+  Scenario: Neither attribute matches — conservative default
+    When a recommendation is requested
+    Then the recommendation kind is "alpha"
+    And the rate limit is 10
+
+  # Stacking two @flags tags on one scenario: two independent runs, each with its own provider
+  # and context, against the same shared CDN/proxy/WireMock pair — one run lands in the
+  # audience, the other doesn't.
+  @flags(plan=premium, region=eu)
+  @flags(plan=premium, region=us)
+  Scenario: Stacked tags run this scenario twice, once per tag, against the same shared CDN
+    When a recommendation is requested
+    Then the recommendation kind is "alpha"

--- a/conformance-zio-bdd/src/test/resources/mitmproxy/redirect_to_wiremock.py
+++ b/conformance-zio-bdd/src/test/resources/mitmproxy/redirect_to_wiremock.py
@@ -1,0 +1,28 @@
+"""mitmdump addon used by ProxyFlagMatrixSpec.
+
+Acts as the forward HTTP proxy the test JVM is pointed at (via http.proxyHost/
+http.proxyPort). Any request whose Host matches MATCH_HOST -- the fake,
+RFC 2606 .invalid CDN host the test's OptimizelyProvider is configured with --
+is rewritten in-flight to TARGET_HOST:TARGET_PORT (WireMock, reachable from
+inside the container via Testcontainers' host.testcontainers.internal alias)
+before mitmproxy opens the upstream connection. Every other request passes
+through untouched.
+"""
+
+import os
+
+MATCH_HOST = os.environ.get("MATCH_HOST", "cdn.optimizely.invalid")
+TARGET_HOST = os.environ["TARGET_HOST"]
+TARGET_PORT = int(os.environ["TARGET_PORT"])
+
+
+class RedirectToWiremock:
+    def request(self, flow):
+        if flow.request.pretty_host != MATCH_HOST:
+            return
+        flow.request.host = TARGET_HOST
+        flow.request.port = TARGET_PORT
+        flow.request.headers["Host"] = f"{TARGET_HOST}:{TARGET_PORT}"
+
+
+addons = [RedirectToWiremock()]

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/ProxyFlagMatrixSpec.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/ProxyFlagMatrixSpec.scala
@@ -1,0 +1,65 @@
+package zio.openfeature.conformance.bdd.matrix
+
+import zio._
+import zio.bdd.core.Suite
+import zio.bdd.core.Assertions.assertTrue
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.gherkin.ScenarioMetadata
+import zio.openfeature._
+import zio.openfeature.optimizely.matrix.{RecommendationResult, RecommendationService}
+
+/** Flag-matrix BDD suite where every scenario fetches the *same* datafile from the *same* simulated CDN endpoint,
+  * concurrently, and differs only by evaluation context.
+  *
+  * Contrast with [[FlagMatrixSpec]]: there, `@flags(datafile=X)` selects *which fixture* a scenario's own dedicated
+  * WireMock server serves. Here there is no `datafile` key at all — every `@flags(...)` tag is a set of
+  * evaluation-context attributes (e.g. `plan`, `region`), and all scenarios' providers point at one shared WireMock
+  * instance fronted by a mitmproxy container (see [[ProxyMatrixHarness]]). `recommendation_rate_limit` in the
+  * `audience-segments` datafile is gated on *both* attributes together (`plan = "premium" AND region = "eu"`), so a
+  * single tag carrying both keys is what actually changes the flag's resolved value — not a provider swap.
+  */
+@Suite(
+  featureDirs = Array("conformance-zio-bdd/src/test/resources/features/optimizely/proxy"),
+  reporters = Array("pretty"),
+  parallelism = 1,
+  scenarioParallelism = 8,
+  logLevel = "warning"
+)
+object ProxyFlagMatrixSpec extends ZIOSteps[FeatureFlags, World] {
+
+  /** Every key in a `@flags(...)` tag becomes a global evaluation-context attribute — there's no `datafile` key to
+    * special-case here, unlike [[FlagMatrixSpec]].
+    */
+  override def flagLayer(meta: ScenarioMetadata, flags: Map[String, String]): ZLayer[Any, Throwable, FeatureFlags] =
+    ProxyMatrixHarness.layerForSharedCdn(flags)
+
+  // ── Assertions (mirrors FlagMatrixSpec's; separate suite object, separate step registry) ──
+
+  Then("the recommendation kind is " / string) { (expected: String) =>
+    for {
+      world <- ScenarioContext.get
+      result = world.lastResult.getOrElse(RecommendationResult("__none__", -1))
+      _ <- assertTrue(result.kind == expected, s"kind '${result.kind}' != '$expected'")
+    } yield ()
+  }
+
+  And("the rate limit is " / int) { (expected: Int) =>
+    for {
+      world <- ScenarioContext.get
+      result = world.lastResult.getOrElse(RecommendationResult("__none__", -1))
+      _ <- assertTrue(result.rateLimit == expected, s"rateLimit ${result.rateLimit} != $expected")
+    } yield ()
+  }
+
+  // ── Request step — entirely tag-driven, no plan/region wording in step text ──
+
+  When("a recommendation is requested") {
+    ZIO.serviceWithZIO[FeatureFlags] { ff =>
+      val svc = new RecommendationService(ff)
+      for {
+        result <- svc.recommendWithContext(EvaluationContext("proxy-matrix-user"))
+        _      <- ScenarioContext.update(_.copy(lastResult = Some(result)))
+      } yield ()
+    }
+  }
+}

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/ProxyMatrixHarness.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/ProxyMatrixHarness.scala
@@ -1,0 +1,122 @@
+package zio.openfeature.conformance.bdd.matrix
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import org.testcontainers.Testcontainers
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.MountableFile
+import zio._
+import zio.openfeature._
+import zio.openfeature.optimizely.{OptimizelyProvider, OptimizelyProviderConfig}
+
+/** Builds per-scenario `FeatureFlags` layers that all fetch the *same* datafile from the *same* simulated CDN endpoint,
+  * concurrently, via a shared mitmproxy + WireMock pair started once for the whole suite.
+  *
+  * This is a different isolation shape than [[MatrixHarness]]: there, every scenario gets its own WireMock server
+  * (different port, often a different datafile) — providers never actually contend for the same backing service. Here,
+  * every scenario's `OptimizelyProvider` is configured with the identical CDN-shaped `datafileUrl`
+  * (`http://$MatchHost$DatafilePath`); what makes concurrent scenarios resolve different flag values isn't a different
+  * datafile, it's a different evaluation context (set as that scenario's global context from its `@flags(...)` tag).
+  *
+  * The CDN hop itself is simulated rather than stubbed directly: `OptimizelyProvider`'s HTTP client is configured (via
+  * standard `http.proxyHost`/`http.proxyPort` JVM properties, which the Optimizely SDK's default Apache HttpClient
+  * honors automatically) to route through a forward proxy — mitmproxy, run via Testcontainers — which detects the
+  * request's Host header and redirects it to the shared WireMock instance. So every scenario's provider really does
+  * "call the CDN"; mitmproxy is what's standing in for Optimizely's real edge network.
+  *
+  * Per-scenario isolation is still provider-level, not infra-level: each call to [[layerForSharedCdn]] builds a fresh
+  * `OptimizelyProvider` registered under its own freshly-generated domain (see [[MatrixHarness]]'s doc for why a named
+  * domain is required for `scenarioParallelism > 1` to be safe) — only the WireMock server and the mitmproxy container
+  * are shared.
+  */
+object ProxyMatrixHarness {
+
+  private val SdkKey       = "test-proxy-matrix-key"
+  private val MatchHost    = "cdn.optimizely.invalid"
+  private val DatafilePath = s"/datafiles/$SdkKey.json"
+  private val Datafile     = loadDatafile("audience-segments")
+
+  private def loadDatafile(name: String): String = {
+    val path = s"/datafiles/$name.json"
+    val is   = getClass.getResourceAsStream(path)
+    require(is != null, s"Datafile fixture not found on classpath: $path")
+    scala.io.Source.fromInputStream(is).mkString
+  }
+
+  // testcontainers' GenericContainer is F-bounded (`GenericContainer[SELF <: GenericContainer[SELF]]`);
+  // subclassing with the self type keeps its fluent `withX` builder methods chainable from Scala.
+  final private class MitmProxyContainer(image: String) extends GenericContainer[MitmProxyContainer](image)
+
+  /** Starts the shared WireMock server + mitmproxy container on first access and sets the JVM-wide
+    * `http.proxyHost`/`http.proxyPort` properties so every `OptimizelyProvider` built afterward in this JVM routes
+    * through it. `lazy val` makes this both once-only and safe under concurrent scenarios (the JVM spec guarantees at
+    * most one thread runs the initializer). Deliberately never torn down explicitly — Testcontainers' own Ryuk reaper
+    * removes the container, and the WireMock server is a plain daemon-backed Jetty instance, when the test JVM exits.
+    */
+  private lazy val sharedInfra: Unit = {
+    // zio-bdd's test framework runs scenario fibers on its own thread pool, whose threads' context
+    // classloader doesn't have visibility into this jar's META-INF/services entries the way sbt's
+    // own test-running thread does — testcontainers' `DockerClientProviderStrategy` lookup is a plain
+    // `ServiceLoader.load(...)` against the *current thread's* context classloader, so without this it
+    // silently finds zero strategies and fails with "Could not find a valid Docker environment."
+    Thread.currentThread().setContextClassLoader(getClass.getClassLoader)
+
+    val wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort())
+    wireMock.start()
+    wireMock.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(Datafile)))
+
+    Testcontainers.exposeHostPorts(wireMock.port())
+
+    val proxy = new MitmProxyContainer("mitmproxy/mitmproxy:11.1.3")
+      .withExposedPorts(8080)
+      .withCopyFileToContainer(
+        MountableFile.forClasspathResource("mitmproxy/redirect_to_wiremock.py"),
+        "/addons/redirect_to_wiremock.py"
+      )
+      .withEnv("MATCH_HOST", MatchHost)
+      .withEnv("TARGET_HOST", "host.testcontainers.internal")
+      .withEnv("TARGET_PORT", wireMock.port().toString)
+      .withCommand("mitmdump", "--listen-port", "8080", "-s", "/addons/redirect_to_wiremock.py")
+      .waitingFor(Wait.forListeningPort())
+    proxy.start()
+
+    java.lang.System.setProperty("http.proxyHost", proxy.getHost)
+    java.lang.System.setProperty("http.proxyPort", proxy.getMappedPort(8080).toString)
+    java.lang.System.setProperty("http.nonProxyHosts", "")
+  }
+
+  /** A scoped `FeatureFlags` layer backed by a fresh provider pointed at the shared simulated CDN.
+    *
+    * `contextAttributes` becomes that scenario's *global* evaluation context — `setGlobalContext` replaces rather than
+    * merges, so every attribute from the tag is folded into one context and set in a single call, rather than one call
+    * per key (which would have each call silently discard the previous attribute).
+    */
+  def layerForSharedCdn(contextAttributes: Map[String, String]): ZLayer[Any, Throwable, FeatureFlags] =
+    ZLayer.scoped {
+      for {
+        // `sharedInfra` is a JVM `lazy val`, which compiles to a `synchronized` block: the first fiber to
+        // force it blocks its underlying OS thread for as long as the container takes to start. Under
+        // `scenarioParallelism > 1`, every scenario's fiber forces it near-simultaneously — `attemptBlocking`
+        // routes that onto ZIO's dedicated blocking thread pool so it can't starve the (much smaller) compute
+        // pool the rest of the runtime depends on.
+        _ <- ZIO.attemptBlocking(sharedInfra)
+        config = OptimizelyProviderConfig(
+          sdkKey = SdkKey,
+          datafileUrl = Some(s"http://$MatchHost$DatafilePath"),
+          initWait = java.time.Duration.ofSeconds(10),
+          pollingInterval = Some(java.time.Duration.ofSeconds(3600)), // no polling in tests
+          blockingTimeout = Some(java.time.Duration.ofSeconds(5))
+        )
+        provider <- OptimizelyProvider.scoped(config).mapError(e => RuntimeException(e.message))
+        domain = s"proxy-flag-matrix-${java.util.UUID.randomUUID()}"
+        env <- FeatureFlags.fromProviderWithDomain(provider, domain).build
+        ff = env.get[FeatureFlags]
+        ctx = contextAttributes.foldLeft(EvaluationContext.empty) { case (acc, (k, v)) =>
+          acc.withAttribute(k, AttributeValue.StringValue(v))
+        }
+        _ <- ff.setGlobalContext(ctx)
+      } yield ff
+    }
+}

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
@@ -115,8 +115,10 @@ final class OptimizelyFeatureProvider private[optimizely] (
     }
     notificationHandle.set(handlerId)
 
-    // Start datafile polling only now that the update handler is registered, so the first
-    // datafile-load notification cannot be missed. Construction performs no network activity.
+    // The handler is registered before this call so a notification firing from here on can't be missed. The SDK
+    // may already have a fetch in flight or completed from construction time (see OptimizelyProvider#buildClient),
+    // in which case this `start()` is just a no-op (idempotent) — the `optimizely.isValid` check right below is
+    // what catches that already-completed case.
     configManager.foreach(_.start())
 
     if (optimizely.isValid) initLatch.countDown()

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
@@ -231,14 +231,22 @@ object OptimizelyProvider {
       configBuilder.withBlockingTimeout(java.lang.Long.valueOf(d.toMillis), TimeUnit.MILLISECONDS)
     )
     httpClient.foreach(configBuilder.withOptimizelyHttpClient)
-    // `build()` (no-arg) would start polling AND block up to the SDK's blocking timeout (default 10s) waiting for
-    // the first datafile — with an unreachable CDN, construction stalls and then a background poller retries
-    // forever. `build(true)` skips the blocking wait but still calls `start()`, so we `stop()` immediately:
-    // construction performs no network activity, and `initialize()` starts polling once the update handler is in
-    // place. The first scheduled fetch may be submitted in the instant before `stop()` cancels it
-    // (`cancel(mayInterrupt = true)` on a daemon thread) — at most one aborted request, no lingering activity.
+    // `build()` (no-arg) would block construction up to the SDK's blocking timeout (default 10s) waiting for the
+    // first datafile — with an unreachable CDN, construction stalls. `build(true)` skips that blocking wait, but
+    // `HttpProjectConfigManager.Builder.build(boolean)` calls `start()` unconditionally either way (there's no
+    // public SDK API to construct without auto-starting), so the manager's first poll is already scheduled by the
+    // time this returns.
+    //
+    // We deliberately do NOT call `configManager.stop()` here to "undo" that: cancelling the scheduled fetch uses
+    // `cancel(mayInterrupt = true)`, and interrupting a thread blocked mid-socket-I/O on JDK 13+'s NioSocketImpl
+    // force-closes the channel — which can corrupt the shared `OptimizelyHttpClient`'s connection pool for the
+    // manager's entire remaining lifetime if the cancel lands while that first fetch is actually in flight (more
+    // likely the farther the datafile host is, e.g. behind a proxy). Letting the construction-time fetch run to
+    // completion is safe: `initialize()` registers the update-notification handler before calling
+    // `configManager.start()` itself, and `start()` is idempotent (a no-op if already started), so the first fetch
+    // either completes before `initialize()` runs — caught by `initialize()`'s `optimizely.isValid` fallback check
+    // — or is still in flight and finishes normally afterward. See #237.
     val configManager = configBuilder.build(true)
-    configManager.stop()
     val optimizely =
       Optimizely.builder().withConfigManager(configManager).withNotificationCenter(notificationCenter).build()
     (optimizely, configManager)

--- a/optimizely/src/test/resources/datafiles/audience-segments.json
+++ b/optimizely/src/test/resources/datafiles/audience-segments.json
@@ -1,0 +1,130 @@
+{
+  "version": "4",
+  "accountId": "test",
+  "projectId": "test",
+  "revision": "5",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "attributes": [
+    { "id": "600", "key": "plan" },
+    { "id": "601", "key": "region" }
+  ],
+  "audiences": [
+    {
+      "id": "700",
+      "name": "premium EU users",
+      "conditions": "[\"and\", {\"name\": \"plan\", \"match\": \"exact\", \"type\": \"custom_attribute\", \"value\": \"premium\"}, {\"name\": \"region\", \"match\": \"exact\", \"type\": \"custom_attribute\", \"value\": \"eu\"}]"
+    }
+  ],
+  "typedAudiences": [
+    {
+      "id": "700",
+      "name": "premium EU users",
+      "conditions": [
+        "and",
+        { "name": "plan", "match": "exact", "type": "custom_attribute", "value": "premium" },
+        { "name": "region", "match": "exact", "type": "custom_attribute", "value": "eu" }
+      ]
+    }
+  ],
+  "featureFlags": [
+    {
+      "id": "100",
+      "key": "recommendation_kill_switch",
+      "rolloutId": "200",
+      "experimentIds": [],
+      "variables": []
+    },
+    {
+      "id": "101",
+      "key": "recommendation_variant",
+      "rolloutId": "201",
+      "experimentIds": [],
+      "variables": [
+        { "id": "500", "key": "value", "type": "string", "defaultValue": "alpha" }
+      ]
+    },
+    {
+      "id": "102",
+      "key": "recommendation_rate_limit",
+      "rolloutId": "202",
+      "experimentIds": [],
+      "variables": [
+        { "id": "501", "key": "value", "type": "integer", "defaultValue": "10" }
+      ]
+    }
+  ],
+  "rollouts": [
+    {
+      "id": "200",
+      "experiments": [
+        {
+          "id": "300",
+          "key": "rollout-kill-switch-off-segments",
+          "status": "Running",
+          "layerId": "200",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "400", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "400",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "201",
+      "experiments": [
+        {
+          "id": "301",
+          "key": "rollout-variant-alpha-segments",
+          "status": "Running",
+          "layerId": "201",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "401", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "401",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [{ "id": "500", "value": "alpha" }]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "202",
+      "experiments": [
+        {
+          "id": "302",
+          "key": "rollout-rate-limit-premium-eu",
+          "status": "Running",
+          "layerId": "202",
+          "audienceIds": ["700"],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "402", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "402",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [{ "id": "501", "value": "250" }]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "groups": [],
+  "variables": [],
+  "events": []
+}


### PR DESCRIPTION
## Summary
- **Fixes #237**: `OptimizelyProvider.buildClient` cancelled its construction-time datafile fetch via `configManager.stop()` right after `build(true)`. The SDK's `stop()` uses `cancel(mayInterruptIfRunning = true)`; if that cancel landed while the fetch's socket I/O was actually in flight (more likely the farther/slower the datafile host), the interrupt could force-close the shared `OptimizelyHttpClient`'s connection pool for the rest of the provider's life, leaving it permanently `NOT_READY`. Localhost-only WireMock tests never hit the race window — a proxied CDN hop did. Fix: let the construction-time fetch run; `initialize()` already registers its notification handler before calling `start()` (idempotent) and falls back to an `optimizely.isValid` check, so nothing is missed.
- **New BDD example** (`ProxyFlagMatrixSpec` / `ProxyMatrixHarness`): a different isolation shape than the existing `FlagMatrixSpec` — instead of one WireMock server per scenario, every scenario's provider fetches the *same* datafile from the *same* simulated CDN endpoint concurrently, via one shared WireMock + mitmproxy pair (mitmproxy intercepts the request's Host header and redirects to WireMock). Flag values vary by evaluation context (multiple `@flags` variables combined via an AND-audience, plus stacked `@flags` tags), not by swapping the datafile.

## Test plan
- [x] `sbt optimizely/test` and `++2.13.16 optimizely/test` — 58/58 on both Scala versions
- [x] `sbt conformanceZioBdd/test conformance/test` — `FlagMatrixSpec`, `ProxyFlagMatrixSpec` (6/6), `ConformanceSpec` all green together
- [x] `ProxyFlagMatrixSpec` stable across repeated runs at `scenarioParallelism=8`
- [x] `sbt scalafmtCheckAll`
- [x] No CI changes needed — `conformanceZioBdd/test` already runs as its own CI job on `ubuntu-latest`, which has Docker available