### PR TITLE
Non-blocking provider initialization: fromAcquireAsync (fallback-first), DeferredProvider, and awaitReady

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Non-blocking provider initialization** (#241). Three additions so provider construction never sits on the
+  application boot path:
+  - **`FeatureFlags.fromAcquireAsync`** — a fallback-first async factory (`URLayer[Scope, FeatureFlags]`). It takes the
+    real provider *as an effect*, builds the layer immediately on a fresh fallback (status `Ready` from time zero,
+    evaluations answer fallback values), constructs the real provider in a background scoped fiber with retry/timeout,
+    and hot-swaps it in when ready. Terminal construction failures run `onConstructionError` and stay on the fallback;
+    the `Nothing` error channel proves at compile time that no provider failure can fail the app's layer graph. Covers
+    both constructor-blocking and `initialize()`-blocking providers.
+  - **`zio.openfeature.extras.DeferredProvider`** — adapts a constructor-blocking provider into an `initialize()`-blocking
+    one, deferring construction to the SDK init executor. Stable metadata name, typed `PROVIDER_NOT_READY` before ready,
+    a state machine that handles `shutdown()` racing an in-flight `initialize()`, and hook forwarding.
+  - **`FeatureFlags.awaitReady(within)`** — semantically blocks until the provider is evaluable (`Ready`/`Stale`),
+    returns early on `Fatal`, or times out, returning the status at that moment. Backed by a status change stream (no
+    polling) and safe for many concurrent waiters; ideal for `/ready` probes. The internal provider-status ref is now a
+    `SubscriptionRef`, and the async init watchdog's `Fatal` transition now releases the `onReady` latch and is
+    observable via `awaitReady`.
+
 ### Changed
 
 - **Bump `dev.openfeature:sdk` to 1.21.0** (#239). Per-provider error detail in multi-provider strategies and

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
@@ -1,6 +1,7 @@
 package zio.openfeature.conformance.bdd
 
 import zio._
+import zio.stream.SubscriptionRef
 import zio.bdd.core.Suite
 import zio.bdd.core.Assertions.assertTrue
 import zio.bdd.core.step.{State, ZIOSteps}
@@ -45,7 +46,7 @@ object ConformanceSpec extends ZIOSteps[Any, World] {
   // released by the `afterScenario` hook below — no global/leaked scope.
   private def buildInMemory(sc: Scope.Closeable): ZIO[Any, Throwable, FeatureFlags] =
     for {
-      statusRef <- Ref.make[ProviderStatus](ProviderStatus.Ready)
+      statusRef <- SubscriptionRef.make[ProviderStatus](ProviderStatus.Ready)
       api    = OpenFeatureAPIFactory.create()
       domain = s"bdd-${java.util.UUID.randomUUID()}"
       env <- sc.extend[Any](

--- a/conformance/src/test/scala/zio/openfeature/conformance/ConformanceSteps.scala
+++ b/conformance/src/test/scala/zio/openfeature/conformance/ConformanceSteps.scala
@@ -3,6 +3,7 @@ package zio.openfeature.conformance
 import io.cucumber.datatable.DataTable
 import io.cucumber.scala.{EN, ScalaDsl}
 import zio._
+import zio.stream.SubscriptionRef
 import zio.openfeature._
 import zio.openfeature.testkit.TestFeatureProvider
 import dev.openfeature.sdk.{EvaluationContext => OFEvaluationContext, OpenFeatureAPIFactory}
@@ -63,7 +64,7 @@ class ConformanceSteps extends ScalaDsl with EN {
 
   private def setupInMemory(): Unit = {
     val sc        = openScope()
-    val statusRef = run(Ref.make[ProviderStatus](ProviderStatus.Ready))
+    val statusRef = run(SubscriptionRef.make[ProviderStatus](ProviderStatus.Ready))
     val api       = OpenFeatureAPIFactory.create()
     val domain    = s"conf-${java.util.UUID.randomUUID()}"
     val ff = run(

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -136,6 +136,14 @@ trait FeatureFlags {
 
   def events: ZStream[Any, Nothing, ProviderEvent]
   def providerStatus: UIO[ProviderStatus]
+
+  /** Semantically block until the provider reaches an evaluable state (`canEvaluate` — Ready/Stale), returns early on
+    * `Fatal`, or `within` elapses — returning the status at that moment in every case. Backed by the status change
+    * stream (no polling), and safe for many concurrent waiters. Ideal for `/ready` probes:
+    * `ff.awaitReady(5.seconds).map(_.canEvaluate)`.
+    */
+  def awaitReady(within: Duration = Duration.Infinity): UIO[ProviderStatus]
+
   def providerMetadata: UIO[ProviderMetadata]
   def clientMetadata: UIO[ClientMetadata]
 
@@ -369,6 +377,9 @@ object FeatureFlags {
   def providerStatus: ZIO[FeatureFlags, Nothing, ProviderStatus] =
     ZIO.serviceWithZIO(_.providerStatus)
 
+  def awaitReady(within: Duration = Duration.Infinity): ZIO[FeatureFlags, Nothing, ProviderStatus] =
+    ZIO.serviceWithZIO(_.awaitReady(within))
+
   def providerMetadata: ZIO[FeatureFlags, Nothing, ProviderMetadata] =
     ZIO.serviceWithZIO(_.providerMetadata)
 
@@ -491,7 +502,7 @@ object FeatureFlags {
     domain: Option[String],
     version: Option[String],
     initialHooks: List[FeatureHook],
-    statusRef: Option[Ref[ProviderStatus]],
+    statusRef: Option[SubscriptionRef[ProviderStatus]],
     addShutdownFinalizer: Boolean,
     apiOverride: Option[OpenFeatureAPI] = None,
     evaluationTimeout: Option[Duration] = Some(DefaultEvaluationTimeout),
@@ -640,7 +651,7 @@ object FeatureFlags {
   private[openfeature] def fromProviderWithDomain(
     provider: OFFeatureProvider,
     domain: String,
-    statusRef: Ref[ProviderStatus],
+    statusRef: SubscriptionRef[ProviderStatus],
     api: Option[OpenFeatureAPI] = None,
     onReady: Option[java.util.concurrent.CountDownLatch] = None
   ): ZLayer[Scope, Throwable, FeatureFlags] =
@@ -702,7 +713,7 @@ object FeatureFlags {
     domain: Option[String],
     version: Option[String],
     initialHooks: List[FeatureHook],
-    statusRef: Option[Ref[ProviderStatus]],
+    statusRef: Option[SubscriptionRef[ProviderStatus]],
     addShutdownFinalizer: Boolean,
     apiOverride: Option[OpenFeatureAPI] = None,
     onReady: Option[java.util.concurrent.CountDownLatch] = None,
@@ -768,7 +779,15 @@ object FeatureFlags {
           case ProviderStatus.NotReady | ProviderStatus.Error => (true, ProviderStatus.Fatal)
           case other                                          => (false, other)
         }
-        .flatMap(transitioned => ZIO.when(transitioned)(ZIO.attemptBlocking(provider.shutdown()).ignore))).forkScoped
+        .flatMap(transitioned =>
+          ZIO.when(transitioned)(
+            // Fatal is terminal. Shut the provider down (its poller/HTTP threads must not outlive the layer) and
+            // release the onReady latch so latch-waiters (registry handshake, `awaitReady` seeded from the latch)
+            // don't hang forever. The transition itself is observable via `statusRef.changes` (see `awaitReady`).
+            ZIO.attemptBlocking(provider.shutdown()).ignore *>
+              ZIO.succeed(onReady.foreach(_.countDown()))
+          )
+        )).forkScoped
     } yield ff
 
   /** Create a FeatureFlags layer from any OpenFeature provider (non-blocking).
@@ -873,7 +892,7 @@ object FeatureFlags {
   private[openfeature] def fromProviderWithDomainAsync(
     provider: OFFeatureProvider,
     domain: String,
-    statusRef: Ref[ProviderStatus],
+    statusRef: SubscriptionRef[ProviderStatus],
     api: Option[OpenFeatureAPI] = None,
     onReady: Option[java.util.concurrent.CountDownLatch] = None
   ): ZLayer[Scope, Throwable, FeatureFlags] =
@@ -920,4 +939,97 @@ object FeatureFlags {
     import scala.jdk.CollectionConverters._
     fromProviderAsync(new MultiProvider(providers.asJava, strategy))
   }
+
+  /** Default `compose` for [[fromAcquireAsync]]: layer the real provider over the fallback with a first-successful
+    * strategy, so a sick real provider transparently falls through to the fallback. `MultiProvider` keys children by
+    * their metadata name and silently drops duplicates — the real and fallback providers must therefore have distinct
+    * names (rename one if they collide).
+    */
+  def defaultAcquireCompose(real: OFFeatureProvider, fallback: OFFeatureProvider): OFFeatureProvider = {
+    import scala.jdk.CollectionConverters._
+    new MultiProvider(List(real, fallback).asJava, new FirstSuccessfulStrategy())
+  }
+
+  /** Fallback-first async factory: build the layer immediately on a fresh `fallback`, construct the real provider in a
+    * background scoped fiber, and hot-swap it in when ready.
+    *
+    * Unlike every other factory, this takes the real provider **as an effect** (`acquire`) rather than a strict,
+    * already-constructed instance — so a provider whose Java constructor does network I/O never runs on the
+    * application's boot path. The layer's error channel is `Nothing` (`URLayer`): a failing real provider is handled
+    * internally (retried, then `onConstructionError`, then left on the fallback), so the compiler proves no
+    * provider-related failure can propagate into the application's layer graph.
+    *
+    *   - Status is `Ready` from time zero; evaluations answer fallback values (never `ProviderNotReady`) until the
+    *     swap.
+    *   - `acquire` runs with `.retry(constructionRetry)`, each attempt bounded by `constructionTimeout`. On terminal
+    *     failure, `onConstructionError` runs and the instance stays on the fallback.
+    *   - The composed stack uses a **fresh** fallback instance (the SDK shuts down the replaced provider on swap, so
+    *     the first fallback must not be reused). Hooks, contexts, and event handlers survive the swap.
+    *   - The construction fiber is scope-owned: layer release interrupts an in-flight `acquire`. A real provider
+    *     acquired but not yet swapped is torn down by scope close **when `acquire` registers it in its `Scope`** (e.g.
+    *     via `ZIO.acquireRelease`); a bare `attemptBlocking(new Provider(...))` registers no finalizer, so teardown of
+    *     the not-yet-swapped provider is then the caller's responsibility.
+    *
+    * @param acquire
+    *   the real provider as a scoped effect (typically `ZIO.attemptBlocking(new Provider(...))`)
+    * @param fallback
+    *   a scoped effect producing a FRESH fallback instance each time it is run
+    * @param compose
+    *   how to combine (real, freshFallback) into the swapped-in provider
+    * @param constructionRetry
+    *   retry policy for `acquire`
+    * @param constructionTimeout
+    *   per-attempt bound on `acquire`
+    * @param onConstructionError
+    *   run when `acquire` (or the swap) ultimately fails; the instance stays on the fallback
+    */
+  def fromAcquireAsync(
+    acquire: RIO[Scope, OFFeatureProvider],
+    fallback: URIO[Scope, OFFeatureProvider],
+    compose: (OFFeatureProvider, OFFeatureProvider) => OFFeatureProvider = defaultAcquireCompose,
+    constructionRetry: Schedule[Any, Throwable, Any] = Schedule.recurs(3) && Schedule.exponential(1.second).jittered,
+    constructionTimeout: Duration = DefaultInitTimeout,
+    onConstructionError: Throwable => UIO[Unit] = _ => ZIO.unit,
+    evaluationTimeout: Duration = DefaultEvaluationTimeout,
+    initTimeout: Duration = DefaultInitTimeout
+  ): URLayer[Scope, FeatureFlags] =
+    ZLayer.scoped {
+      for {
+        // Build immediately on a fresh fallback. An in-memory fallback whose init fails is a programming bug, not a
+        // recoverable condition, so a failed build is a defect (`orDie`) — this is what makes the layer a `URLayer`.
+        firstFallback <- fallback
+        ff <- build(
+          firstFallback,
+          domain = None,
+          version = None,
+          initialHooks = Nil,
+          statusRef = None,
+          addShutdownFinalizer = true,
+          evaluationTimeout = Some(evaluationTimeout),
+          initTimeout = initTimeout
+        ).orDie
+        // Background construction + swap. `acquire`'s Scope is the layer scope, so the acquired real provider is torn
+        // down on layer release even if it was never swapped in. The fiber is `forkScoped`, so an in-flight acquire is
+        // interrupted on release. A terminal construction/swap failure is caught, reported, and left on the fallback —
+        // nothing escapes to the (already-built) layer.
+        construct = for {
+          real <- acquire.disconnect
+            // `.disconnect` so the per-attempt timeout returns promptly even when `acquire` is an uninterruptible
+            // `attemptBlocking(new Provider(...))` — the underlying constructor may keep running in the background, but
+            // the retry advances instead of waiting on a hung attempt.
+            .timeoutFail(new TimeoutException(s"Provider construction exceeded $constructionTimeout"))(
+              constructionTimeout
+            )
+            .retry(constructionRetry)
+          freshFallback <- fallback
+          _ <- ff
+            .setProvider(compose(real, freshFallback))
+            // `setProvider`'s rollback restored the live fallback to the provider ref but left status `Error`; the
+            // fallback is still serving, so force status back to Ready before reporting the failure.
+            .tapError(_ => ff.forceReady)
+            .mapError(e => new RuntimeException(s"Provider swap failed: $e"))
+        } yield ()
+        _ <- construct.catchAll(onConstructionError).forkScoped
+      } yield ff
+    }
 }

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -674,6 +674,25 @@ final private[openfeature] class FeatureFlagsLive(
   override def providerStatus: UIO[ProviderStatus] =
     state.statusRef.get
 
+  // Force status back to Ready. Used by `fromAcquireAsync` when a hot-swap to the real provider fails: `setProvider`'s
+  // rollback restores the still-live fallback to `providerRef` but leaves status `Error`, which would fail every
+  // evaluation with `ProviderNotReady(Error)` despite a usable fallback. Package-private — not part of the public API.
+  private[openfeature] def forceReady: UIO[Unit] =
+    state.statusRef.set(ProviderStatus.Ready)
+
+  override def awaitReady(within: Duration): UIO[ProviderStatus] =
+    // `.changes` emits the current status first (so an already-Ready provider returns immediately) then every
+    // subsequent transition — no polling. `runHead` completes on the first evaluable-or-Fatal status. On timeout
+    // (`None`) or an exhausted stream we return the then-current status, so every path yields a real status.
+    state.statusRef.changes
+      .filter(s => s.canEvaluate || s == ProviderStatus.Fatal)
+      .runHead
+      .timeout(within)
+      .flatMap {
+        case Some(Some(status)) => ZIO.succeed(status)
+        case _                  => state.statusRef.get
+      }
+
   override def providerMetadata: UIO[ProviderMetadata] =
     ZIO.succeed(ProviderMetadata(providerNameRef.get()))
 

--- a/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
+++ b/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
@@ -1,6 +1,7 @@
 package zio.openfeature.internal
 
 import zio._
+import zio.stream.SubscriptionRef
 import zio.openfeature._
 
 final case class FeatureFlagsState(
@@ -11,7 +12,10 @@ final case class FeatureFlagsState(
   zioApiHooksRef: Ref[List[FeatureHook]],
   hooksRef: Ref[List[FeatureHook]],
   eventHub: Hub[ProviderEvent],
-  statusRef: Ref[ProviderStatus],
+  // SubscriptionRef (not plain Ref) so status transitions are observable as a stream: every writer (event bridge,
+  // setProvider, watchdog, shutdown) already goes through this ref, so `.changes` sees all of them with no extra
+  // wiring. `awaitReady` consumes `.changes`; the ref still behaves as a Ref for all existing set/get/modify callers.
+  statusRef: SubscriptionRef[ProviderStatus],
   trackRecorder: Ref[Chunk[(String, EvaluationContext, Option[TrackingEventDetails])]]
 )
 
@@ -33,7 +37,7 @@ object FeatureFlagsState {
       hooksRef       <- Ref.make(List.empty[FeatureHook])
       // Bounded; subscribers reconcile via current state on next evaluation, so dropping intermediate events is safe.
       eventHub  <- Hub.dropping[ProviderEvent](256)
-      statusRef <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
+      statusRef <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
       trackRec  <- Ref.make(Chunk.empty[(String, EvaluationContext, Option[TrackingEventDetails])])
     } yield FeatureFlagsState(
       globalCtxRef,

--- a/core/src/main/scala/zio/openfeature/internal/ProviderEvaluations.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ProviderEvaluations.scala
@@ -1,6 +1,6 @@
 package zio.openfeature.internal
 
-import dev.openfeature.sdk.ProviderEvaluation
+import dev.openfeature.sdk.{ErrorCode, ProviderEvaluation, Reason}
 
 /** Builds [[ProviderEvaluation]] without fluently chaining off the Lombok-generated builder's self-type.
   *
@@ -30,6 +30,19 @@ private[openfeature] object ProviderEvaluations {
     builder.reason(reason)
     // build() returns the existentially-captured C (bounded by ProviderEvaluation[T]); widen explicitly since
     // that bound doesn't auto-widen across this method's declared return type.
+    builder.build().asInstanceOf[ProviderEvaluation[T]]
+  }
+
+  /** Build an error evaluation carrying the given error code (reason `ERROR`). The `value` is the caller's default — a
+    * typed error evaluation still returns a value rather than throwing, so callers never NPE. Uses the same
+    * stable-reference builder pattern as `of` to sidestep the Scala 2.13 existential-chain issue.
+    */
+  def error[T](value: T, errorCode: ErrorCode, errorMessage: String): ProviderEvaluation[T] = {
+    val builder = ProviderEvaluation.builder[T]()
+    builder.value(value)
+    builder.reason(Reason.ERROR.toString)
+    builder.errorCode(errorCode)
+    builder.errorMessage(errorMessage)
     builder.build().asInstanceOf[ProviderEvaluation[T]]
   }
 }

--- a/core/src/test/scala/zio/openfeature/NonBlockingInitSpec.scala
+++ b/core/src/test/scala/zio/openfeature/NonBlockingInitSpec.scala
@@ -1,0 +1,276 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.stream.SubscriptionRef
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  FeatureProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderState,
+  Value
+}
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+
+object NonBlockingInitSpec extends ZIOSpecDefault {
+
+  private def uniqueDomain(prefix: String): String = s"$prefix-${java.util.UUID.randomUUID()}"
+
+  /** Always-READY provider answering a fixed boolean for every key; records shutdown() invocations. */
+  private class FixedBoolProvider(nm: String, value: Boolean, shutdowns: AtomicInteger = new AtomicInteger(0))
+      extends FeatureProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { override def getName: String = nm }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = { shutdowns.incrementAndGet(); () }
+    def shutdownCount: Int                                  = shutdowns.get()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of(java.lang.Boolean.valueOf(value), "STATIC")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+  }
+
+  /** Provider whose initialize() blocks on a gate so the Java SDK never fires PROVIDER_READY — the status ref stays
+    * whatever the test drives it to. The gate is released on shutdown() (invoked by the api-shutdown finalizer at scope
+    * close), so no executor thread leaks.
+    */
+  private class InertProvider extends FeatureProvider {
+    private val gate = new CountDownLatch(1)
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { override def getName: String = "inert" }
+    override def getState: ProviderState                    = ProviderState.NOT_READY
+    override def initialize(ctx: OFEvaluationContext): Unit = gate.await()
+    override def shutdown(): Unit                           = gate.countDown()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+  }
+
+  private def buildControlled(
+    ref: SubscriptionRef[ProviderStatus],
+    provider: FeatureProvider,
+    onReady: Option[CountDownLatch] = None,
+    initTimeout: Duration = 1.hour
+  ): ZIO[Scope, Throwable, FeatureFlagsLive] =
+    FeatureFlags.buildAsync(
+      provider,
+      domain = Some(uniqueDomain("await")),
+      version = None,
+      initialHooks = Nil,
+      statusRef = Some(ref),
+      addShutdownFinalizer = true,
+      apiOverride = Some(OpenFeatureAPIFactory.create()),
+      onReady = onReady,
+      initTimeout = initTimeout
+    )
+
+  def spec = suite("NonBlockingInitSpec")(
+    // AC1
+    test("fromAcquireAsync builds instantly and answers fallback while acquire never completes") {
+      val acquire: RIO[Scope, FeatureProvider] =
+        ZIO.sleep(10.minutes) *> ZIO.succeed(new FixedBoolProvider("real", true))
+      val fallback = ZIO.succeed[FeatureProvider](new FixedBoolProvider("fb", false))
+      ZIO.scoped {
+        FeatureFlags.fromAcquireAsync(acquire, fallback).build.map(_.get[FeatureFlags]).flatMap { ff =>
+          for {
+            status <- ff.providerStatus
+            v      <- ff.boolean("x", true) // default true; fallback answers false, proving fallback is live
+          } yield assertTrue(status == ProviderStatus.Ready, !v)
+        }
+      }
+    },
+    // AC2
+    test("fromAcquireAsync: terminal acquire failure runs onConstructionError and stays on fallback") {
+      val fallback = ZIO.succeed[FeatureProvider](new FixedBoolProvider("fb", false))
+      for {
+        errP <- Promise.make[Nothing, Throwable]
+        acquire: RIO[Scope, FeatureProvider] = ZIO.fail(new RuntimeException("boom"))
+        result <- ZIO.scoped {
+          FeatureFlags
+            .fromAcquireAsync(
+              acquire,
+              fallback,
+              constructionRetry = Schedule.recurs(2), // no delay, fail fast after 3 attempts
+              onConstructionError = e => errP.succeed(e).unit
+            )
+            .build
+            .map(_.get[FeatureFlags])
+            .flatMap { ff =>
+              for {
+                err    <- errP.await
+                status <- ff.providerStatus
+                v      <- ff.boolean("x", true)
+              } yield assertTrue(err.getMessage == "boom", status == ProviderStatus.Ready, !v)
+            }
+        }
+      } yield result
+    },
+    // AC2b: swap failure (acquire succeeds, setProvider fails) must keep the instance usable on the fallback
+    test("fromAcquireAsync: swap failure stays usable on the fallback with an evaluable status") {
+      val fallback: URIO[Scope, FeatureProvider] = ZIO.succeed(new FixedBoolProvider("fb", false))
+      val acquire: RIO[Scope, FeatureProvider]   = ZIO.succeed(new FixedBoolProvider("real", true))
+      // compose returns a provider whose initialize() throws, so setProviderAndWait fails and rolls back to the fallback
+      val badCompose: (FeatureProvider, FeatureProvider) => FeatureProvider = (_, _) =>
+        new FixedBoolProvider("bad", true) {
+          override def initialize(c: OFEvaluationContext): Unit = throw new RuntimeException("init boom")
+        }
+      for {
+        errP <- Promise.make[Nothing, Throwable]
+        result <- ZIO.scoped {
+          FeatureFlags
+            .fromAcquireAsync(acquire, fallback, compose = badCompose, onConstructionError = e => errP.succeed(e).unit)
+            .build
+            .map(_.get[FeatureFlags])
+            .flatMap { ff =>
+              for {
+                _ <- errP.await
+                // forceReady must have restored an evaluable status (setProvider's rollback left it Error), so the
+                // instance stays usable instead of hard-failing every evaluation with ProviderNotReady(Error).
+                status <- ff.awaitReady(30.seconds)
+                v      <- ff.boolean("x", true).either
+              } yield assertTrue(status.canEvaluate, v.isRight)
+            }
+        }
+      } yield result
+    },
+    // AC3
+    test(
+      "fromAcquireAsync: successful swap preserves hooks and context, uses a fresh fallback, shuts the first fallback down once"
+    ) {
+      val fbShutdowns = new AtomicInteger(0)
+      val created     = new AtomicInteger(0)
+      val fallback = ZIO.succeed[FeatureProvider] {
+        created.incrementAndGet()
+        new FixedBoolProvider(s"fb-${created.get()}", false, fbShutdowns)
+      }
+      val acquire: RIO[Scope, FeatureProvider] = ZIO.succeed(new FixedBoolProvider("real", true))
+      val hook: FeatureHook                    = new FeatureHook {}
+      ZIO.scoped {
+        FeatureFlags
+          .fromAcquireAsync(acquire, fallback)
+          .build
+          .map(_.get[FeatureFlags])
+          .flatMap { ff =>
+            val marker = EvaluationContext.empty.withAttribute("marker", AttributeValue.StringValue("keep"))
+            for {
+              _ <- ff.addHook(hook)
+              _ <- ff.setGlobalContext(marker)
+              // Wait for the swap: the composed stack answers the real value (true) for the default-false call. The eval
+              // transiently fails with ProviderNotReady during the swap window, so tolerate that (`.either`) and retry.
+              swapped <- Live.live(
+                ff.boolean("x", false).either.repeatUntil(_ == Right(true)).timeout(30.seconds)
+              )
+              hooks    <- ff.hooks
+              ctx      <- ff.globalContext
+              createdN <- ZIO.succeed(created.get())
+              fbDown   <- ZIO.succeed(fbShutdowns.get())
+            } yield assertTrue(
+              swapped.contains(Right(true)),
+              hooks.contains(hook),                     // hooks survive the swap
+              ctx.getString("marker").contains("keep"), // context survives the swap
+              createdN == 2,                            // first fallback + fresh fallback
+              fbDown == 1                               // pre-swap fallback shut down exactly once
+            )
+          }
+      }
+    },
+    // AC4
+    test(
+      "fromAcquireAsync: scope close tears down a real provider acquired but not yet swapped, interrupting acquire"
+    ) {
+      val fallback = ZIO.succeed[FeatureProvider](new FixedBoolProvider("fb", false))
+      for {
+        released <- Ref.make(0)
+        acquired <- Promise.make[Nothing, Unit]
+        acquire: RIO[Scope, FeatureProvider] = ZIO
+          .acquireRelease(acquired.succeed(()).as(new FixedBoolProvider("real", true): FeatureProvider))(_ =>
+            released.update(_ + 1)
+          )
+          .zipRight(ZIO.never)
+        _ <- ZIO.scoped {
+          FeatureFlags.fromAcquireAsync(acquire, fallback).build.map(_.get[FeatureFlags]).flatMap { _ =>
+            acquired.await // return (and close the scope) once the real provider has been acquired
+          }
+        }
+        r <- released.get
+      } yield assertTrue(r == 1)
+    },
+    // AC6 (a) many concurrent waiters
+    test("awaitReady: many concurrent waiters all complete when status becomes Ready") {
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
+        out <- ZIO.scoped {
+          buildControlled(ref, new InertProvider).flatMap { ff =>
+            for {
+              waiters <- ZIO.foreach(1 to 8)(_ => ff.awaitReady().fork)
+              _       <- ref.set(ProviderStatus.Ready)
+              results <- ZIO.foreach(waiters)(_.join)
+            } yield assertTrue(results.forall(_ == ProviderStatus.Ready))
+          }
+        }
+      } yield out
+    },
+    // AC6 (b) Fatal returns promptly
+    test("awaitReady: returns Fatal when status transitions to Fatal") {
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
+        out <- ZIO.scoped {
+          buildControlled(ref, new InertProvider).flatMap { ff =>
+            ref.set(ProviderStatus.Fatal) *> ff.awaitReady().map(s => assertTrue(s == ProviderStatus.Fatal))
+          }
+        }
+      } yield out
+    },
+    // AC6 (c) timeout returns the then-current status, no polling
+    test("awaitReady: times out returning the then-current status") {
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
+        out <- ZIO.scoped {
+          buildControlled(ref, new InertProvider).flatMap { ff =>
+            for {
+              fiber  <- ff.awaitReady(1.second).fork
+              _      <- TestClock.adjust(1.second)
+              status <- fiber.join
+            } yield assertTrue(status == ProviderStatus.NotReady)
+          }
+        }
+      } yield out
+    },
+    // AC7 watchdog Fatal releases onReady latch and is observable via awaitReady
+    test("watchdog: Fatal transition releases the onReady latch and is observable via awaitReady") {
+      val latch = new CountDownLatch(1)
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
+        out <- ZIO.scoped {
+          buildControlled(ref, new InertProvider, onReady = Some(latch), initTimeout = 200.millis).flatMap { ff =>
+            for {
+              _      <- TestClock.adjust(200.millis)
+              status <- ff.awaitReady(5.seconds)
+              // The latch countdown happens after an attemptBlocking hop in the watchdog fiber, so poll for it rather
+              // than reading immediately (which could race the still-dispatching countdown).
+              count <- Live.live(ZIO.succeed(latch.getCount).repeatUntil(_ == 0L).timeout(5.seconds))
+            } yield assertTrue(status == ProviderStatus.Fatal, count.contains(0L))
+          }
+        }
+      } yield out
+    }
+  ) @@ TestAspect.sequential
+}

--- a/core/src/test/scala/zio/openfeature/ProviderInitFailureSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderInitFailureSpec.scala
@@ -2,6 +2,7 @@ package zio.openfeature
 import zio.openfeature.internal.ProviderEvaluations
 
 import zio._
+import zio.stream.SubscriptionRef
 import zio.test._
 import zio.test.TestAspect.{sequential, withLiveClock}
 import dev.openfeature.sdk.{
@@ -204,7 +205,7 @@ object ProviderInitFailureSpec extends ZIOSpecDefault {
       val api      = OpenFeatureAPIFactory.create()
       ZIO.scoped {
         for {
-          statusRef <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
+          statusRef <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
           ff <- FeatureFlags.buildAsync(
             provider,
             domain = Some(uniqueDomain("async-error")),
@@ -242,7 +243,7 @@ object ProviderInitFailureSpec extends ZIOSpecDefault {
       val api      = OpenFeatureAPIFactory.create()
       ZIO.scoped {
         for {
-          statusRef <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
+          statusRef <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
           ff <- FeatureFlags.buildAsync(
             provider,
             domain = Some(uniqueDomain("async-recovery")),
@@ -286,7 +287,7 @@ object ProviderInitFailureSpec extends ZIOSpecDefault {
       val api      = OpenFeatureAPIFactory.create()
       ZIO.scoped {
         for {
-          statusRef <- Ref.make[ProviderStatus](ProviderStatus.Ready)
+          statusRef <- SubscriptionRef.make[ProviderStatus](ProviderStatus.Ready)
           ff <- FeatureFlags.build(
             provider,
             domain = Some(uniqueDomain("classify-unreachable")),

--- a/core/src/test/scala/zio/openfeature/ProviderInitHardeningSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderInitHardeningSpec.scala
@@ -2,6 +2,7 @@ package zio.openfeature
 import zio.openfeature.internal.ProviderEvaluations
 
 import zio._
+import zio.stream.SubscriptionRef
 import zio.test._
 import zio.test.TestAspect.{withLiveClock, sequential}
 import dev.openfeature.sdk.{
@@ -195,7 +196,7 @@ object ProviderInitHardeningSpec extends ZIOSpecDefault {
       val api      = OpenFeatureAPIFactory.create()
       ZIO.scoped {
         for {
-          statusRef <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
+          statusRef <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
           _ <- FeatureFlags.buildAsync(
             provider,
             domain = Some(uniqueDomain("async-watchdog")),

--- a/docs/extras.md
+++ b/docs/extras.md
@@ -149,6 +149,30 @@ val provider = EnvVarProvider.withLookup(testEnv.get)
 
 ---
 
+## Deferred Provider
+
+`DeferredProvider` adapts a **constructor-blocking** provider — one that does all its network work in its Java constructor — into an `initialize()`-blocking one. It defers construction to `initialize(ctx)`, which the OpenFeature SDK runs on its own init executor, so every `*Async` factory (`fromProviderAsync`, `fromMultiProviderAsync`) already keeps that work off the caller's thread.
+
+```scala
+import zio.openfeature.extras.DeferredProvider
+
+// `construct` runs on the SDK init executor, not the layer-build thread
+val deferred = DeferredProvider("optimizely")(() => new CofOptimizelyLocalProvider(options))
+
+val layer = FeatureFlags.fromProviderAsync(deferred)
+```
+
+Behaviour:
+
+- **Stable metadata** — `getMetadata` returns the given name before and after construction, so the event bridge and `MultiProvider` keying see one identity.
+- **No NPE before ready** — evaluations before construction completes return a typed `ProviderEvaluation` with `ErrorCode.PROVIDER_NOT_READY`.
+- **Clean shutdown race** — `shutdown()` racing an in-flight `initialize()` shuts the delegate down once construction finishes, instead of leaking its poller/HTTP client.
+- **Hooks forwarded** — `getProviderHooks` delegates once active.
+
+Use `DeferredProvider` when you want plain async semantics (typed `PROVIDER_NOT_READY` until ready). When a fallback must *answer* during the init window, use [`FeatureFlags.fromAcquireAsync`](providers.md#fallback-first-initialization-fromacquireasync) instead — inside a `MultiProvider`, `DeferredProvider` still gates overall readiness, since the SDK awaits all children.
+
+---
+
 ## OFREP Provider
 
 Evaluates flags via the [OpenFeature Remote Evaluation Protocol](https://github.com/open-feature/protocol) (OFREP) — the standard HTTP protocol for vendor-neutral remote flag evaluation. Use this when your flags are served by an OFREP-compatible backend (flagd, OFREP relays, or any compliant server) and you want a vendor-agnostic client.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -501,6 +501,39 @@ yield result
 program.provide(Scope.default >>> FeatureFlags.fromProviderAsync(provider))
 ```
 
+### Fallback-first initialization (`fromAcquireAsync`)
+
+`fromProviderAsync` still takes a **strict, already-constructed** provider — so a provider whose *Java constructor* does the network work (e.g. the no-arg `HttpProjectConfigManager.build()`, which blocks up to 10s waiting for the first datafile) blocks the layer build before any factory runs. `fromAcquireAsync` closes that gap: it takes the real provider **as an effect**, builds the layer immediately on a fresh fallback, constructs the real provider in a background scoped fiber, and hot-swaps it in when ready.
+
+```scala
+import zio.openfeature.extras.EnvVarProvider
+
+val layer: URLayer[Scope, FeatureFlags] =
+  FeatureFlags.fromAcquireAsync(
+    acquire  = ZIO.attemptBlocking(new CofOptimizelyLocalProvider(options)), // constructor does the I/O
+    fallback = ZIO.succeed(EnvVarProvider()),                                // fresh instance per use
+    onConstructionError = e => ZIO.logWarning(s"Optimizely init failed, staying on EnvVar: ${e.getMessage}")
+  )
+```
+
+Key properties:
+
+- **`URLayer` (error channel `Nothing`)** — a failing real provider is retried, then reported to `onConstructionError`, then left on the fallback. The compiler proves no provider failure can fail your application's layer graph; there is nothing to `catchAll`.
+- **`Ready` from time zero** — the layer build is independent of `acquire` latency; evaluations answer *fallback* values (env-var kill-switches stay correct) instead of failing `ProviderNotReady` until the swap lands.
+- **Fresh fallback + preserved state** — the composed stack (`MultiProvider(real, fallback)` with `FirstSuccessfulStrategy` by default) uses a fresh fallback instance because the SDK shuts the replaced provider down on swap; hooks, contexts, and event handlers survive the swap.
+- **Scope-owned** — layer release interrupts an in-flight `acquire`. A real provider acquired but not yet swapped is torn down on scope close when `acquire` registers it in its `Scope` (e.g. via `ZIO.acquireRelease`); a bare `attemptBlocking(new Provider(...))` registers no finalizer, so teardown of the not-yet-swapped provider is then the caller's responsibility.
+
+For a constructor-blocking provider where you want plain async semantics (typed `PROVIDER_NOT_READY` until ready, no fallback), wrap it in [`DeferredProvider`](extras.md#deferredprovider) instead and pass it to `fromProviderAsync`.
+
+### Waiting for readiness (`awaitReady`)
+
+`awaitReady(within)` semantically blocks until the provider reaches an evaluable state (`Ready`/`Stale`), returns early on `Fatal`, or times out — returning the status at that moment in every case. It is backed by the status change stream (no polling) and safe for many concurrent waiters, which makes it the natural primitive for a `/ready` probe:
+
+```scala
+val readinessCheck: URIO[FeatureFlags, Boolean] =
+  ZIO.serviceWithZIO[FeatureFlags](_.awaitReady(5.seconds).map(_.canEvaluate))
+```
+
 ---
 
 ## Choosing a strategy — sync vs async, with vs without fallback

--- a/extras/src/main/scala/zio/openfeature/extras/DeferredProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/DeferredProvider.scala
@@ -1,0 +1,154 @@
+package zio.openfeature.extras
+
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  ErrorCode,
+  FeatureProvider,
+  Hook,
+  Metadata,
+  ProviderEvaluation,
+  ProviderState,
+  Value
+}
+import zio.openfeature.internal.ProviderEvaluations
+
+import java.util.concurrent.atomic.AtomicReference
+
+/** Adapts a constructor-blocking provider into an `initialize()`-blocking one.
+  *
+  * Some providers do all their network work in the Java constructor (blocking the call site). Wrapping such a provider
+  * in `DeferredProvider` defers construction to `initialize(ctx)`, which the OpenFeature SDK runs on its own init
+  * executor — so every existing `*Async` factory (`fromProviderAsync`, `fromMultiProviderAsync`) already keeps that
+  * work off the caller's thread. Use this when you want plain async semantics (typed `PROVIDER_NOT_READY` until ready);
+  * use [[zio.openfeature.FeatureFlags.fromAcquireAsync]] instead when a fallback must answer during the init window
+  * (inside a `MultiProvider`, `DeferredProvider` still gates overall readiness, since the SDK awaits all children).
+  *
+  *   - Metadata name is stable (`name`) before and after construction, so the event bridge and `MultiProvider` keying
+  *     see a single identity.
+  *   - Evaluations before construction completes return a typed `ProviderEvaluation` with
+  *     `ErrorCode.PROVIDER_NOT_READY` — never an NPE on the null delegate.
+  *   - `shutdown()` racing an in-flight `initialize()` shuts the delegate down once construction completes, instead of
+  *     leaking its poller / HTTP client.
+  *   - `getProviderHooks` forwards to the delegate once active.
+  *
+  * Limitation: wrapping an `EventProvider` does not forward its events — `DeferredProvider` is a plain
+  * `FeatureProvider`, which matches the typical constructor-blocking provider.
+  *
+  * @param name
+  *   stable metadata name reported before and after construction
+  * @param construct
+  *   builds the real provider; runs on the SDK init executor when `initialize` is called
+  */
+final class DeferredProvider(name: String)(construct: () => FeatureProvider) extends FeatureProvider {
+  import DeferredProvider._
+
+  private val stateRef = new AtomicReference[State](State.NotStarted)
+
+  @scala.annotation.nowarn("msg=deprecated")
+  override def getMetadata: Metadata = new Metadata {
+    override def getName: String = name
+  }
+
+  @scala.annotation.nowarn("msg=deprecated")
+  override def getState: ProviderState =
+    stateRef.get() match {
+      case State.Active(delegate) => delegate.getState
+      case _                      => ProviderState.NOT_READY
+    }
+
+  override def initialize(context: OFEvaluationContext): Unit =
+    // Only the first initialize() constructs; a second call (or one after shutdown) is a no-op.
+    if (stateRef.compareAndSet(State.NotStarted, State.Constructing)) {
+      // If construction throws, don't wedge in Constructing (which would report NOT_READY forever and no-op shutdown):
+      // move to Shutdown and rethrow so the SDK marks the provider errored.
+      val delegate =
+        try construct()
+        catch { case t: Throwable => stateRef.set(State.Shutdown); throw t }
+      // If delegate.initialize throws, the delegate is already built — shut it down so its poller/HTTP client doesn't
+      // leak, move to Shutdown, and rethrow.
+      try delegate.initialize(context)
+      catch {
+        case t: Throwable =>
+          stateRef.set(State.Shutdown)
+          delegate.shutdown()
+          throw t
+      }
+      // Publish the delegate — unless shutdown() raced in during construction, in which case the state is already
+      // Shutdown and we must tear the freshly built delegate down so its background threads don't leak.
+      if (!stateRef.compareAndSet(State.Constructing, State.Active(delegate)))
+        delegate.shutdown()
+    }
+
+  override def shutdown(): Unit =
+    stateRef.getAndSet(State.Shutdown) match {
+      case State.Active(delegate) => delegate.shutdown()
+      // Constructing: initialize() will observe the Shutdown state and shut the delegate down once it finishes
+      // constructing. NotStarted / Shutdown: nothing to release.
+      case _ => ()
+    }
+
+  override def getProviderHooks: java.util.List[Hook[_]] =
+    stateRef.get() match {
+      case State.Active(delegate) => delegate.getProviderHooks
+      case _                      => java.util.Collections.emptyList[Hook[_]]()
+    }
+
+  private def notReady[T](default: T): ProviderEvaluation[T] =
+    ProviderEvaluations.error(default, ErrorCode.PROVIDER_NOT_READY, s"Provider '$name' is not yet initialized")
+
+  private def delegateOr[T](default: T)(f: FeatureProvider => ProviderEvaluation[T]): ProviderEvaluation[T] =
+    stateRef.get() match {
+      case State.Active(delegate) => f(delegate)
+      case _                      => notReady(default)
+    }
+
+  override def getBooleanEvaluation(
+    key: String,
+    defaultValue: java.lang.Boolean,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Boolean] =
+    delegateOr(defaultValue)(_.getBooleanEvaluation(key, defaultValue, context))
+
+  override def getStringEvaluation(
+    key: String,
+    defaultValue: String,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[String] =
+    delegateOr(defaultValue)(_.getStringEvaluation(key, defaultValue, context))
+
+  override def getIntegerEvaluation(
+    key: String,
+    defaultValue: java.lang.Integer,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Integer] =
+    delegateOr(defaultValue)(_.getIntegerEvaluation(key, defaultValue, context))
+
+  override def getDoubleEvaluation(
+    key: String,
+    defaultValue: java.lang.Double,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Double] =
+    delegateOr(defaultValue)(_.getDoubleEvaluation(key, defaultValue, context))
+
+  override def getObjectEvaluation(
+    key: String,
+    defaultValue: Value,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[Value] =
+    delegateOr(defaultValue)(_.getObjectEvaluation(key, defaultValue, context))
+}
+
+object DeferredProvider {
+
+  /** Create a DeferredProvider. `construct` is deferred to `initialize()` (run on the SDK init executor). */
+  def apply(name: String)(construct: () => FeatureProvider): DeferredProvider =
+    new DeferredProvider(name)(construct)
+
+  sealed private trait State
+  private object State {
+    case object NotStarted                             extends State
+    case object Constructing                           extends State
+    final case class Active(delegate: FeatureProvider) extends State
+    case object Shutdown                               extends State
+  }
+}

--- a/extras/src/test/scala/zio/openfeature/extras/DeferredProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/DeferredProviderSpec.scala
@@ -1,0 +1,130 @@
+package zio.openfeature.extras
+
+import zio._
+import zio.test._
+import zio.openfeature.{FeatureFlags, ProviderStatus}
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  ErrorCode,
+  FeatureProvider,
+  ImmutableContext,
+  Metadata,
+  ProviderEvaluation,
+  ProviderState,
+  Value
+}
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+
+object DeferredProviderSpec extends ZIOSpecDefault {
+
+  private val ctx: OFEvaluationContext = new ImmutableContext()
+
+  /** A ready delegate answering a fixed boolean; records its initialize() thread and shutdown() count. */
+  private class RecordingProvider(
+    value: Boolean,
+    shutdowns: AtomicInteger = new AtomicInteger(0),
+    initThread: AtomicReference[String] = new AtomicReference[String](null)
+  ) extends FeatureProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                    = new Metadata { override def getName: String = "delegate" }
+    override def getState: ProviderState                  = ProviderState.READY
+    override def initialize(c: OFEvaluationContext): Unit = { initThread.set(Thread.currentThread().getName); () }
+    override def shutdown(): Unit                         = { shutdowns.incrementAndGet(); () }
+    def shutdownCount: Int                                = shutdowns.get()
+    def initThreadName: String                            = initThread.get()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of(java.lang.Boolean.valueOf(value), "STATIC")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) = ProviderEvaluations.of(d, "DEFAULT")
+  }
+
+  def spec = suite("DeferredProviderSpec")(
+    // AC5: no NPE pre-construction; typed PROVIDER_NOT_READY
+    test("pre-construction evaluation returns a typed PROVIDER_NOT_READY, not an NPE") {
+      val dp   = DeferredProvider("d")(() => new RecordingProvider(true))
+      val eval = dp.getBooleanEvaluation("flag", false, ctx)
+      assertTrue(
+        eval.getErrorCode == ErrorCode.PROVIDER_NOT_READY,
+        !eval.getValue.booleanValue(),
+        dp.getState == ProviderState.NOT_READY,
+        dp.getMetadata.getName == "d"
+      )
+    },
+    // AC5: shutdown() racing an in-flight initialize() shuts the delegate down exactly once
+    test("shutdown during initialize shuts the freshly built delegate down once") {
+      val constructing = new CountDownLatch(1)
+      val release      = new CountDownLatch(1)
+      val delegate     = new RecordingProvider(true)
+      val dp = DeferredProvider("d") { () =>
+        constructing.countDown()
+        release.await()
+        delegate
+      }
+      for {
+        fiber <- ZIO.attemptBlocking(dp.initialize(ctx)).fork
+        _     <- ZIO.attemptBlocking(constructing.await())
+        _     <- ZIO.succeed(dp.shutdown())
+        _     <- ZIO.succeed(release.countDown())
+        _     <- fiber.join
+        sd    <- ZIO.succeed(delegate.shutdownCount)
+        st    <- ZIO.succeed(dp.getState)
+      } yield assertTrue(sd == 1, st == ProviderState.NOT_READY)
+    } @@ TestAspect.withLiveClock,
+    // AC5: delegate.initialize throwing shuts the delegate down once and does not wedge in Constructing
+    test("delegate.initialize throwing shuts the delegate down and reports not-ready") {
+      val delegateShutdowns = new AtomicInteger(0)
+      val delegate = new RecordingProvider(true, delegateShutdowns) {
+        override def initialize(c: OFEvaluationContext): Unit = throw new RuntimeException("init boom")
+      }
+      val dp = DeferredProvider("d")(() => delegate)
+      for {
+        res <- ZIO.attempt(dp.initialize(ctx)).either
+        sd  <- ZIO.succeed(delegateShutdowns.get())
+        st  <- ZIO.succeed(dp.getState)
+      } yield assertTrue(res.isLeft, sd == 1, st == ProviderState.NOT_READY)
+    },
+    // AC5: works through fromProviderAsync; initialize runs off the caller thread (on the SDK executor)
+    test("works through fromProviderAsync and constructs off the caller thread") {
+      val delegate = new RecordingProvider(true)
+      val dp       = DeferredProvider("deferred")(() => delegate)
+      for {
+        callerThread <- ZIO.succeed(Thread.currentThread().getName)
+        result <- ZIO.scoped {
+          FeatureFlags.fromProviderAsync(dp).build.map(_.get[FeatureFlags]).flatMap { ff =>
+            for {
+              status <- ff.awaitReady(10.seconds)
+              v      <- ff.boolean("flag", false)
+              it     <- ZIO.succeed(delegate.initThreadName)
+            } yield assertTrue(
+              status == ProviderStatus.Ready,
+              v,                 // delegate answers true once active
+              it != null,        // initialize actually ran
+              it != callerThread // ...on the SDK executor, not the caller's thread
+            )
+          }
+        }
+      } yield result
+    } @@ TestAspect.withLiveClock,
+    // AC5: works through fromMultiProviderAsync
+    test("works through fromMultiProviderAsync") {
+      val delegate = new RecordingProvider(true)
+      val dp       = DeferredProvider("deferred-multi")(() => delegate)
+      val other    = new RecordingProvider(false)
+      ZIO.scoped {
+        FeatureFlags.fromMultiProviderAsync(List(dp, other)).build.map(_.get[FeatureFlags]).flatMap { ff =>
+          for {
+            status <- ff.awaitReady(10.seconds)
+            v      <- ff.boolean("flag", false)
+          } yield assertTrue(status == ProviderStatus.Ready, v)
+        }
+      }
+    } @@ TestAspect.withLiveClock
+  ) @@ TestAspect.sequential
+}

--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -35,7 +35,7 @@ final class TestFeatureProvider private (
   private val state: AtomicReference[ProviderState],
   private val evaluations: CopyOnWriteArrayList[(String, OFEvaluationContext)],
   private val eventsHub: Hub[ProviderEvent],
-  private[openfeature] val statusRef: Ref[ProviderStatus],
+  private[openfeature] val statusRef: SubscriptionRef[ProviderStatus],
   private val initLatch: Option[CountDownLatch],
   private[testkit] val initDone: Option[CountDownLatch]
 ) extends EventProvider {
@@ -407,7 +407,7 @@ object TestFeatureProvider {
   def make(initialFlags: Map[String, Any]): UIO[TestFeatureProvider] =
     for {
       eventsHub <- Hub.unbounded[ProviderEvent]
-      statusRef <- Ref.make[ProviderStatus](ProviderStatus.Ready)
+      statusRef <- SubscriptionRef.make[ProviderStatus](ProviderStatus.Ready)
       provider <- ZIO.succeed {
         val flags = new ConcurrentHashMap[String, Any]()
         initialFlags.foreach { case (k, v) => flags.put(k, v) }
@@ -459,7 +459,7 @@ object TestFeatureProvider {
   private def makeReadyWithInitDone(initialFlags: Map[String, Any]): UIO[TestFeatureProvider] =
     for {
       eventsHub <- Hub.unbounded[ProviderEvent]
-      statusRef <- Ref.make[ProviderStatus](ProviderStatus.Ready)
+      statusRef <- SubscriptionRef.make[ProviderStatus](ProviderStatus.Ready)
       provider <- ZIO.succeed {
         val flags = new ConcurrentHashMap[String, Any]()
         initialFlags.foreach { case (k, v) => flags.put(k, v) }
@@ -545,7 +545,7 @@ object TestFeatureProvider {
   private[testkit] def makeNotReady(initialFlags: Map[String, Any]): UIO[TestFeatureProvider] =
     for {
       eventsHub <- Hub.unbounded[ProviderEvent]
-      statusRef <- Ref.make[ProviderStatus](ProviderStatus.NotReady)
+      statusRef <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
       provider <- ZIO.succeed {
         val flags = new ConcurrentHashMap[String, Any]()
         initialFlags.foreach { case (k, v) => flags.put(k, v) }


### PR DESCRIPTION
## Summary

Three additions so provider construction never sits on the application boot path:

- **`FeatureFlags.fromAcquireAsync`** — a fallback-first async factory (`URLayer[Scope, FeatureFlags]`). Takes the real provider *as an effect*, builds the layer immediately on a fresh fallback (status `Ready` from time zero; evaluations answer fallback values), constructs the real provider in a background scoped fiber with retry/per-attempt-timeout, and hot-swaps it in when ready. Terminal construction/swap failures run `onConstructionError` and leave the instance usable on the fallback; the `Nothing` error channel proves at compile time that no provider failure can fail the app's layer graph.
- **`zio.openfeature.extras.DeferredProvider`** — adapts a constructor-blocking provider into an `initialize()`-blocking one, deferring construction to the SDK init executor. Stable metadata name, typed `PROVIDER_NOT_READY` before ready, a race-safe state machine for `shutdown()` racing an in-flight `initialize()`, and hook forwarding.
- **`FeatureFlags.awaitReady(within)`** — semantically blocks until the provider is evaluable (`Ready`/`Stale`), returns early on `Fatal`, or times out, returning the status at that moment. Backed by a status change stream (no polling) via a `SubscriptionRef` migration of the provider-status ref; safe for many concurrent waiters. Ideal for `/ready` probes. The async init watchdog's `Fatal` transition now also releases the `onReady` latch and is observable via `awaitReady`.

## Docs

- `CHANGELOG.md` (Added), `docs/providers.md` (fallback-first + awaitReady sections), `docs/extras.md` (Deferred Provider section).

## Verification

Full Scala 3 test suite (812 tests, 0 failed), Scala 2.13 cross-compile (core/testkit/extras), `conformance/test`, `conformanceZioBdd/test`, and `scalafmtCheckAll` all pass (also enforced by the pre-push gate).

Closes #241

Milestone: 1.0-readiness