### PR TITLE
buildAsync wraps throwing SDK calls in ZIO.succeed; a defect hangs FeatureFlagRegistry.getClient callers forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reference instead of chaining off the return value) and used it at the ~90 call sites across `core`, `extras`,
   `optimizely`, and `testkit` that build a `ProviderEvaluation`.
 
+### Fixed
+
+- **`FeatureFlagRegistry.getClient` no longer hangs when provider registration throws** (#242). `FeatureFlags.buildAsync`
+  wrapped the synchronous Java SDK registration calls (`api.setProvider`, `provider.getMetadata`) in `ZIO.succeed`, so a
+  throw became a ZIO *defect* rather than a typed error. Combined with `runBuild` handling only typed failures, such a
+  defect left the registry's per-domain `Promise` never completed and never evicted — every current and future
+  `getClient(domain)` caller blocked forever. Registration is now wrapped in `ZIO.attempt` (surfacing throws as typed
+  `ProviderInitializationFailed`), and `runBuild` settles and evicts the entry on any failure cause (typed or defect),
+  restoring the documented "a failed initialization is not cached — a subsequent call retries" contract.
+
 ## [1.0.0] — unreleased
 
 > **Not yet published.** The latest artifact on Maven Central is `1.0.0-RC2`; the `v1.0.0` tag has not been

--- a/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagRegistry.scala
@@ -172,8 +172,22 @@ final private class FeatureFlagRegistryLive(
     remove: UIO[Unit]
   ): UIO[Unit] =
     buildClient
-      .foldZIO(
-        err => lock.withPermit(remove *> promise.fail(err)).unit,
+      // `foldCauseZIO`, not `foldZIO`: a *defect* (a throwing SDK call that escaped the typed channel) is not a
+      // typed failure, so `foldZIO` would let it kill this fiber with the promise never settled and the entry never
+      // removed — every current and future `getClient` for this domain would then block on `promise.await` forever.
+      // Handling the full cause guarantees the promise is always completed and the entry evicted so callers retry.
+      .foldCauseZIO(
+        cause =>
+          cause.failureOrCause match {
+            // Typed failure (e.g. ProviderInitializationFailed): settle and evict so callers retry.
+            case Left(err) => lock.withPermit(remove *> promise.fail(err)).unit
+            // Interruption only (registry scope closing mid-build): unblock awaiters; teardown handles eviction.
+            case Right(c) if c.isInterruptedOnly => promise.interrupt.unit
+            // Defect: convert to a typed error, settle, and evict — never leave the promise uncompleted.
+            case Right(c) =>
+              val defect = c.dieOption.getOrElse(new RuntimeException(c.prettyPrint))
+              lock.withPermit(remove *> promise.fail(FeatureFlagError.ProviderInitializationFailed(defect))).unit
+          },
         client =>
           lock.withPermit {
             zioApiHooksRef.get.flatMap(client.addZioApiHooks) *> promise.succeed(client)

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -703,18 +703,28 @@ object FeatureFlags {
       // Register the API shutdown finalizer BEFORE the provider, so a failure later in the build
       // (e.g. getClient) still tears down the registered provider when the scope closes.
       _ <- ZIO.when(addShutdownFinalizer)(ZIO.addFinalizer(ZIO.attemptBlocking(api.shutdown()).ignore))
-      // Register provider FIRST so the client binds to it (not the NoOp default)
+      // Register provider FIRST so the client binds to it (not the NoOp default). Use `ZIO.attempt` (not
+      // `ZIO.succeed`) so a synchronous throw from registration — a null provider, or a provider whose
+      // `getMetadata` throws while the SDK reads its name — surfaces in the typed Throwable channel instead of
+      // becoming a defect. As a defect it would escape `buildClient`'s `mapError` and the registry's build
+      // fiber would die with its promise never settled, hanging every `getClient` for that domain forever.
+      // `ZIO.attempt` (not `attemptBlocking`): `setProvider` is the non-blocking registration call — it submits
+      // `initialize()` to the SDK's background executor and returns after cheap bookkeeping, so there is no
+      // blocking I/O to move off the compute pool. (The sync `build` path uses `attemptBlocking` because
+      // `setProviderAndWait` genuinely blocks the thread for the whole initialization.)
       _ <- domain match {
-        case Some(d) => ZIO.succeed(api.setProvider(d, provider))
-        case None    => ZIO.succeed(api.setProvider(provider))
+        case Some(d) => ZIO.attempt(api.setProvider(d, provider))
+        case None    => ZIO.attempt(api.setProvider(provider))
       }
       client <- (domain, version) match {
         case (Some(d), Some(v)) => ZIO.attempt(api.getClient(d, v))
         case (Some(d), None)    => ZIO.attempt(api.getClient(d))
         case _                  => ZIO.attempt(api.getClient())
       }
-      providerName = Option(provider.getMetadata).map(_.getName).getOrElse("unknown")
-      providerRef <- Ref.make(provider)
+      // `ZIO.attempt` for the same reason as the registration above: a throwing `getMetadata` here must be a
+      // typed failure, not a defect that strands the registry build fiber (see the `setProvider` note).
+      providerName <- ZIO.attempt(Option(provider.getMetadata).map(_.getName).getOrElse("unknown"))
+      providerRef  <- Ref.make(provider)
       providerNameRef = new java.util.concurrent.atomic.AtomicReference(providerName)
       swapLock  <- Semaphore.make(1)
       baseState <- FeatureFlagsState.make

--- a/core/src/test/scala/zio/openfeature/FeatureFlagRegistrySpec.scala
+++ b/core/src/test/scala/zio/openfeature/FeatureFlagRegistrySpec.scala
@@ -274,6 +274,46 @@ object FeatureFlagRegistrySpec extends ZIOSpecDefault {
           meta     <- client.providerMetadata
         } yield assertTrue(meta.name == "Billing")
       }
+    },
+    test("getClient does not hang when registration throws synchronously; failure is typed and retryable (#242)") {
+      ZIO.scoped {
+        val defaultProvider = new SimpleProvider("Default", Map("flag" -> "default"))
+        // Throws synchronously when the registry reads its metadata / registers it with the SDK — the
+        // buildAsync defect path (getMetadata / api.setProvider), NOT an async initialize() failure.
+        val throwingProvider = new SimpleProvider("Throwing", Map.empty) {
+          @scala.annotation.nowarn("msg=deprecated")
+          override def getMetadata: Metadata =
+            throw new RuntimeException("metadata boom")
+        }
+        val goodProvider = new SimpleProvider("Good", Map("flag" -> "good"))
+        for {
+          registry <- registryLayer(defaultProvider).build.map(_.get[FeatureFlagRegistry])
+          // Live clock so the regression guard (a hang) is bounded in real time; the registry's own
+          // readiness poll uses blocking sleeps, so the default frozen TestClock would never fire timeout.
+          result <- Live.live(
+            (for {
+              _      <- registry.setProvider("bad", throwingProvider)
+              first  <- registry.getClient("bad").exit
+              _      <- registry.setProvider("bad", goodProvider)
+              client <- registry.getClient("bad")
+              v      <- client.string("flag", default = "none")
+            } yield (first, v)).timeout(15.seconds)
+          )
+        } yield result match {
+          case Some((first, v)) =>
+            assertTrue(
+              first.isFailure,
+              first match {
+                case Exit.Failure(cause) =>
+                  cause.failureOption.exists(_.isInstanceOf[FeatureFlagError.ProviderInitializationFailed])
+                case _ => false
+              },
+              v == "good"
+            )
+          case None =>
+            assertTrue(false) // timed out → getClient hung (regression)
+        }
+      }
     }
   )
 }

--- a/core/src/test/scala/zio/openfeature/ProviderInitFailureSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderInitFailureSpec.scala
@@ -103,6 +103,18 @@ object ProviderInitFailureSpec extends ZIOSpecDefault {
     override def shutdown(): Unit = st.set(ProviderState.NOT_READY)
   }
 
+  /** Case 8a: provider whose `getMetadata` throws synchronously — exercises the `providerName <- ZIO.attempt(...)`
+    * guard in `buildAsync` directly (the registry test relies on `runBuild`'s backstop, so it can't isolate this).
+    */
+  final private class ThrowingMetadataProvider extends EvaluationStubs {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata = throw new RuntimeException("metadata boom")
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+  }
+
   private def uniqueDomain(label: String): String = s"init-failure-$label-${java.util.UUID.randomUUID()}"
 
   def spec = suite("ProviderInitFailureSpec")(
@@ -130,6 +142,61 @@ object ProviderInitFailureSpec extends ZIOSpecDefault {
         result.isLeft,
         // The Java SDK may wrap the original Throwable; check the message threads through.
         result.left.exists(t => Option(t.getMessage).exists(_.contains("synthetic init failure")))
+      )
+    } @@ withLiveClock,
+    test("[B2 / case 8a] buildAsync: a throwing getMetadata surfaces a typed failure, not a defect (#242)") {
+      val provider = new ThrowingMetadataProvider
+      val api      = OpenFeatureAPIFactory.create()
+      val build = ZIO.scoped {
+        FeatureFlags
+          .buildAsync(
+            provider,
+            domain = Some(uniqueDomain("throwing-metadata")),
+            version = None,
+            initialHooks = Nil,
+            statusRef = None,
+            addShutdownFinalizer = false,
+            apiOverride = Some(api),
+            initTimeout = 5.seconds
+          )
+          .unit
+      }
+      for {
+        exit <- build.exit
+      } yield assertTrue(
+        exit.isFailure,
+        // Typed Throwable in the failure channel, NOT a defect — before the fix this was a `Die`.
+        exit match {
+          case Exit.Failure(cause) => cause.failureOption.isDefined && cause.dieOption.isEmpty
+          case _                   => false
+        }
+      )
+    } @@ withLiveClock,
+    test("[B2 / case 8b] buildAsync: a null provider surfaces a typed failure from setProvider, not a defect (#242)") {
+      val nullProvider: dev.openfeature.sdk.FeatureProvider = null
+      val api                                               = OpenFeatureAPIFactory.create()
+      val build = ZIO.scoped {
+        FeatureFlags
+          .buildAsync(
+            nullProvider,
+            domain = Some(uniqueDomain("null-provider")),
+            version = None,
+            initialHooks = Nil,
+            statusRef = None,
+            addShutdownFinalizer = false,
+            apiOverride = Some(api),
+            initTimeout = 5.seconds
+          )
+          .unit
+      }
+      for {
+        exit <- build.exit
+      } yield assertTrue(
+        exit.isFailure,
+        exit match {
+          case Exit.Failure(cause) => cause.failureOption.isDefined && cause.dieOption.isEmpty
+          case _                   => false
+        }
       )
     } @@ withLiveClock,
     test("[B2 / case 5] async provider fires PROVIDER_ERROR after init -> evaluations fail with ProviderNotReady") {


### PR DESCRIPTION
## Summary
- Root cause: `FeatureFlags.buildAsync` wrapped the synchronous Java SDK registration calls (`api.setProvider`, `provider.getMetadata`) in `ZIO.succeed`, so a throw became a ZIO *defect* instead of a typed error; combined with `FeatureFlagRegistry.runBuild` using `foldZIO` (typed failures only), such a defect left the per-domain `Promise` never settled and never evicted — every `getClient(domain)` caller then blocked forever.
- Fix: `buildAsync` now uses `ZIO.attempt` for the registration and metadata reads (surfacing throws as typed `ProviderInitializationFailed`); `runBuild` uses `foldCauseZIO` to settle the promise and evict the entry on ANY cause (typed failure or defect), restoring the documented "a failed init is not cached — a subsequent call retries" contract. Used `ZIO.attempt` (not `attemptBlocking`) because `setProvider` is the non-blocking registration call.
- Tests: a registry-level regression test (`getClient does not hang...` in FeatureFlagRegistrySpec) plus two direct `buildAsync`-level tests (`[B2 / case 8a]` getMetadata-throw, `[B2 / case 8b]` null-provider) in ProviderInitFailureSpec asserting a typed `Fail`, not a `Die`. CHANGELOG updated.
- Note: the sync `build` path was intentionally left unchanged (it surfaces defects as visible layer-build failures, not registry hangs — out of scope).

Closes #242