### PR TITLE
Do not hard-fail evaluations while provider status is Error (spec 1.7.6/1.7.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Evaluations no longer hard-fail while the provider status is `Error`** (#245). Per the OpenFeature spec, only
+  `NOT_READY` (§1.7.6) and `FATAL` (§1.7.7) fail-fast; `checkProviderStatus` was also failing every evaluation with
+  `ProviderNotReady(Error)` whenever a single transient `PROVIDER_ERROR` (e.g. one failed datafile poll) arrived,
+  turning a degraded-but-serving provider into a total outage until a `PROVIDER_READY` re-arrived (which many providers
+  never re-emit). Evaluations in `ERROR` now proceed to the provider — it serves cached values or errors on its own.
+  `NOT_READY` and `FATAL` still fail-fast, and the `FeatureFlagRegistry` init handshake still fast-fails a provider that
+  errors before ever becoming ready (that init-time behavior is intentional and left to the status-state-machine rework
+  in #244).
+
 - **`FeatureFlagRegistry.getClient` no longer hangs when provider registration throws** (#242). `FeatureFlags.buildAsync`
   wrapped the synchronous Java SDK registration calls (`api.setProvider`, `provider.getMetadata`) in `ZIO.succeed`, so a
   throw became a ZIO *defect* rather than a typed error. Combined with `runBuild` handling only typed failures, such a

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -285,9 +285,11 @@ final private[openfeature] class FeatureFlagsLive(
     providerStatus.flatMap {
       case ProviderStatus.Fatal    => ZIO.fail(FeatureFlagError.ProviderFatal)
       case ProviderStatus.NotReady => ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.NotReady))
-      case ProviderStatus.Error    => ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.Error))
       case ProviderStatus.ShuttingDown =>
         ZIO.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.ShuttingDown))
+      // Error/Ready/Stale proceed: per OpenFeature spec 1.7.6/1.7.7 only NOT_READY and FATAL fail-fast. A provider in
+      // ERROR is typically a transient, recoverable state and commonly still serves cached values — let the evaluation
+      // reach it (the provider serves or errors on its own) rather than turning one PROVIDER_ERROR into a total outage.
       case _ => Exit.unit
     }
 
@@ -675,8 +677,9 @@ final private[openfeature] class FeatureFlagsLive(
     state.statusRef.get
 
   // Force status back to Ready. Used by `fromAcquireAsync` when a hot-swap to the real provider fails: `setProvider`'s
-  // rollback restores the still-live fallback to `providerRef` but leaves status `Error`, which would fail every
-  // evaluation with `ProviderNotReady(Error)` despite a usable fallback. Package-private — not part of the public API.
+  // rollback restores the still-live fallback to `providerRef` but leaves status `Error`. Evaluations still proceed in
+  // `Error` (spec 1.7.6/1.7.7), but restoring `Ready` keeps `providerStatus` / `awaitReady` accurate for the usable
+  // fallback (`Error` is not `canEvaluate`). Package-private — not part of the public API.
   private[openfeature] def forceReady: UIO[Unit] =
     state.statusRef.set(ProviderStatus.Ready)
 

--- a/core/src/test/scala/zio/openfeature/NonBlockingInitSpec.scala
+++ b/core/src/test/scala/zio/openfeature/NonBlockingInitSpec.scala
@@ -142,11 +142,13 @@ object NonBlockingInitSpec extends ZIOSpecDefault {
             .flatMap { ff =>
               for {
                 _ <- errP.await
-                // forceReady must have restored an evaluable status (setProvider's rollback left it Error), so the
-                // instance stays usable instead of hard-failing every evaluation with ProviderNotReady(Error).
-                status <- ff.awaitReady(30.seconds)
-                v      <- ff.boolean("x", true).either
-              } yield assertTrue(status.canEvaluate, v.isRight)
+                // The real guarantee is that the instance stays *usable* on the fallback: the evaluation succeeds
+                // rather than hard-failing. Since #245 lets evaluations proceed in Error, this holds regardless of
+                // whether `forceReady` won the race or a late async PROVIDER_ERROR (from the failing provider's init)
+                // re-set the status to Error. (Asserting via `awaitReady` under this spec's frozen TestClock would
+                // block forever on that Error race, so assert on the evaluation itself.)
+                v <- ff.boolean("x", true).either
+              } yield assertTrue(v.isRight)
             }
         }
       } yield result

--- a/core/src/test/scala/zio/openfeature/ProviderInitFailureSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderInitFailureSpec.scala
@@ -25,8 +25,9 @@ import java.util.concurrent.atomic.AtomicReference
   *
   * Cases covered here:
   *   1. Sync `initialize()` throws synchronously → layer build fails with the thrown exception. 5. Async provider fires
-  *      `PROVIDER_ERROR` after construction → status reflects `Error`, evaluations fail with `ProviderNotReady(Error)`.
-  *      6. Async provider recovers (ERROR → READY) → evaluations succeed after recovery. 7. Evaluation throws
+  *      `PROVIDER_ERROR` after construction → status reflects `Error`, but evaluations still proceed (spec 1.7.6/1.7.7:
+  *      only NOT_READY and FATAL fail-fast). 5b. Fail-fast contract: NOT_READY and FATAL block evaluation; Ready/Error
+  *      proceed. 6. Async provider recovers (ERROR → READY) → evaluations succeed after recovery. 7. Evaluation throws
   *      `UnknownHostException` from the Java SDK → classifier surfaces `Unreachable`.
   *
   * Cases 2, 3, 4 are already covered by [[ProviderInitHardeningSpec]] and are not duplicated here.
@@ -200,7 +201,9 @@ object ProviderInitFailureSpec extends ZIOSpecDefault {
         }
       )
     } @@ withLiveClock,
-    test("[B2 / case 5] async provider fires PROVIDER_ERROR after init -> evaluations fail with ProviderNotReady") {
+    test(
+      "[B2 / case 5] async provider fires PROVIDER_ERROR after init -> evaluations still proceed (spec 1.7.6/1.7.7)"
+    ) {
       val provider = new EventDriverProvider
       val api      = OpenFeatureAPIFactory.create()
       ZIO.scoped {
@@ -229,12 +232,49 @@ object ProviderInitFailureSpec extends ZIOSpecDefault {
             .repeatUntil(_ == ProviderStatus.Error)
             .timeout(5.seconds)
             .someOrFail(new Exception("timed out waiting for PROVIDER_ERROR to propagate"))
+          // Spec 1.7.6/1.7.7: only NOT_READY and FATAL fail-fast. In ERROR the evaluation proceeds to the provider
+          // (which serves cached values or errors on its own) instead of a blanket ProviderNotReady failure.
           result <- ff.booleanDetails("any-flag", default = false).either
+        } yield assertTrue(result.isRight)
+      }
+    } @@ withLiveClock,
+    test("[B2 / case 5b] checkProviderStatus fail-fast contract: only NOT_READY and FATAL block evaluation") {
+      val provider = new EventDriverProvider
+      val api      = OpenFeatureAPIFactory.create()
+      ZIO.scoped {
+        for {
+          statusRef <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
+          ff <- FeatureFlags.buildAsync(
+            provider,
+            domain = Some(uniqueDomain("status-gate")),
+            version = None,
+            initialHooks = Nil,
+            statusRef = Some(statusRef),
+            addShutdownFinalizer = false,
+            apiOverride = Some(api),
+            initTimeout = 60.seconds
+          )
+          _ <- ZIO.attempt(provider.release())
+          _ <- statusRef.get
+            .repeatUntil(_ == ProviderStatus.Ready)
+            .timeout(5.seconds)
+            .someOrFail(new Exception("timed out waiting for PROVIDER_READY to propagate"))
+          // Ready -> proceeds
+          readyEval <- ff.booleanDetails("any-flag", default = false).either
+          // Error -> proceeds (no longer fail-fast)
+          _         <- statusRef.set(ProviderStatus.Error)
+          errorEval <- ff.booleanDetails("any-flag", default = false).either
+          // NotReady -> fail-fast
+          _            <- statusRef.set(ProviderStatus.NotReady)
+          notReadyEval <- ff.booleanDetails("any-flag", default = false).either
+          // Fatal -> fail-fast
+          _         <- statusRef.set(ProviderStatus.Fatal)
+          fatalEval <- ff.booleanDetails("any-flag", default = false).either
         } yield assertTrue(
-          result match {
-            case Left(FeatureFlagError.ProviderNotReady(ProviderStatus.Error)) => true
-            case _                                                             => false
-          }
+          readyEval.isRight,
+          errorEval.isRight,
+          notReadyEval == Left(FeatureFlagError.ProviderNotReady(ProviderStatus.NotReady)),
+          fatalEval == Left(FeatureFlagError.ProviderFatal)
         )
       }
     } @@ withLiveClock,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,7 +242,7 @@ The OpenFeature SDK manages provider lifecycle. ZIO OpenFeature adds scoped reso
 |:------|:------------|
 | `NotReady` | Provider not initialized. Evaluations fail with `ProviderNotReady` |
 | `Ready` | Can evaluate flags |
-| `Error` | Provider encountered recoverable error |
+| `Error` | Provider encountered a recoverable error. Evaluations still proceed (spec 1.7.6/1.7.7) — the provider serves cached values or errors on its own |
 | `Stale` | Provider data may be outdated |
 | `Fatal` | Provider encountered unrecoverable error. Evaluations fail with `ProviderFatal` |
 

--- a/testkit/src/test/scala/zio/openfeature/testkit/AsyncInitSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/AsyncInitSpec.scala
@@ -86,14 +86,13 @@ object AsyncInitSpec extends ZIOSpecDefault {
       }.provide(asyncLayer(Map("flag" -> true)))
     ),
     suite("Error state")(
-      test("evaluations fail with ProviderNotReady when provider is in Error state") {
+      test("evaluations proceed when a ready provider transitions to Error state (spec 1.7.6/1.7.7)") {
         for {
           tp     <- ZIO.service[TestFeatureProvider]
-          _      <- tp.setStatus(ProviderStatus.Error)
-          result <- FeatureFlags.boolean("flag", default = false).either
-        } yield assertTrue(
-          result.is(_.left) == FeatureFlagError.ProviderNotReady(ProviderStatus.Error)
-        )
+          _      <- tp.setStatus(ProviderStatus.Ready) // provider becomes ready and serves
+          _      <- tp.setStatus(ProviderStatus.Error) // then a transient error — evaluations must still proceed
+          result <- FeatureFlags.boolean("flag", default = false)
+        } yield assertTrue(result == true)
       }.provide(asyncLayer(Map("flag" -> true))),
       test("evaluations fail with ProviderFatal when provider is in Fatal state") {
         for {
@@ -106,17 +105,15 @@ object AsyncInitSpec extends ZIOSpecDefault {
       }.provide(asyncLayer(Map("flag" -> true)))
     ),
     suite("Recovery")(
-      test("evaluations recover after provider transitions from Error to Ready") {
+      test("evaluations keep serving through an Error blip and remain healthy on recovery to Ready") {
         for {
-          tp  <- ZIO.service[TestFeatureProvider]
-          _   <- tp.setStatus(ProviderStatus.Error)
-          err <- FeatureFlags.boolean("flag", default = false).either
-          _   <- tp.setStatus(ProviderStatus.Ready)
-          ok  <- FeatureFlags.boolean("flag", default = false)
-        } yield assertTrue(
-          err.is(_.left).isInstanceOf[FeatureFlagError.ProviderNotReady],
-          ok == true
-        )
+          tp     <- ZIO.service[TestFeatureProvider]
+          _      <- tp.setStatus(ProviderStatus.Ready)
+          _      <- tp.setStatus(ProviderStatus.Error) // transient blip — evaluations still proceed (spec 1.7.6/1.7.7)
+          during <- FeatureFlags.boolean("flag", default = false)
+          _      <- tp.setStatus(ProviderStatus.Ready) // recovered
+          ok     <- FeatureFlags.boolean("flag", default = false)
+        } yield assertTrue(during == true, ok == true)
       }.provide(asyncLayer(Map("flag" -> true))),
       test("evaluations recover after provider transitions from NotReady to Ready") {
         for {

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -762,14 +762,14 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
           result       <- FeatureFlags.boolean("test-flag", default = false)
         } yield assertTrue(result == true)
       }.provide(testLayer(Map("test-flag" -> true))),
-      test("evaluation fails with ProviderNotReady when provider is in Error status (spec 1.7.3)") {
+      test(
+        "evaluation proceeds when provider is in Error status (spec 1.7.6/1.7.7: only NOT_READY and FATAL fail-fast)"
+      ) {
         for {
           testProvider <- ZIO.service[TestFeatureProvider]
           _            <- testProvider.setStatus(ProviderStatus.Error)
-          result       <- FeatureFlags.boolean("test-flag", default = false).exit
-        } yield assertTrue(
-          result == Exit.fail(FeatureFlagError.ProviderNotReady(ProviderStatus.Error))
-        )
+          result       <- FeatureFlags.boolean("test-flag", default = false)
+        } yield assertTrue(result == true)
       }.provide(testLayer(Map("test-flag" -> true)))
     ),
     suite("Hook Context Metadata")(


### PR DESCRIPTION
## Summary

`checkProviderStatus` hard-failed every evaluation while the provider status was `Error`, but the OpenFeature spec only makes `NOT_READY` (§1.7.6) and `FATAL` (§1.7.7) fail-fast. A single transient `PROVIDER_ERROR` (e.g. one failed datafile poll) turned a degraded-but-serving provider into a total outage until a `PROVIDER_READY` re-arrived — which many providers never re-emit.

- **Fix:** remove the `ProviderStatus.Error` case from `checkProviderStatus` — evaluations in `ERROR` now proceed to the provider (which serves cached values or errors on its own). `NOT_READY` and `FATAL` still fail-fast; `ShuttingDown` still rejects during teardown.

## Scope

The `FeatureFlagRegistry` init handshake (`awaitReady`) still fast-fails a provider that errors *before ever becoming ready* — that init-time behavior is intentional and relied on by the #182 tests; treating Error as non-terminal there would turn `getClient` fast-fail into a 30s poll-until-timeout. Unifying init-time vs eval-time status handling is left to the status-state-machine rework in #244 (documented in the CHANGELOG).

## Tests

- `ProviderInitFailureSpec` `[B2 / case 5]` updated (Error → evaluations still proceed) and new `[B2 / case 5b]` (Ready/Error proceed; NOT_READY/FATAL fail-fast).
- testkit `AsyncInitSpec` and `FeatureFlagsSpec` Error-state tests updated to the spec-compliant behavior.

## Docs

- `CHANGELOG.md` (Fixed) and `docs/architecture.md` provider-status table.

## Verification

Full Scala 3 test suite (all modules), Scala 2.13 core cross-compile, `conformance/test`, `conformanceZioBdd/test`, and `scalafmtCheckAll` pass (also enforced by the pre-push gate).

Closes #245

Milestone: 1.0-readiness