### PR TITLE
Fix hook pipeline stage routing: error-code resolutions and before-hook defects (spec 4.3.6/4.4.6/4.3.8/4.4.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Hook pipeline stage routing now matches the spec** (#246). Two violations in `runHookPipeline`: (1) a returned
+  resolution carrying an error code (`FLAG_NOT_FOUND`, `TYPE_MISMATCH`, ...) ran *both* the `after` and `error` stages —
+  per spec §4.3.6/§4.4.6 an error-code resolution is abnormal execution, so it now runs `error` only (`after` runs only
+  for a clean resolution). This fixes the built-in metrics hook double-counting a single `FLAG_NOT_FOUND` as both a
+  success and a failure. (2) A defect in a `before` hook skipped the `error` and `finallyAfter` stages entirely
+  (violating §4.3.8/§4.4.7 and the "finally runs on every exit" contract); the whole pipeline is now wrapped so a
+  before-hook defect still runs `error` and `finallyAfter` before propagating.
+
 - **Evaluations no longer hard-fail while the provider status is `Error`** (#245). Per the OpenFeature spec, only
   `NOT_READY` (§1.7.6) and `FATAL` (§1.7.7) fail-fast; `checkProviderStatus` was also failing every evaluation with
   `ProviderNotReady(Error)` whenever a single transient `PROVIDER_ERROR` (e.g. one failed datafile poll) arrived,

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -233,35 +233,62 @@ final private[openfeature] class FeatureFlagsLive(
   ): IO[FeatureFlagError, FlagResolution[A]] = {
     val composedHook = FeatureHook.compose(hooks)
 
-    for {
-      beforeResult <- composedHook.before(hookCtx, initialHints)
-      (effectiveCtx, hints) = beforeResult match {
-        case Some((modifiedCtx, h)) => (modifiedCtx, h)
-        case None                   => (context, initialHints)
-      }
-      // Per spec §4.3.5-4.3.8, after/error/finally stages must observe the evaluation context as modified
-      // by the before hooks, not the original one. finallyAfter runs on every exit (success, failure,
-      // interruption); the resolution is read straight off the Exit rather than smuggled through a
-      // per-evaluation Ref.
-      stageCtx = hookCtx.copy(evaluationContext = effectiveCtx)
-      result <- evaluate(effectiveCtx)
-        .tapBoth(
-          err => composedHook.error(stageCtx, err, hints),
-          // A resolution can be returned and still represent an error (FLAG_NOT_FOUND, TYPE_MISMATCH, ...): the Java
-          // SDK surfaces those as a default value plus an error code rather than a thrown error. Per spec §4.4.6 the
-          // `error` stage must observe such evaluations, so we run `after` (the resolution was returned) and, when it
-          // carries an error code, also `error`.
-          res =>
-            composedHook.after(stageCtx, res, hints) *>
-              ZIO.foreachDiscard(res.errorCode)(code =>
-                composedHook.error(stageCtx, errorFromResolution(res.flagKey, code, res.errorMessage), hints)
-              )
+    // `finallyAfter` must run on EVERY exit — including an interruption of `before` itself — so it is attached as one
+    // outer `onExit` wrapping the whole pipeline (an `onExit` nested inside the foldCauseZIO branches would be skipped
+    // when `before` is interrupted before that branch's effect is even entered). Per spec §4.3.5-4.3.8 the finally
+    // stage must observe the context as modified by the before hooks; that modified `(ctx, hints)` is recorded in a Ref
+    // once `before` succeeds, so the outer finalizer uses it, falling back to the original context when `before` never
+    // completed.
+    Ref.make((hookCtx, initialHints)).flatMap { finallyCtxRef =>
+      composedHook
+        .before(hookCtx, initialHints)
+        .foldCauseZIO(
+          // `before` is a UIO, so a non-success cause is a Die or an Interrupt. Only a Die is abnormal execution that
+          // runs the `error` stage (spec §4.3.8/§4.4.7) — a pure interruption (timeout / scope-close) is a cancellation,
+          // not a hook failure, so it must not be reported to `error`. The original cause is always preserved: even if
+          // the `error` stage itself defects, its cause is combined with (never replaces) `beforeCause`.
+          beforeCause =>
+            beforeCause.dieOption match {
+              case Some(defect) =>
+                composedHook
+                  .error(hookCtx, FeatureFlagError.ProviderError(defect), initialHints)
+                  .foldCauseZIO(
+                    errCause => ZIO.refailCause(beforeCause ++ errCause),
+                    _ => ZIO.refailCause(beforeCause)
+                  )
+              case None => ZIO.refailCause(beforeCause)
+            },
+          beforeResult => {
+            val (effectiveCtx, hints) = beforeResult match {
+              case Some((modifiedCtx, h)) => (modifiedCtx, h)
+              case None                   => (context, initialHints)
+            }
+            val stageCtx = hookCtx.copy(evaluationContext = effectiveCtx)
+            finallyCtxRef.set((stageCtx, hints)) *>
+              evaluate(effectiveCtx)
+                .tapBoth(
+                  err => composedHook.error(stageCtx, err, hints),
+                  // A returned resolution can still be *abnormal* execution — it carries an error code (FLAG_NOT_FOUND,
+                  // TYPE_MISMATCH, ...) that the Java SDK surfaces as a default value plus a code rather than a throw.
+                  // Per spec §4.3.6/§4.4.6 that is the `error` stage's domain, NOT `after`: run `error` for an
+                  // error-code resolution and `after` only for a clean one.
+                  res =>
+                    res.errorCode match {
+                      case Some(code) =>
+                        composedHook.error(stageCtx, errorFromResolution(res.flagKey, code, res.errorMessage), hints)
+                      case None =>
+                        composedHook.after(stageCtx, res, hints)
+                    }
+                )
+          }
         )
         .onExit { exit =>
-          val details: Option[FlagResolution[_]] = exit.foldExit(_ => None, res => Some(res))
-          composedHook.finallyAfter(stageCtx, details, hints)
+          finallyCtxRef.get.flatMap { case (ctx, hints) =>
+            val details: Option[FlagResolution[_]] = exit.foldExit(_ => None, res => Some(res))
+            composedHook.finallyAfter(ctx, details, hints)
+          }
         }
-    } yield result
+    }
   }
 
   /** Reconstruct a typed error from a resolution that carries an error code, so the `error` hook stage can observe a

--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -111,10 +111,11 @@ object HookHints {
   * still propagate and fail the evaluation fiber, so wrap genuinely untrusted code in `ZIO.attempt(...).ignoreLogged`
   * or similar.
   *
-  * '''Error stage and error-code resolutions''' (spec §4.4.6): the `error` stage runs both when an evaluation fails
-  * through the typed error channel (`ProviderNotReady`/`ProviderFatal`) and when it returns a `FlagResolution` carrying
-  * an error code (`FLAG_NOT_FOUND`, `TYPE_MISMATCH`, ...). In the latter case `after` also runs, because the resolution
-  * (the default value) was still returned. `finallyAfter` always runs last.
+  * '''Error stage and error-code resolutions''' (spec §4.3.6/§4.4.6): the `error` stage runs both when an evaluation
+  * fails through the typed error channel (`ProviderNotReady`/`ProviderFatal`) and when it returns a `FlagResolution`
+  * carrying an error code (`FLAG_NOT_FOUND`, `TYPE_MISMATCH`, ...). An error-code resolution is abnormal execution, so
+  * it runs `error`, NOT `after` — `after` runs only for a clean resolution. A defect in a `before` hook also runs
+  * `error` (and never skips it). `finallyAfter` always runs last, on every exit.
   *
   * Provider-level hooks are not modeled here: they run inside the Java SDK evaluation call, per the OpenFeature
   * architecture (see #167). Java `dev.openfeature.sdk.Hook` instances can be registered at the Java API level via

--- a/core/src/test/scala/zio/openfeature/HookErrorRoutingSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookErrorRoutingSpec.scala
@@ -1,0 +1,174 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  ErrorCode,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderState,
+  Value
+}
+
+/** Verifies the hook-stage routing required by spec §4.3.6/§4.4.6 and §4.3.8/§4.4.7:
+  *   - an error-code resolution (FLAG_NOT_FOUND, ...) runs the `error` stage, NOT `after`;
+  *   - a clean resolution runs `after`, NOT `error`;
+  *   - a defect in a `before` hook still runs `error` and `finallyAfter` (never skipped).
+  */
+object HookErrorRoutingSpec extends ZIOSpecDefault {
+
+  /** "missing" → an error-code resolution (FLAG_NOT_FOUND); anything else → a clean STATIC true. */
+  private class RoutingProvider extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "Routing" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      if (k == "missing") ProviderEvaluations.error[java.lang.Boolean](d, ErrorCode.FLAG_NOT_FOUND, "not found")
+      else ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  private def recordingHook(log: Ref[List[String]]): FeatureHook = new FeatureHook {
+    override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+      log.update(_ :+ "before").as(None)
+    override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+      log.update(_ :+ "after")
+    override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
+      log.update(_ :+ "error")
+    override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
+      log.update(_ :+ "finallyAfter")
+  }
+
+  /** before() records then dies; the other stages record safely — so we can assert error/finally run after a
+    * before-hook defect.
+    */
+  private def beforeDiesHook(log: Ref[List[String]]): FeatureHook = new FeatureHook {
+    override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+      log.update(_ :+ "before") *> ZIO.die(new RuntimeException("defect in before"))
+    override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+      log.update(_ :+ "after")
+    override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
+      log.update(_ :+ "error")
+    override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
+      log.update(_ :+ "finallyAfter")
+  }
+
+  private def buildFF(hooks: List[FeatureHook]): ZIO[Scope, Throwable, FeatureFlags] = {
+    val api = OpenFeatureAPIFactory.create()
+    FeatureFlags.build(
+      new RoutingProvider,
+      domain = Some(s"hook-routing-${java.util.UUID.randomUUID()}"),
+      version = None,
+      initialHooks = hooks,
+      statusRef = None,
+      addShutdownFinalizer = true,
+      apiOverride = Some(api),
+      evaluationTimeout = Some(5.seconds)
+    )
+  }
+
+  def spec = suite("HookErrorRoutingSpec")(
+    test("an error-code resolution runs `error`, not `after` (spec §4.3.6/§4.4.6)") {
+      ZIO.scoped {
+        for {
+          log   <- Ref.make[List[String]](Nil)
+          ff    <- buildFF(List(recordingHook(log)))
+          v     <- ff.boolean("missing", default = false) // error-code resolution still returns the default value
+          calls <- log.get
+        } yield assertTrue(
+          !v, // provider's default (false) is returned despite the error code
+          calls.contains("before"),
+          calls.contains("error"),
+          !calls.contains("after"),
+          calls.contains("finallyAfter")
+        )
+      }
+    },
+    test("a clean resolution runs `after`, not `error`") {
+      ZIO.scoped {
+        for {
+          log   <- Ref.make[List[String]](Nil)
+          ff    <- buildFF(List(recordingHook(log)))
+          v     <- ff.boolean("ok", default = false)
+          calls <- log.get
+        } yield assertTrue(
+          v,
+          calls.contains("before"),
+          calls.contains("after"),
+          !calls.contains("error"),
+          calls.contains("finallyAfter")
+        )
+      }
+    },
+    test("a defect in a before hook still runs `error` and `finallyAfter` (spec §4.3.8/§4.4.7)") {
+      ZIO.scoped {
+        for {
+          log    <- Ref.make[List[String]](Nil)
+          ff     <- buildFF(List(beforeDiesHook(log)))
+          result <- ff.boolean("ok", default = false).sandbox.either
+          calls  <- log.get
+        } yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.isDie),
+          calls.contains("before"),
+          calls.contains("error"),
+          !calls.contains("after"), // a before-defect never reaches the success/after branch
+          calls.contains("finallyAfter")
+        )
+      }
+    },
+    test("an interruption during before does not run `error`, but `finallyAfter` still runs") {
+      ZIO.scoped {
+        for {
+          log  <- Ref.make[List[String]](Nil)
+          gate <- Promise.make[Nothing, Unit]
+          blockingHook = new FeatureHook {
+            override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+              log.update(_ :+ "before") *> gate.await.as(None)
+            override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+              log.update(_ :+ "after")
+            override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
+              log.update(_ :+ "error")
+            override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints)
+              : UIO[Unit] =
+              log.update(_ :+ "finallyAfter")
+          }
+          ff    <- buildFF(List(blockingHook))
+          fiber <- ff.boolean("ok", default = false).fork
+          _     <- log.get.repeatUntil(_.contains("before")) // wait until before is running (and blocked on the gate)
+          _     <- fiber.interrupt                           // interrupt returns only after finalizers have run
+          calls <- log.get
+        } yield assertTrue(
+          calls.contains("before"),
+          !calls.contains("error"), // cancellation is not a hook failure
+          calls.contains("finallyAfter")
+        )
+      }
+    },
+    test("the built-in metrics hook counts a FLAG_NOT_FOUND resolution once (failure), not twice") {
+      ZIO.scoped {
+        for {
+          counts <- Ref.make[List[Boolean]](Nil)
+          hook = FeatureHook.metrics((_, _, success) => counts.update(_ :+ success))
+          ff <- buildFF(List(hook))
+          _  <- ff.boolean("missing", default = false)
+          cs <- counts.get
+        } yield assertTrue(cs == List(false)) // exactly one call, marked failure — not success+failure
+      }
+    }
+  ) @@ sequential @@ withLiveClock
+}


### PR DESCRIPTION
## Summary

Two OpenFeature hook-pipeline spec violations in `runHookPipeline`, fixed in one pass:

1. **Error-code resolution ran both `after` and `error`** (spec §4.3.6/§4.4.6). A returned resolution carrying an error code (`FLAG_NOT_FOUND`, `TYPE_MISMATCH`, ...) is *abnormal* execution — it now runs the `error` stage **only**; `after` runs only for a clean resolution. This fixes the built-in `FeatureHook.metrics` double-counting a single `FLAG_NOT_FOUND` as both a success and a failure.

2. **A defect in a `before` hook skipped the `error` and `finallyAfter` stages** (spec §4.3.8/§4.4.7, and the "finally runs on every exit" contract). `before` is now wrapped in `foldCauseZIO`: a before-hook **defect** runs `error` then propagates, preserving the original cause even if the error stage itself defects. A pure **interruption** of `before` (timeout/scope-close) is a cancellation, not a hook failure, so it does *not* fire `error`. `finallyAfter` is attached as a single **outer** `onExit` wrapping the whole pipeline, so it runs on every exit — including an interruption of `before` — with the spec-required modified context (threaded via a `Ref`).

## Tests

New `HookErrorRoutingSpec` (5 tests): error-code→`error` not `after`; clean→`after` not `error`; before-defect→`error`+`finally` (surfaces as a defect, never reaches `after`); interruption→no `error`, `finally` still runs; and a direct metrics-hook test asserting a `FLAG_NOT_FOUND` is counted once (failure), not twice.

## Docs

- `CHANGELOG.md` (Fixed) and the `Hook.scala` scaladoc (was documenting the buggy after-also-runs behavior).

## Verification

Full Scala 3 test suite (all modules), Scala 2.13 core cross-compile, `conformance/test`, `conformanceZioBdd/test`, and `scalafmtCheckAll` pass (also enforced by the pre-push gate).

Closes #246

Milestone: 1.0-readiness