### PR TITLE
1.0.0 is documented as released but was never published; MiMa has no baseline; README compat table drifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference instead of chaining off the return value) and used it at the ~90 call sites across `core`, `extras`,
   `optimizely`, and `testkit` that build a `ProviderEvaluation`.
 
-## [1.0.0] — 2026-06-17
+## [1.0.0] — unreleased
 
-First stable release. **Upgrading from 0.9.x:** two behavior changes may require action —
+> **Not yet published.** The latest artifact on Maven Central is `1.0.0-RC2`; the `v1.0.0` tag has not been
+> cut. The changes below shipped in the `1.0.0-RC1`/`1.0.0-RC2` pre-releases and are staged for the first
+> stable release. This heading is dated when `v1.0.0` is tagged (see [`RELEASING.md`](RELEASING.md)).
+
+Planned first stable release. **Upgrading from 0.9.x:** two behavior changes may require action —
 **`FlagType` decoders no longer coerce silently** (strict type decoding, #187) and a **1-second default
 per-evaluation timeout** (bounds hung providers; opt out with `evaluationTimeout = None`). Details in the
 entries below.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ ZIO OpenFeature provides a type-safe, functional interface for feature flag eval
 
 | ZIO OpenFeature | OpenFeature Spec | OpenFeature Java SDK |
 |:----------------|:-----------------|:---------------------|
-| 1.0.x | [v0.8.0](https://github.com/open-feature/spec/releases/tag/v0.8.0) | 1.20.2 |
+| 1.0.0-RC2 (latest published) | [v0.8.0](https://github.com/open-feature/spec/releases/tag/v0.8.0) | 1.20.2 |
+| 1.0.0 (upcoming) | [v0.8.0](https://github.com/open-feature/spec/releases/tag/v0.8.0) | 1.21.0 |
 
 This library implements the **dynamic-context paradigm** (server-side) of the OpenFeature specification. See [Spec Compliance](https://etacassiopeia.github.io/zio-openfeature/spec-compliance) for details.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,53 @@
+# Releasing
+
+Publishing is driven by [sbt-ci-release]: pushing a `v*` tag triggers
+[`.github/workflows/release.yml`](.github/workflows/release.yml), which runs the tests on both Scala versions
+and then `sbt ci-release` to publish to Maven Central and create a GitHub Release. A plain `main` push publishes
+a `-SNAPSHOT`; only a `v*` **tag** publishes a real version.
+
+**The tag is the release.** Nothing is published until `v<x.y.z>` is pushed — so the CHANGELOG and README must
+never describe a version as released before its tag exists. This checklist keeps the docs from getting ahead of
+Maven Central (the drift that motivated #269).
+
+## Pre-release checklist
+
+Run through this on `main` (or the release branch) **before** tagging:
+
+- [ ] **CHANGELOG** — move the `## [Unreleased]` / `## [x.y.z] — unreleased` entries under a dated
+      `## [x.y.z] — YYYY-MM-DD` heading, and drop the "not yet published" note. Confirm every referenced PR/issue
+      number is correct.
+- [ ] **README compatibility table** — update the row(s) in [`README.md`](README.md#version-compatibility) so the
+      "latest published" line matches the version you are about to tag, with the correct OpenFeature Spec and Java
+      SDK versions (`openFeatureSdkVersion` in `build.sbt`). Remove any stale "upcoming" row that this release
+      fulfils.
+- [ ] **Version references** — grep docs for the previous version string and update any hardcoded mentions.
+- [ ] **Green `main`** — the full build matrix must be green on the commit you are about to tag.
+
+## First stable release (`v1.0.0`) — additional steps
+
+- [ ] **Enable MiMa** — in [`build.sbt`](build.sbt), set
+      `mimaPreviousArtifacts := Set(organization.value %% moduleName.value % "<last-release>")` (baseline against the
+      just-published `1.0.0`, or the previous patch on later releases). It is intentionally `Set.empty` while pre-1.0
+      because the RC line still makes deliberate breaking changes; only turn it on once the API is frozen. After
+      enabling, `sbt +mimaReportBinaryIssues` gates every PR; whitelist an intentional break with a
+      `mimaBinaryIssueFilters` rule scoped to the specific symbol.
+
+## Cutting the release
+
+1. Complete the checklist above and merge those doc changes to `main`.
+2. Confirm the build matrix is green on the target commit.
+3. Tag and push:
+   ```sh
+   git tag v<x.y.z>
+   git push origin v<x.y.z>
+   ```
+4. Watch [`release.yml`](.github/workflows/release.yml) go green (tests on both Scala versions → `ci-release` →
+   GitHub Release).
+5. Verify the artifacts appear on Maven Central and that the badge in the README resolves to the new version.
+
+## Post-release
+
+- [ ] Open a fresh `## [Unreleased]` section at the top of the CHANGELOG.
+- [ ] Add an "upcoming" README compatibility row if the next version already targets a newer OpenFeature SDK.
+
+[sbt-ci-release]: https://github.com/sbt/sbt-ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -61,11 +61,12 @@ ThisBuild / coverageEnabled          := false
 ThisBuild / coverageMinimumStmtTotal := 80
 ThisBuild / coverageFailOnMinimum    := true
 
-// Binary-compatibility check via sbt-mima. `mimaPreviousArtifacts` is intentionally empty across all modules until
-// the first post-mima tag exists; the first 1.0 release sets a baseline (typically the previous patch version of
-// the same module) and `sbt mimaReportBinaryIssues` then catches accidental breaking changes on every PR.
-// To intentionally break binary compatibility on a major version bump, add a `mimaBinaryIssueFilters` rule scoped
-// to the specific symbol — see https://github.com/lightbend/mima for the filter API.
+// Binary-compatibility check via sbt-mima. `mimaPreviousArtifacts` is intentionally empty across all modules while
+// the project is pre-1.0: the `1.0.0-RCx` line is still making deliberate breaking changes, so baselining against an
+// RC would fail CI on intended breakage rather than catching accidental breakage. The baseline is set as part of
+// cutting `v1.0.0` — see `RELEASING.md` step "enable MiMa". After that, `sbt mimaReportBinaryIssues` catches
+// accidental breaking changes on every PR, and an intentional break is whitelisted with a `mimaBinaryIssueFilters`
+// rule scoped to the specific symbol — see https://github.com/lightbend/mima for the filter API.
 ThisBuild / mimaFailOnNoPrevious := false
 
 // Version-specific source directories
@@ -100,8 +101,8 @@ lazy val commonSettings = Seq(
     "dev.zio" %% "zio-test"     % zioVersion % Test,
     "dev.zio" %% "zio-test-sbt" % zioVersion % Test
   ),
-  // Empty by default — populated by the first published module per major release line. See ThisBuild
-  // `mimaFailOnNoPrevious := false` above.
+  // Empty while pre-1.0 (see the ThisBuild `mimaFailOnNoPrevious := false` note above). When cutting `v1.0.0`,
+  // set this to `Set(organization.value %% moduleName.value % "<last-release>")` per `RELEASING.md`.
   mimaPreviousArtifacts := Set.empty
 ) ++ crossVersionSourceDirs
 


### PR DESCRIPTION
Closes #269

## Summary

The `1.0.0` release is documented in CHANGELOG and README as if it were released, but it was never published to Maven Central. Additionally, MiMa (Binary Compatibility checker) has no baseline configured for pre-1.0 releases, and the README Version Compatibility table is out of sync with the current SDK versions.

## Changes

- **CHANGELOG.md**: Relabeled `1.0.0` heading from a release date to `[unreleased]` with a "not yet published to Maven Central" note
- **README.md**: Updated Version Compatibility table to clarify `1.0.0-RC2 (latest published)` supports SDK 1.20.2, and added new `1.0.0 (upcoming)` row for SDK 1.21.0
- **build.sbt**: Clarified comments explaining why `mimaPreviousArtifacts` is intentionally empty for pre-1.0 releases
- **RELEASING.md**: New file — comprehensive checklist for cutting the `v1.0.0` release, including the step to enable MiMa baseline after the tag is pushed

## Deliberate Decisions

**MiMa baseline intentionally NOT configured:**
The project is pre-1.0 (latest published artifact is `1.0.0-RC2`, no `v1.0.0` tag yet). The RC line still makes deliberate breaking changes. Baselining `mimaPreviousArtifacts` against RC2 would cause CI to fail on intended breakage rather than catching accidental regressions. Enabling MiMa is documented as an explicit step in the new `RELEASING.md` for when `v1.0.0` is cut.

**Cutting the actual `v1.0.0` release is NOT part of this PR:**
This PR corrects documentation and adds a checklist to prevent recurrence. Actually publishing `v1.0.0` (pushing the git tag → Maven Central) is a maintainer action deferred to a follow-up.