### PR TITLE
FeatureFlags.shutdown unconditionally shuts down the shared OpenFeatureAPI, killing all other domain clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `getClient(domain)` caller blocked forever. Registration is now wrapped in `ZIO.attempt` (surfacing throws as typed
   `ProviderInitializationFailed`), and `runBuild` settles and evicts the entry on any failure cause (typed or defect),
   restoring the documented "a failed initialization is not cached — a subsequent call retries" contract.
+- **`FeatureFlags.shutdown` no longer tears down sibling clients that share an `OpenFeatureAPI`** (#243). `shutdown`
+  called `api.shutdown()` unconditionally, so shutting down one client shut down every other client on the same API —
+  including, for the `FeatureFlagRegistry` (whose domain clients share one API) and the global-singleton factories,
+  clients the caller never touched. `shutdown` now only shuts the API when the instance solely owns it; a shared-API
+  (registry/domain) client leaves the shared API and its provider untouched — both are owned by whatever owns the API
+  (e.g. the registry, which tears every provider down once on its own scope close) — and releases only its own state.
 
 ## [1.0.0] — unreleased
 

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -199,9 +199,17 @@ trait FeatureFlags {
     *
     * The status transitions to `ShuttingDown` for the duration of the teardown (evaluations started in that window fail
     * with `ProviderNotReady(ShuttingDown)`) and ends at `NotReady`. Client-level and ZIO API-level hooks, the global
-    * and client contexts, and the tracked-events recorder are cleared; the event hub is shut down and the underlying
-    * OpenFeature API (and with it the provider) is shut down. Fiber-local context and any in-flight transaction state
-    * are fiber-scoped and unaffected.
+    * and client contexts, and the tracked-events recorder are cleared, and the event hub is shut down.
+    *
+    * Provider/API teardown depends on ownership. An instance created by a sole-owner factory (e.g. `fromProvider` /
+    * `fromProviderAsync`) shuts down the underlying OpenFeature API, and with it its provider. An instance that shares
+    * its API with siblings — a client obtained from `FeatureFlagRegistry`, or any domain-scoped client — leaves the
+    * shared API and its provider untouched (both belong to whatever owns the API, which tears every provider down once
+    * when its own scope closes), releasing only this instance's own state; such clients should be retired via whatever
+    * owns the API's lifecycle (e.g. the registry). Note that a domain-scoped client created directly on the
+    * process-global API (e.g. `fromProviderWithDomain`) has no such owner: neither `shutdown` nor scope close reclaims
+    * its provider, so for a resource-heavy provider prefer a sole-owner factory (or the registry), or shut the global
+    * API down yourself. Fiber-local context and any in-flight transaction state are fiber-scoped and unaffected.
     */
   def shutdown: UIO[Unit]
 
@@ -531,6 +539,9 @@ object FeatureFlags {
         version,
         state,
         api,
+        // Owns the api iff we also register the api-shutdown scope finalizer — keeps explicit `shutdown` and
+        // scope-close teardown consistent, so a shared-api (registry/domain) client never shuts the whole api.
+        ownsApi = addShutdownFinalizer,
         swapLock,
         onReady,
         evaluationTimeout
@@ -738,6 +749,9 @@ object FeatureFlags {
         version,
         state,
         api,
+        // Owns the api iff we also register the api-shutdown scope finalizer — keeps explicit `shutdown` and
+        // scope-close teardown consistent, so a shared-api (registry/domain) client never shuts the whole api.
+        ownsApi = addShutdownFinalizer,
         swapLock,
         onReady,
         evaluationTimeout

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -25,6 +25,10 @@ final private[openfeature] class FeatureFlagsLive(
   version: Option[String],
   state: FeatureFlagsState,
   api: OpenFeatureAPI,
+  // True when this instance solely owns `api` (the sole-owner factories that also register the api-shutdown scope
+  // finalizer). When false — a registry/domain client sharing an api (and possibly a provider) with sibling clients —
+  // `shutdown` must NOT touch the shared api or provider; both belong to whatever owns the api's lifecycle.
+  ownsApi: Boolean,
   swapLock: Semaphore,
   onReady: Option[java.util.concurrent.CountDownLatch] = None,
   evaluationTimeout: Option[Duration] = Some(FeatureFlags.DefaultEvaluationTimeout)
@@ -853,7 +857,15 @@ final private[openfeature] class FeatureFlagsLive(
       state.clientContextRef.set(EvaluationContext.empty) *>
       state.trackRecorder.set(Chunk.empty) *>
       state.eventHub.shutdown *>
-      ZIO.attemptBlocking(api.shutdown()).ignore *>
+      // Only tear down the provider/API when this instance solely owns the API (the sole-owner factories). A
+      // non-owning instance — a registry/domain client that shares its API, and possibly its provider, with sibling
+      // clients — must NOT shut the API or the provider: both belong to whatever owns the API (e.g. the registry,
+      // which shuts every registered provider exactly once when its own scope closes). Shutting the API here would
+      // kill sibling clients (the #243 bug); shutting the provider directly would kill siblings that share it (the
+      // registry falls back to one shared default provider) and double-shut a provider the API still has registered.
+      // A non-owning `shutdown` therefore releases only this instance's own state (status/hooks/contexts/event hub,
+      // torn down above); retire such clients via whatever owns the API (e.g. the registry).
+      ZIO.when(ownsApi)(ZIO.attemptBlocking(api.shutdown()).ignore) *>
       state.statusRef.set(ProviderStatus.NotReady)
 
   // Tracking API

--- a/core/src/test/scala/zio/openfeature/FeatureFlagsShutdownSpec.scala
+++ b/core/src/test/scala/zio/openfeature/FeatureFlagsShutdownSpec.scala
@@ -1,0 +1,90 @@
+package zio.openfeature
+import zio.openfeature.internal.ProviderEvaluations
+
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderState,
+  Value
+}
+import zio._
+import zio.test._
+import zio.test.TestAspect.withLiveClock
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Covers shutdown ownership (#243): `shutdown` on a client that does NOT own its `OpenFeatureAPI` must not tear down
+  * the shared api or its provider (both belong to the api owner) — otherwise it kills sibling clients. A sole-owner
+  * client still shuts the api (which cascades to every provider registered on it).
+  */
+object FeatureFlagsShutdownSpec extends ZIOSpecDefault {
+
+  private class TrackingProvider(name: String, shutCalled: AtomicBoolean) extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = name }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = shutCalled.set(true)
+
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](d, "DEFAULT")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  private def uniqueDomain(label: String): String = s"shutdown-$label-${java.util.UUID.randomUUID()}"
+
+  private def buildShared(name: String, shut: AtomicBoolean, owns: Boolean, api: dev.openfeature.sdk.OpenFeatureAPI) =
+    FeatureFlags.buildAsync(
+      new TrackingProvider(name, shut),
+      domain = Some(uniqueDomain(name)),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = owns,
+      apiOverride = Some(api)
+    )
+
+  def spec = suite("FeatureFlagsShutdownSpec")(
+    test("shutdown on a non-owning (shared-api) client shuts down neither the shared api nor any provider (#243)") {
+      val shutA = new AtomicBoolean(false)
+      val shutB = new AtomicBoolean(false)
+      val api   = OpenFeatureAPIFactory.create()
+      ZIO.scoped {
+        for {
+          ffA     <- buildShared("A", shutA, owns = false, api)
+          _       <- buildShared("B", shutB, owns = false, api)
+          _       <- ffA.shutdown
+          statusA <- ffA.providerStatus
+        } yield assertTrue(
+          !shutA.get(),                      // own provider is left to the api owner
+          !shutB.get(),                      // sibling's provider is untouched
+          statusA == ProviderStatus.NotReady // ...but ffA did release its own state
+        )
+      }
+    } @@ withLiveClock,
+    test("shutdown on a sole-owner client shuts the shared api, cascading to siblings (#243 regression)") {
+      val shutOwn = new AtomicBoolean(false)
+      val shutSib = new AtomicBoolean(false)
+      val api     = OpenFeatureAPIFactory.create()
+      ZIO.scoped {
+        for {
+          ffOwn <- buildShared("Own", shutOwn, owns = true, api)
+          _     <- buildShared("Sib", shutSib, owns = false, api)
+          _     <- ffOwn.shutdown
+        } yield assertTrue(
+          shutOwn.get(), // api.shutdown() shut the owner's provider
+          shutSib.get()  // ...and cascaded to every provider on the api — proving api.shutdown() actually fired
+        )
+      }
+    } @@ withLiveClock
+  )
+}


### PR DESCRIPTION
Closes #243

## Root cause
`FeatureFlagsLive.shutdown` called `api.shutdown()` unconditionally, but the `OpenFeatureAPI` is frequently shared: `FeatureFlagRegistry` domain clients share one `OpenFeatureAPIFactory.create()` instance, and `fromProvider`/`fromProviderAsync` use the JVM-global `OpenFeatureAPI.getInstance()`. So shutting down one client tore down every sibling client on that API.

## Fix
Added an `ownsApi` flag to `FeatureFlagsLive`, set to `addShutdownFinalizer` — the same flag that decides whether the api-shutdown scope finalizer is registered, so explicit `shutdown` and scope-close teardown stay consistent. `shutdown` now shuts the API only when the instance solely owns it. A non-owning (registry/domain) client shuts down **neither the shared API nor any provider** — both belong to whatever owns the API (e.g. the registry, which shuts every provider once on its own scope close) — releasing only its own instance state (status → NotReady, hooks/contexts/event hub).

## Design note for reviewers
An earlier approach shut the client's *own provider* directly instead of the API. Review found the registry falls back to a single shared `defaultProvider` instance, so that would still kill siblings sharing that provider, and would double-shut a provider the API still has registered (registry scope-close then calls `api.shutdown()`). The final approach therefore touches **no** shared resource for non-owning clients.

Trade-off (documented in the `shutdown` ScalaDoc): a `fromProviderWithDomain` client created directly on the process-global API has no owner that reclaims its provider, so for resource-heavy providers users should prefer a sole-owner factory or the registry. This is strictly better than the prior behavior (which reclaimed it only by nuking the global singleton — the bug).

## Tests
`FeatureFlagsShutdownSpec` (new):
- non-owning shutdown on a shared API shuts neither the API nor any provider, and sets its own status to NotReady;
- owning shutdown cascades `api.shutdown()` to a sibling on the same API — proving the API was actually shut (a real discriminator).

Both use the exact construction shape as the registry's `buildClient` (`buildAsync` + `addShutdownFinalizer=false` + shared `apiOverride`), so they faithfully cover the registry domain-client scenario. A registry-level test was intentionally not added: the OF Java SDK asynchronously shuts providers during registry setup regardless of this fix, making provider-shutdown tracking a non-discriminator there.

Updated `FeatureFlags.shutdown` ScalaDoc and CHANGELOG.
