### PR TITLE
Bump dev.openfeature:sdk to 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   package-private `EventProvider.attach` gained a required `AutoCloseableReentrantReadWriteLock` parameter — updated
   `EventProviderBridge` (used by `CachingProvider`/`CircuitBreakerProvider` to forward delegate events) to supply a
   private lock instance; the lock is only used to serialize `emit` against a real `OpenFeatureAPI`'s state, which our
-  unregistered delegates never touch.
+  unregistered delegates never touch. Separately, Lombok's generated builders moved to a SuperBuilder-style F-bounded
+  self-type, so `ProviderEvaluation.builder[T]().value(v).reason(r)` no longer resolves under Scala 2.13 ("value
+  reason is not a member of ?1") even though Scala 3 is unaffected — this only surfaced via the cross-build CI matrix,
+  not local `sbt test`. Added `zio.openfeature.internal.ProviderEvaluations` (call each builder setter on a stable
+  reference instead of chaining off the return value) and used it at the ~90 call sites across `core`, `extras`,
+  `optimizely`, and `testkit` that build a `ProviderEvaluation`.
 
 ## [1.0.0] — 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Bump `dev.openfeature:sdk` to 1.21.0** (#239). Per-provider error detail in multi-provider strategies and
+  isolated `OpenFeatureAPI` instance support now flow from the upstream fix with no further wrapper changes (our
+  event hub and `apiOverride` plumbing already isolated us from the bugs this release fixes). The SDK's
+  package-private `EventProvider.attach` gained a required `AutoCloseableReentrantReadWriteLock` parameter — updated
+  `EventProviderBridge` (used by `CachingProvider`/`CircuitBreakerProvider` to forward delegate events) to supply a
+  private lock instance; the lock is only used to serialize `emit` against a real `OpenFeatureAPI`'s state, which our
+  unregistered delegates never touch.
+
 ## [1.0.0] — 2026-06-17
 
 First stable release. **Upgrading from 0.9.x:** two behavior changes may require action —

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import net.nmoncho.sbt.dependencycheck.settings._
 val scala213Version       = "2.13.16"
 val scala3Version         = "3.3.4"
 val zioVersion            = "2.1.14"
-val openFeatureSdkVersion = "1.20.2"
+val openFeatureSdkVersion = "1.21.0"
 
 // OpenFeature Specification Compatibility
 // Spec version: v0.8.0 (https://github.com/open-feature/spec)

--- a/core/src/main/scala/zio/openfeature/internal/ProviderEvaluations.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ProviderEvaluations.scala
@@ -1,0 +1,35 @@
+package zio.openfeature.internal
+
+import dev.openfeature.sdk.ProviderEvaluation
+
+/** Builds [[ProviderEvaluation]] without fluently chaining off the Lombok-generated builder's self-type.
+  *
+  * Since SDK 1.21.0, `ProviderEvaluation.builder[T]()` returns `ProviderEvaluationBuilder[T, ?, ?]` (an F-bounded
+  * self-type for SuperBuilder-style subclassing). Scala 2.13 cannot resolve a second fluent call's member lookup
+  * against the captured existential (`scalac` reports "value reason is not a member of ?1"), even though Scala 3
+  * handles it fine. Calling each setter on the same stable `builder` reference — discarding its return value, since
+  * Lombok builders mutate in place and return `this` — sidesteps the existential chain entirely. Call sites with more
+  * setters (e.g. `flagMetadata`, `errorCode`) that don't fit these two common shapes use the same stable-reference
+  * pattern inline instead of a third helper overload.
+  */
+private[openfeature] object ProviderEvaluations {
+
+  def of[T](value: T, reason: String): ProviderEvaluation[T] = {
+    val builder = ProviderEvaluation.builder[T]()
+    builder.value(value)
+    builder.reason(reason)
+    // build() returns the existentially-captured C (bounded by ProviderEvaluation[T]); widen explicitly since
+    // that bound doesn't auto-widen across this method's declared return type.
+    builder.build().asInstanceOf[ProviderEvaluation[T]]
+  }
+
+  def of[T](value: T, variant: String, reason: String): ProviderEvaluation[T] = {
+    val builder = ProviderEvaluation.builder[T]()
+    builder.value(value)
+    builder.variant(variant)
+    builder.reason(reason)
+    // build() returns the existentially-captured C (bounded by ProviderEvaluation[T]); widen explicitly since
+    // that bound doesn't auto-widen across this method's declared return type.
+    builder.build().asInstanceOf[ProviderEvaluation[T]]
+  }
+}

--- a/core/src/test/scala/zio/openfeature/ApiHookIsolationSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ApiHookIsolationSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -27,35 +28,35 @@ object ApiHookIsolationSpec extends ZIOSpecDefault {
       defaultValue: java.lang.Boolean,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Boolean] =
-      ProviderEvaluation.builder[java.lang.Boolean]().value(value).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Boolean](value, "STATIC")
 
     override def getStringEvaluation(
       key: String,
       defaultValue: String,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[String] =
-      ProviderEvaluation.builder[String]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[String](defaultValue, "STATIC")
 
     override def getIntegerEvaluation(
       key: String,
       defaultValue: java.lang.Integer,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Integer] =
-      ProviderEvaluation.builder[java.lang.Integer]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Integer](defaultValue, "STATIC")
 
     override def getDoubleEvaluation(
       key: String,
       defaultValue: java.lang.Double,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Double] =
-      ProviderEvaluation.builder[java.lang.Double]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Double](defaultValue, "STATIC")
 
     override def getObjectEvaluation(
       key: String,
       defaultValue: dev.openfeature.sdk.Value,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[dev.openfeature.sdk.Value] =
-      ProviderEvaluation.builder[dev.openfeature.sdk.Value]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[dev.openfeature.sdk.Value](defaultValue, "STATIC")
   }
 
   // Counts before-hook invocations from the Java SDK thread.

--- a/core/src/test/scala/zio/openfeature/BoundedLatencyContractSpec.scala
+++ b/core/src/test/scala/zio/openfeature/BoundedLatencyContractSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -36,23 +37,23 @@ object BoundedLatencyContractSpec extends ZIOSpecDefault {
       c: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Boolean] = {
       Thread.sleep(delayMillis)
-      ProviderEvaluation.builder[java.lang.Boolean]().value(true).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
     }
     override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) = {
       Thread.sleep(delayMillis)
-      ProviderEvaluation.builder[String]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[String](d, "DEFAULT")
     }
     override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) = {
       Thread.sleep(delayMillis)
-      ProviderEvaluation.builder[java.lang.Integer]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
     }
     override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) = {
       Thread.sleep(delayMillis)
-      ProviderEvaluation.builder[java.lang.Double]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
     }
     override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) = {
       Thread.sleep(delayMillis)
-      ProviderEvaluation.builder[Value]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[Value](d, "DEFAULT")
     }
   }
 

--- a/core/src/test/scala/zio/openfeature/FeatureFlagRegistrySpec.scala
+++ b/core/src/test/scala/zio/openfeature/FeatureFlagRegistrySpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -28,7 +29,7 @@ object FeatureFlagRegistrySpec extends ZIOSpecDefault {
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Boolean] = {
       val v = flags.get(key).map(_.asInstanceOf[Boolean]).getOrElse(defaultValue.booleanValue())
-      ProviderEvaluation.builder[java.lang.Boolean]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Boolean](v, "STATIC")
     }
 
     override def getStringEvaluation(
@@ -37,7 +38,7 @@ object FeatureFlagRegistrySpec extends ZIOSpecDefault {
       ctx: OFEvaluationContext
     ): ProviderEvaluation[String] = {
       val v = flags.get(key).map(_.toString).getOrElse(defaultValue)
-      ProviderEvaluation.builder[String]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[String](v, "STATIC")
     }
 
     override def getIntegerEvaluation(
@@ -46,7 +47,7 @@ object FeatureFlagRegistrySpec extends ZIOSpecDefault {
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Integer] = {
       val v = flags.get(key).map(_.asInstanceOf[Int]).getOrElse(defaultValue.intValue())
-      ProviderEvaluation.builder[java.lang.Integer]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Integer](v, "STATIC")
     }
 
     override def getDoubleEvaluation(
@@ -55,7 +56,7 @@ object FeatureFlagRegistrySpec extends ZIOSpecDefault {
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Double] = {
       val v = flags.get(key).map(_.asInstanceOf[Double]).getOrElse(defaultValue.doubleValue())
-      ProviderEvaluation.builder[java.lang.Double]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Double](v, "STATIC")
     }
 
     override def getObjectEvaluation(
@@ -63,7 +64,7 @@ object FeatureFlagRegistrySpec extends ZIOSpecDefault {
       defaultValue: Value,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[Value] =
-      ProviderEvaluation.builder[Value]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[Value](defaultValue, "STATIC")
   }
 
   private def registryLayer(defaultProvider: SimpleProvider): ZLayer[Scope, Throwable, FeatureFlagRegistry] =

--- a/core/src/test/scala/zio/openfeature/HookDefectSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookDefectSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -32,15 +33,15 @@ object HookDefectSpec extends ZIOSpecDefault {
     override def shutdown(): Unit                           = ()
 
     override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Boolean]().value(true).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
     override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[String]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[String](d, "DEFAULT")
     override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Integer]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
     override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Double]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
     override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[Value]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[Value](d, "DEFAULT")
   }
 
   // A hook stage that throws synchronously (not in a ZIO effect), which ZIO converts to a Die defect.

--- a/core/src/test/scala/zio/openfeature/HookStageContextSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookStageContextSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -31,35 +32,35 @@ object HookStageContextSpec extends ZIOSpecDefault {
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Boolean] =
       if (failKeys.contains(key)) throw new ProviderNotReadyError(s"simulated failure for $key")
-      else ProviderEvaluation.builder[java.lang.Boolean]().value(value).reason("STATIC").build()
+      else ProviderEvaluations.of[java.lang.Boolean](value, "STATIC")
 
     override def getStringEvaluation(
       key: String,
       defaultValue: String,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[String] =
-      ProviderEvaluation.builder[String]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[String](defaultValue, "STATIC")
 
     override def getIntegerEvaluation(
       key: String,
       defaultValue: java.lang.Integer,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Integer] =
-      ProviderEvaluation.builder[java.lang.Integer]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Integer](defaultValue, "STATIC")
 
     override def getDoubleEvaluation(
       key: String,
       defaultValue: java.lang.Double,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Double] =
-      ProviderEvaluation.builder[java.lang.Double]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Double](defaultValue, "STATIC")
 
     override def getObjectEvaluation(
       key: String,
       defaultValue: dev.openfeature.sdk.Value,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[dev.openfeature.sdk.Value] =
-      ProviderEvaluation.builder[dev.openfeature.sdk.Value]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[dev.openfeature.sdk.Value](defaultValue, "STATIC")
   }
 
   private def buildIsolated(provider: EventProvider): ZIO[Scope, Throwable, FeatureFlags] = {

--- a/core/src/test/scala/zio/openfeature/ProviderEventShutdownSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderEventShutdownSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -28,15 +29,15 @@ object ProviderEventShutdownSpec extends ZIOSpecDefault {
     override def shutdown(): Unit                           = ()
 
     override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Boolean]().value(true).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
     override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[String]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[String](d, "DEFAULT")
     override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Integer]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
     override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Double]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
     override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[Value]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[Value](d, "DEFAULT")
   }
 
   private def buildFF: ZIO[Scope, Throwable, FeatureFlags] = {

--- a/core/src/test/scala/zio/openfeature/ProviderHookDuplicationSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderHookDuplicationSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -41,35 +42,35 @@ object ProviderHookDuplicationSpec extends ZIOSpecDefault {
       defaultValue: java.lang.Boolean,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Boolean] =
-      ProviderEvaluation.builder[java.lang.Boolean]().value(value).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Boolean](value, "STATIC")
 
     override def getStringEvaluation(
       key: String,
       defaultValue: String,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[String] =
-      ProviderEvaluation.builder[String]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[String](defaultValue, "STATIC")
 
     override def getIntegerEvaluation(
       key: String,
       defaultValue: java.lang.Integer,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Integer] =
-      ProviderEvaluation.builder[java.lang.Integer]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Integer](defaultValue, "STATIC")
 
     override def getDoubleEvaluation(
       key: String,
       defaultValue: java.lang.Double,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Double] =
-      ProviderEvaluation.builder[java.lang.Double]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Double](defaultValue, "STATIC")
 
     override def getObjectEvaluation(
       key: String,
       defaultValue: dev.openfeature.sdk.Value,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[dev.openfeature.sdk.Value] =
-      ProviderEvaluation.builder[dev.openfeature.sdk.Value]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[dev.openfeature.sdk.Value](defaultValue, "STATIC")
   }
 
   def spec = suite("Provider hook duplication")(

--- a/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -29,7 +30,7 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Boolean] = {
       val v = flags.get(key).map(_.asInstanceOf[Boolean]).getOrElse(defaultValue.booleanValue())
-      ProviderEvaluation.builder[java.lang.Boolean]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Boolean](v, "STATIC")
     }
 
     override def getStringEvaluation(
@@ -38,7 +39,7 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
       ctx: OFEvaluationContext
     ): ProviderEvaluation[String] = {
       val v = flags.get(key).map(_.toString).getOrElse(defaultValue)
-      ProviderEvaluation.builder[String]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[String](v, "STATIC")
     }
 
     override def getIntegerEvaluation(
@@ -47,7 +48,7 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Integer] = {
       val v = flags.get(key).map(_.asInstanceOf[Int]).getOrElse(defaultValue.intValue())
-      ProviderEvaluation.builder[java.lang.Integer]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Integer](v, "STATIC")
     }
 
     override def getDoubleEvaluation(
@@ -56,7 +57,7 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Double] = {
       val v = flags.get(key).map(_.asInstanceOf[Double]).getOrElse(defaultValue.doubleValue())
-      ProviderEvaluation.builder[java.lang.Double]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Double](v, "STATIC")
     }
 
     override def getObjectEvaluation(
@@ -64,7 +65,7 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
       defaultValue: Value,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[Value] =
-      ProviderEvaluation.builder[Value]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[Value](defaultValue, "STATIC")
   }
 
   private def buildWithDomain(provider: SimpleProvider): ZIO[Scope, Throwable, FeatureFlags] = {

--- a/core/src/test/scala/zio/openfeature/ProviderHotSwapStressSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderHotSwapStressSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -29,15 +30,15 @@ object ProviderHotSwapStressSpec extends ZIOSpecDefault {
     override def shutdown(): Unit                           = ()
 
     override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Boolean]().value(value).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Boolean](value, "STATIC")
     override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[String]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[String](d, "DEFAULT")
     override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Integer]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
     override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Double]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
     override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[Value]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[Value](d, "DEFAULT")
   }
 
   // Provider whose initialize() throws so setProvider → fails → rollback is triggered.
@@ -49,15 +50,15 @@ object ProviderHotSwapStressSpec extends ZIOSpecDefault {
     override def shutdown(): Unit                           = ()
 
     override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Boolean]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Boolean](d, "DEFAULT")
     override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[String]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[String](d, "DEFAULT")
     override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Integer]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
     override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Double]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
     override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[Value]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[Value](d, "DEFAULT")
   }
 
   private val FiberCount    = 200

--- a/core/src/test/scala/zio/openfeature/ProviderInitFailureSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderInitFailureSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import zio._
 import zio.test._
@@ -34,15 +35,15 @@ object ProviderInitFailureSpec extends ZIOSpecDefault {
   // Minimal stub for evaluation methods we don't exercise; keeps each test provider class small.
   private trait EvaluationStubs extends EventProvider {
     override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Boolean]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Boolean](d, "DEFAULT")
     override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[String]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[String](d, "DEFAULT")
     override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Integer]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
     override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Double]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
     override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[Value]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[Value](d, "DEFAULT")
   }
 
   /** Case 1: provider whose `initialize()` throws synchronously. */

--- a/core/src/test/scala/zio/openfeature/ProviderInitHardeningSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderInitHardeningSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import zio._
 import zio.test._
@@ -37,15 +38,15 @@ object ProviderInitHardeningSpec extends ZIOSpecDefault {
     }
 
     override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Boolean]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Boolean](d, "DEFAULT")
     override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[String]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[String](d, "DEFAULT")
     override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Integer]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
     override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Double]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
     override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[Value]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[Value](d, "DEFAULT")
   }
 
   /** A provider that returns successfully from `initialize()` but reports ERROR. The library should refuse to mark such
@@ -59,15 +60,15 @@ object ProviderInitHardeningSpec extends ZIOSpecDefault {
     override def shutdown(): Unit                           = st.set(ProviderState.NOT_READY)
 
     override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Boolean]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Boolean](d, "DEFAULT")
     override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[String]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[String](d, "DEFAULT")
     override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Integer]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
     override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[java.lang.Double]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
     override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
-      ProviderEvaluation.builder[Value]().value(d).reason("DEFAULT").build()
+      ProviderEvaluations.of[Value](d, "DEFAULT")
   }
 
   // Each sync test uses a unique domain so OpenFeatureAPI clients don't share state across cases.

--- a/core/src/test/scala/zio/openfeature/ZioApiHookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ZioApiHookSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -25,35 +26,35 @@ object ZioApiHookSpec extends ZIOSpecDefault {
       defaultValue: java.lang.Boolean,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Boolean] =
-      ProviderEvaluation.builder[java.lang.Boolean]().value(value).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Boolean](value, "STATIC")
 
     override def getStringEvaluation(
       key: String,
       defaultValue: String,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[String] =
-      ProviderEvaluation.builder[String]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[String](defaultValue, "STATIC")
 
     override def getIntegerEvaluation(
       key: String,
       defaultValue: java.lang.Integer,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Integer] =
-      ProviderEvaluation.builder[java.lang.Integer]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Integer](defaultValue, "STATIC")
 
     override def getDoubleEvaluation(
       key: String,
       defaultValue: java.lang.Double,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[java.lang.Double] =
-      ProviderEvaluation.builder[java.lang.Double]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Double](defaultValue, "STATIC")
 
     override def getObjectEvaluation(
       key: String,
       defaultValue: dev.openfeature.sdk.Value,
       ctx: OFEvaluationContext
     ): ProviderEvaluation[dev.openfeature.sdk.Value] =
-      ProviderEvaluation.builder[dev.openfeature.sdk.Value]().value(defaultValue).reason("STATIC").build()
+      ProviderEvaluations.of[dev.openfeature.sdk.Value](defaultValue, "STATIC")
   }
 
   private def buildIsolated(provider: EventProvider): ZIO[Scope, Throwable, FeatureFlags] = {

--- a/extras/src/main/scala/dev/openfeature/sdk/EventProviderBridge.scala
+++ b/extras/src/main/scala/dev/openfeature/sdk/EventProviderBridge.scala
@@ -1,6 +1,6 @@
 package dev.openfeature.sdk
 
-import dev.openfeature.sdk.internal.TriConsumer
+import dev.openfeature.sdk.internal.{AutoCloseableReentrantReadWriteLock, TriConsumer}
 
 /** Accessor for the Java SDK's package-private `EventProvider.attach`/`detach`.
   *
@@ -15,12 +15,20 @@ import dev.openfeature.sdk.internal.TriConsumer
   */
 object EventProviderBridge {
 
-  /** Forward every event emitted by `delegate` to `onEvent`. Runs on the delegate's emitter executor. */
+  /** Forward every event emitted by `delegate` to `onEvent`. Runs on the delegate's emitter executor.
+    *
+    * Since 1.21.0, `attach` takes a read/write lock that `EventProvider.emit` holds for the duration of the callback.
+    * The real `OpenFeatureAPI` uses this to serialize emission against its own state; our delegate is never registered
+    * with an API, so a private lock owned solely by this attachment is sufficient.
+    */
   def attach(delegate: EventProvider, onEvent: (ProviderEvent, ProviderEventDetails) => Unit): Unit =
-    delegate.attach(new TriConsumer[EventProvider, ProviderEvent, ProviderEventDetails] {
-      override def accept(p: EventProvider, event: ProviderEvent, details: ProviderEventDetails): Unit =
-        onEvent(event, details)
-    })
+    delegate.attach(
+      new TriConsumer[EventProvider, ProviderEvent, ProviderEventDetails] {
+        override def accept(p: EventProvider, event: ProviderEvent, details: ProviderEventDetails): Unit =
+          onEvent(event, details)
+      },
+      new AutoCloseableReentrantReadWriteLock()
+    )
 
   /** Remove the attachment installed by [[attach]]. */
   def detach(delegate: EventProvider): Unit = delegate.detach()

--- a/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
@@ -140,16 +140,18 @@ final class CachingProvider private (
       s"${lp(tk)}|$attrs"
     }
 
-  private def withCachedReason[A](eval: ProviderEvaluation[A]): ProviderEvaluation[A] =
-    ProviderEvaluation
-      .builder[A]()
-      .value(eval.getValue)
-      .variant(eval.getVariant)
-      .reason("CACHED")
-      .errorCode(eval.getErrorCode)
-      .errorMessage(eval.getErrorMessage)
-      .flagMetadata(eval.getFlagMetadata)
-      .build()
+  private def withCachedReason[A](eval: ProviderEvaluation[A]): ProviderEvaluation[A] = {
+    // Builder calls are split across statements (not chained) because the SDK's SuperBuilder-style
+    // self-type confuses Scala 2.13's existential resolution past the second fluent call.
+    val builder = ProviderEvaluation.builder[A]()
+    builder.value(eval.getValue)
+    builder.variant(eval.getVariant)
+    builder.reason("CACHED")
+    builder.errorCode(eval.getErrorCode)
+    builder.errorMessage(eval.getErrorMessage)
+    builder.flagMetadata(eval.getFlagMetadata)
+    builder.build().asInstanceOf[ProviderEvaluation[A]]
+  }
 
   private def cached[A](
     key: String,

--- a/extras/src/main/scala/zio/openfeature/extras/EnvVarProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/EnvVarProvider.scala
@@ -8,6 +8,7 @@ import dev.openfeature.sdk.{
   ProviderState,
   Value
 }
+import zio.openfeature.internal.ProviderEvaluations
 
 /** A feature flag provider that reads values from environment variables.
   *
@@ -50,9 +51,9 @@ final class EnvVarProvider private (
           case "false" | "0" | "no" | "off" => false
           case _                            => defaultValue.booleanValue()
         }
-        ProviderEvaluation.builder[java.lang.Boolean]().value(parsed).reason("STATIC").build()
+        ProviderEvaluations.of(java.lang.Boolean.valueOf(parsed), "STATIC")
       case None =>
-        ProviderEvaluation.builder[java.lang.Boolean]().value(defaultValue).reason("DEFAULT").build()
+        ProviderEvaluations.of(defaultValue, "DEFAULT")
     }
 
   override def getStringEvaluation(
@@ -62,9 +63,9 @@ final class EnvVarProvider private (
   ): ProviderEvaluation[String] =
     lookup(key) match {
       case Some(v) =>
-        ProviderEvaluation.builder[String]().value(v).reason("STATIC").build()
+        ProviderEvaluations.of(v, "STATIC")
       case None =>
-        ProviderEvaluation.builder[String]().value(defaultValue).reason("DEFAULT").build()
+        ProviderEvaluations.of(defaultValue, "DEFAULT")
     }
 
   override def getIntegerEvaluation(
@@ -74,9 +75,9 @@ final class EnvVarProvider private (
   ): ProviderEvaluation[java.lang.Integer] =
     lookup(key).flatMap(v => scala.util.Try(v.toInt).toOption) match {
       case Some(v) =>
-        ProviderEvaluation.builder[java.lang.Integer]().value(v).reason("STATIC").build()
+        ProviderEvaluations.of(java.lang.Integer.valueOf(v), "STATIC")
       case None =>
-        ProviderEvaluation.builder[java.lang.Integer]().value(defaultValue).reason("DEFAULT").build()
+        ProviderEvaluations.of(defaultValue, "DEFAULT")
     }
 
   override def getDoubleEvaluation(
@@ -86,9 +87,9 @@ final class EnvVarProvider private (
   ): ProviderEvaluation[java.lang.Double] =
     lookup(key).flatMap(v => scala.util.Try(v.toDouble).toOption) match {
       case Some(v) =>
-        ProviderEvaluation.builder[java.lang.Double]().value(v).reason("STATIC").build()
+        ProviderEvaluations.of(java.lang.Double.valueOf(v), "STATIC")
       case None =>
-        ProviderEvaluation.builder[java.lang.Double]().value(defaultValue).reason("DEFAULT").build()
+        ProviderEvaluations.of(defaultValue, "DEFAULT")
     }
 
   override def getObjectEvaluation(
@@ -98,9 +99,9 @@ final class EnvVarProvider private (
   ): ProviderEvaluation[Value] =
     lookup(key) match {
       case Some(v) =>
-        ProviderEvaluation.builder[Value]().value(new Value(v)).reason("STATIC").build()
+        ProviderEvaluations.of(new Value(v), "STATIC")
       case None =>
-        ProviderEvaluation.builder[Value]().value(defaultValue).reason("DEFAULT").build()
+        ProviderEvaluations.of(defaultValue, "DEFAULT")
     }
 }
 

--- a/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
@@ -11,6 +11,7 @@ import dev.openfeature.sdk.{
   Value
 }
 import dev.openfeature.sdk.exceptions.{ParseError, TypeMismatchError}
+import zio.openfeature.internal.ProviderEvaluations
 import zio._
 import java.util.concurrent.atomic.AtomicReference
 import scala.jdk.CollectionConverters._
@@ -53,13 +54,9 @@ final class HoconProvider private (
     context: OFEvaluationContext
   ): ProviderEvaluation[java.lang.Boolean] =
     if (config.hasPath(key))
-      ProviderEvaluation
-        .builder[java.lang.Boolean]()
-        .value(typedRead(key, config.getBoolean(key)))
-        .reason("STATIC")
-        .build()
+      ProviderEvaluations.of(java.lang.Boolean.valueOf(typedRead(key, config.getBoolean(key))), "STATIC")
     else
-      ProviderEvaluation.builder[java.lang.Boolean]().value(defaultValue).reason("DEFAULT").build()
+      ProviderEvaluations.of(defaultValue, "DEFAULT")
 
   override def getStringEvaluation(
     key: String,
@@ -67,9 +64,9 @@ final class HoconProvider private (
     context: OFEvaluationContext
   ): ProviderEvaluation[String] =
     if (config.hasPath(key))
-      ProviderEvaluation.builder[String]().value(typedRead(key, config.getString(key))).reason("STATIC").build()
+      ProviderEvaluations.of(typedRead(key, config.getString(key)), "STATIC")
     else
-      ProviderEvaluation.builder[String]().value(defaultValue).reason("DEFAULT").build()
+      ProviderEvaluations.of(defaultValue, "DEFAULT")
 
   override def getIntegerEvaluation(
     key: String,
@@ -77,9 +74,9 @@ final class HoconProvider private (
     context: OFEvaluationContext
   ): ProviderEvaluation[java.lang.Integer] =
     if (config.hasPath(key))
-      ProviderEvaluation.builder[java.lang.Integer]().value(typedRead(key, config.getInt(key))).reason("STATIC").build()
+      ProviderEvaluations.of(java.lang.Integer.valueOf(typedRead(key, config.getInt(key))), "STATIC")
     else
-      ProviderEvaluation.builder[java.lang.Integer]().value(defaultValue).reason("DEFAULT").build()
+      ProviderEvaluations.of(defaultValue, "DEFAULT")
 
   override def getDoubleEvaluation(
     key: String,
@@ -87,13 +84,9 @@ final class HoconProvider private (
     context: OFEvaluationContext
   ): ProviderEvaluation[java.lang.Double] =
     if (config.hasPath(key))
-      ProviderEvaluation
-        .builder[java.lang.Double]()
-        .value(typedRead(key, config.getDouble(key)))
-        .reason("STATIC")
-        .build()
+      ProviderEvaluations.of(java.lang.Double.valueOf(typedRead(key, config.getDouble(key))), "STATIC")
     else
-      ProviderEvaluation.builder[java.lang.Double]().value(defaultValue).reason("DEFAULT").build()
+      ProviderEvaluations.of(defaultValue, "DEFAULT")
 
   override def getObjectEvaluation(
     key: String,
@@ -102,9 +95,9 @@ final class HoconProvider private (
   ): ProviderEvaluation[Value] =
     if (config.hasPath(key)) {
       val value = typedRead(key, configValueToSdkValue(config.getValue(key)))
-      ProviderEvaluation.builder[Value]().value(value).reason("STATIC").build()
+      ProviderEvaluations.of(value, "STATIC")
     } else
-      ProviderEvaluation.builder[Value]().value(defaultValue).reason("DEFAULT").build()
+      ProviderEvaluations.of(defaultValue, "DEFAULT")
 
   private def configValueToSdkValue(cv: com.typesafe.config.ConfigValue): Value =
     cv.valueType() match {

--- a/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
@@ -10,6 +10,7 @@ import dev.openfeature.sdk.{
   ProviderState,
   Value
 }
+import zio.openfeature.internal.ProviderEvaluations
 import zio._
 import zio.test._
 import java.util.concurrent.atomic.AtomicInteger
@@ -42,7 +43,7 @@ object CachingProviderSpec extends ZIOSpecDefault {
       evaluationCount.incrementAndGet()
       maybeDelay()
       val v = flags.get(key).map(_.asInstanceOf[Boolean]).getOrElse(defaultValue.booleanValue())
-      ProviderEvaluation.builder[java.lang.Boolean]().value(v).reason("TARGETING_MATCH").build()
+      ProviderEvaluations.of[java.lang.Boolean](v, "TARGETING_MATCH")
     }
 
     override def getStringEvaluation(
@@ -53,7 +54,7 @@ object CachingProviderSpec extends ZIOSpecDefault {
       evaluationCount.incrementAndGet()
       maybeDelay()
       val v = flags.get(key).map(_.toString).getOrElse(defaultValue)
-      ProviderEvaluation.builder[String]().value(v).reason("TARGETING_MATCH").build()
+      ProviderEvaluations.of[String](v, "TARGETING_MATCH")
     }
 
     override def getIntegerEvaluation(
@@ -64,7 +65,7 @@ object CachingProviderSpec extends ZIOSpecDefault {
       evaluationCount.incrementAndGet()
       maybeDelay()
       val v = flags.get(key).map(_.asInstanceOf[Int]).getOrElse(defaultValue.intValue())
-      ProviderEvaluation.builder[java.lang.Integer]().value(v).reason("TARGETING_MATCH").build()
+      ProviderEvaluations.of[java.lang.Integer](v, "TARGETING_MATCH")
     }
 
     override def getDoubleEvaluation(
@@ -75,7 +76,7 @@ object CachingProviderSpec extends ZIOSpecDefault {
       evaluationCount.incrementAndGet()
       maybeDelay()
       val v = flags.get(key).map(_.asInstanceOf[Double]).getOrElse(defaultValue.doubleValue())
-      ProviderEvaluation.builder[java.lang.Double]().value(v).reason("TARGETING_MATCH").build()
+      ProviderEvaluations.of[java.lang.Double](v, "TARGETING_MATCH")
     }
 
     override def getObjectEvaluation(
@@ -85,14 +86,13 @@ object CachingProviderSpec extends ZIOSpecDefault {
     ): ProviderEvaluation[Value] = {
       evaluationCount.incrementAndGet()
       maybeDelay()
-      val v = flags.get(key).map(a => new Value(a.toString)).getOrElse(defaultValue)
-      ProviderEvaluation
-        .builder[Value]()
-        .value(v)
-        .variant("obj-variant")
-        .reason("TARGETING_MATCH")
-        .flagMetadata(ImmutableMetadata.builder().addString("source", "test").build())
-        .build()
+      val v       = flags.get(key).map(a => new Value(a.toString)).getOrElse(defaultValue)
+      val builder = ProviderEvaluation.builder[Value]()
+      builder.value(v)
+      builder.variant("obj-variant")
+      builder.reason("TARGETING_MATCH")
+      builder.flagMetadata(ImmutableMetadata.builder().addString("source", "test").build())
+      builder.build().asInstanceOf[ProviderEvaluation[Value]]
     }
   }
 
@@ -405,13 +405,12 @@ object CachingProviderSpec extends ZIOSpecDefault {
           ): ProviderEvaluation[java.lang.Boolean] =
             if (errorFirst.getAndSet(false)) {
               evaluationCount.incrementAndGet()
-              ProviderEvaluation
-                .builder[java.lang.Boolean]()
-                .value(defaultValue)
-                .reason("ERROR")
-                .errorCode(dev.openfeature.sdk.ErrorCode.GENERAL)
-                .errorMessage("upstream hiccup")
-                .build()
+              val builder = ProviderEvaluation.builder[java.lang.Boolean]()
+              builder.value(defaultValue)
+              builder.reason("ERROR")
+              builder.errorCode(dev.openfeature.sdk.ErrorCode.GENERAL)
+              builder.errorMessage("upstream hiccup")
+              builder.build().asInstanceOf[ProviderEvaluation[java.lang.Boolean]]
             } else super.getBooleanEvaluation(key, defaultValue, c)
         }
         for {

--- a/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerProviderSpec.scala
@@ -1,4 +1,5 @@
 package zio.openfeature.extras
+import zio.openfeature.internal.ProviderEvaluations
 
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -49,7 +50,7 @@ object CircuitBreakerProviderSpec extends ZIOSpecDefault {
       evaluationCount.incrementAndGet()
       maybeFailOrDelay()
       val v = flags.get(key).map(_.asInstanceOf[Boolean]).getOrElse(defaultValue.booleanValue())
-      ProviderEvaluation.builder[java.lang.Boolean]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Boolean](v, "STATIC")
     }
 
     override def getStringEvaluation(
@@ -60,7 +61,7 @@ object CircuitBreakerProviderSpec extends ZIOSpecDefault {
       evaluationCount.incrementAndGet()
       maybeFailOrDelay()
       val v = flags.get(key).map(_.toString).getOrElse(defaultValue)
-      ProviderEvaluation.builder[String]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[String](v, "STATIC")
     }
 
     override def getIntegerEvaluation(
@@ -71,7 +72,7 @@ object CircuitBreakerProviderSpec extends ZIOSpecDefault {
       evaluationCount.incrementAndGet()
       maybeFailOrDelay()
       val v = flags.get(key).map(_.asInstanceOf[Int]).getOrElse(defaultValue.intValue())
-      ProviderEvaluation.builder[java.lang.Integer]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Integer](v, "STATIC")
     }
 
     override def getDoubleEvaluation(
@@ -82,7 +83,7 @@ object CircuitBreakerProviderSpec extends ZIOSpecDefault {
       evaluationCount.incrementAndGet()
       maybeFailOrDelay()
       val v = flags.get(key).map(_.asInstanceOf[Double]).getOrElse(defaultValue.doubleValue())
-      ProviderEvaluation.builder[java.lang.Double]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[java.lang.Double](v, "STATIC")
     }
 
     override def getObjectEvaluation(
@@ -93,7 +94,7 @@ object CircuitBreakerProviderSpec extends ZIOSpecDefault {
       evaluationCount.incrementAndGet()
       maybeFailOrDelay()
       val v = flags.get(key).map(a => new Value(a.toString)).getOrElse(defaultValue)
-      ProviderEvaluation.builder[Value]().value(v).reason("STATIC").build()
+      ProviderEvaluations.of[Value](v, "STATIC")
     }
   }
 

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
@@ -158,13 +158,14 @@ final class OptimizelyFeatureProvider private[optimizely] (
   ): ProviderEvaluation[java.lang.Boolean] =
     decide(key, ctx) match {
       case Right(d) =>
-        ProviderEvaluation
-          .builder[java.lang.Boolean]()
-          .value(java.lang.Boolean.valueOf(d.getEnabled))
-          .variant(d.getVariationKey)
-          .reason(deriveReason(d))
-          .flagMetadata(metadataFrom(d))
-          .build()
+        // Builder calls are split across statements (not chained) because the SDK's SuperBuilder-style
+        // self-type confuses Scala 2.13's existential resolution past the second fluent call.
+        val builder = ProviderEvaluation.builder[java.lang.Boolean]()
+        builder.value(java.lang.Boolean.valueOf(d.getEnabled))
+        builder.variant(d.getVariationKey)
+        builder.reason(deriveReason(d))
+        builder.flagMetadata(metadataFrom(d))
+        builder.build().asInstanceOf[ProviderEvaluation[java.lang.Boolean]]
       case Left(err) => failingEvaluation(defaultValue, err)
     }
 
@@ -186,13 +187,12 @@ final class OptimizelyFeatureProvider private[optimizely] (
               case None     => (defaultValue, true)
             }
         }
-        ProviderEvaluation
-          .builder[String]()
-          .value(value)
-          .variant(d.getVariationKey)
-          .reason(if (usedDefault) Reason.DEFAULT.name() else deriveReason(d))
-          .flagMetadata(metadataFrom(d))
-          .build()
+        val builder = ProviderEvaluation.builder[String]()
+        builder.value(value)
+        builder.variant(d.getVariationKey)
+        builder.reason(if (usedDefault) Reason.DEFAULT.name() else deriveReason(d))
+        builder.flagMetadata(metadataFrom(d))
+        builder.build().asInstanceOf[ProviderEvaluation[String]]
       case Left(err) => failingEvaluation(defaultValue, err)
     }
 
@@ -228,13 +228,12 @@ final class OptimizelyFeatureProvider private[optimizely] (
           case Some(v) => (v, false)
           case None    => (defaultValue, true)
         }
-        ProviderEvaluation
-          .builder[A]()
-          .value(value)
-          .variant(d.getVariationKey)
-          .reason(if (usedDefault) Reason.DEFAULT.name() else deriveReason(d))
-          .flagMetadata(metadataFrom(d))
-          .build()
+        val builder = ProviderEvaluation.builder[A]()
+        builder.value(value)
+        builder.variant(d.getVariationKey)
+        builder.reason(if (usedDefault) Reason.DEFAULT.name() else deriveReason(d))
+        builder.flagMetadata(metadataFrom(d))
+        builder.build().asInstanceOf[ProviderEvaluation[A]]
       case Left(err) => failingEvaluation(defaultValue, err)
     }
 
@@ -251,15 +250,14 @@ final class OptimizelyFeatureProvider private[optimizely] (
   ): ProviderEvaluation[Value] =
     decide(key, ctx) match {
       case Right(d) =>
-        val map   = Option(d.getVariables).map(_.toMap).getOrElse(java.util.Collections.emptyMap[String, Object]())
-        val value = new Value(Structure.mapToStructure(map))
-        ProviderEvaluation
-          .builder[Value]()
-          .value(value)
-          .variant(d.getVariationKey)
-          .reason(deriveReason(d))
-          .flagMetadata(metadataFrom(d))
-          .build()
+        val map     = Option(d.getVariables).map(_.toMap).getOrElse(java.util.Collections.emptyMap[String, Object]())
+        val value   = new Value(Structure.mapToStructure(map))
+        val builder = ProviderEvaluation.builder[Value]()
+        builder.value(value)
+        builder.variant(d.getVariationKey)
+        builder.reason(deriveReason(d))
+        builder.flagMetadata(metadataFrom(d))
+        builder.build().asInstanceOf[ProviderEvaluation[Value]]
       case Left(err) => failingEvaluation(defaultValue, err)
     }
 
@@ -320,13 +318,12 @@ final class OptimizelyFeatureProvider private[optimizely] (
       case "FLAG_NOT_FOUND"        => dev.openfeature.sdk.ErrorCode.FLAG_NOT_FOUND
       case _                       => dev.openfeature.sdk.ErrorCode.GENERAL
     }
-    ProviderEvaluation
-      .builder[A]()
-      .value(defaultValue)
-      .reason(Reason.ERROR.name())
-      .errorCode(mapped)
-      .errorMessage(errorCode)
-      .build()
+    val builder = ProviderEvaluation.builder[A]()
+    builder.value(defaultValue)
+    builder.reason(Reason.ERROR.name())
+    builder.errorCode(mapped)
+    builder.errorMessage(errorCode)
+    builder.build().asInstanceOf[ProviderEvaluation[A]]
   }
 }
 

--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -3,7 +3,7 @@ package zio.openfeature.testkit
 import zio._
 import zio.stream._
 import zio.openfeature._
-import zio.openfeature.internal.ErrorCodeConverter
+import zio.openfeature.internal.{ErrorCodeConverter, ProviderEvaluations}
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
   EventProvider,
@@ -93,11 +93,10 @@ final class TestFeatureProvider private (
     applyBehavior()
     evaluations.add((key, context))
     val value = Option(flags.get(key)).map(_.asInstanceOf[Boolean]).getOrElse(defaultValue.booleanValue())
-    ProviderEvaluation
-      .builder[java.lang.Boolean]()
-      .value(value)
-      .reason(if (flags.containsKey(key)) "TARGETING_MATCH" else "DEFAULT")
-      .build()
+    ProviderEvaluations.of(
+      java.lang.Boolean.valueOf(value),
+      if (flags.containsKey(key)) "TARGETING_MATCH" else "DEFAULT"
+    )
   }
 
   override def getStringEvaluation(
@@ -108,11 +107,7 @@ final class TestFeatureProvider private (
     applyBehavior()
     evaluations.add((key, context))
     val value = Option(flags.get(key)).map(_.toString).getOrElse(defaultValue)
-    ProviderEvaluation
-      .builder[String]()
-      .value(value)
-      .reason(if (flags.containsKey(key)) "TARGETING_MATCH" else "DEFAULT")
-      .build()
+    ProviderEvaluations.of(value, if (flags.containsKey(key)) "TARGETING_MATCH" else "DEFAULT")
   }
 
   override def getIntegerEvaluation(
@@ -130,11 +125,10 @@ final class TestFeatureProvider private (
         case other     => other.toString.toInt
       }
       .getOrElse(defaultValue.intValue())
-    ProviderEvaluation
-      .builder[java.lang.Integer]()
-      .value(value)
-      .reason(if (flags.containsKey(key)) "TARGETING_MATCH" else "DEFAULT")
-      .build()
+    ProviderEvaluations.of(
+      java.lang.Integer.valueOf(value),
+      if (flags.containsKey(key)) "TARGETING_MATCH" else "DEFAULT"
+    )
   }
 
   override def getDoubleEvaluation(
@@ -153,11 +147,10 @@ final class TestFeatureProvider private (
         case other     => other.toString.toDouble
       }
       .getOrElse(defaultValue.doubleValue())
-    ProviderEvaluation
-      .builder[java.lang.Double]()
-      .value(value)
-      .reason(if (flags.containsKey(key)) "TARGETING_MATCH" else "DEFAULT")
-      .build()
+    ProviderEvaluations.of(
+      java.lang.Double.valueOf(value),
+      if (flags.containsKey(key)) "TARGETING_MATCH" else "DEFAULT"
+    )
   }
 
   override def getObjectEvaluation(
@@ -170,11 +163,7 @@ final class TestFeatureProvider private (
     val value = Option(flags.get(key))
       .map(anyToValue)
       .getOrElse(defaultValue)
-    ProviderEvaluation
-      .builder[Value]()
-      .value(value)
-      .reason(if (flags.containsKey(key)) "TARGETING_MATCH" else "DEFAULT")
-      .build()
+    ProviderEvaluations.of(value, if (flags.containsKey(key)) "TARGETING_MATCH" else "DEFAULT")
   }
 
   private def anyToValue(any: Any): Value = any match {


### PR DESCRIPTION
## Summary
- Bump `openFeatureSdkVersion` to `1.21.0`.
- `EventProvider.attach` (package-private, used by `EventProviderBridge` to forward delegate-provider events for `CachingProvider`/`CircuitBreakerProvider`) gained a required `AutoCloseableReentrantReadWriteLock` parameter upstream. Updated `EventProviderBridge.attach` to supply a private lock instance — the lock only serializes `emit` against a real `OpenFeatureAPI`'s state, which our unregistered delegates never touch, so this is a compile fix with no behavior change.
- No other gaps: per-provider error detail in multi-provider strategies and isolated `OpenFeatureAPI` instance support now flow from the upstream fix automatically (our event hub and `apiOverride` plumbing already isolated us from the bugs this release fixes).
- Checked the vendored OpenFeature spec gherkin conformance suite (`conformance/` and `conformance-zio-bdd/`) against current upstream `open-feature/spec` — byte-identical, no new scenarios to vendor.
- The `EventProviderBridge` fix is already exercised by the existing `CachingProviderSpec`/`CircuitBreakerProviderSpec` "Delegate event propagation" suites, which passed against the new lock parameter — no new test needed.

Closes #239

## Test plan
- [x] `sbt compile`
- [x] `sbt scalafmtCheckAll`
- [x] `sbt test` (414 tests passed)