### PR TITLE
Make hook hints immutable through the pipeline; migrate metrics hook to HookData (spec 4.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: `FeatureHook.before` no longer returns hook hints** (#247). Its signature changed from
+  `UIO[Option[(EvaluationContext, HookHints)]]` to `UIO[Option[EvaluationContext]]`, so a `before` hook can modify the
+  evaluation context but can no longer alter the hook hints seen by later hooks and stages — hints are now immutable
+  through the pipeline, as required by spec §4.5.3/§4.2.2.1. Per-hook state belongs in `HookData` (spec §4.6): the
+  built-in `FeatureHook.metrics` hook was migrated to store its start time in `ctx.hookData` (mirroring
+  `metricsDetailed`) instead of writing it into the hints. Migration: a `before` that returned
+  `Some((newContext, newHints))` should return `Some(newContext)` and move any per-hook state to `ctx.hookData`.
+
 - **Bump `dev.openfeature:sdk` to 1.21.0** (#239). Per-provider error detail in multi-provider strategies and
   isolated `OpenFeatureAPI` instance support now flow from the upstream fix with no further wrapper changes (our
   event hub and `apiOverride` plumbing already isolated us from the bugs this release fixes). The SDK's

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
@@ -30,11 +30,12 @@ object HookRow { given Schema[HookRow] = DeriveSchema.gen[HookRow] }
   // The remaining excluded tags are out of scope for a ZIO SDK + in-memory testkit, not coverage gaps:
   //   - async:               tautological — every evaluation already returns a non-blocking ZIO effect; there is no
   //                          separate async API surface to assert against.
-  //   - immutability:        compile-time guaranteed — context/details are immutable case classes, so there is no
-  //                          mutation API to exercise; the language enforces what the scenario asserts.
   //   - reason-codes-cached: the in-memory testkit provider cannot emit a CACHED reason (it derives the reason from
   //                          key presence only), so the scenario can't be satisfied without a contrived provider.
   //   - deprecated:          superseded scenarios retained in the feature file for history, not meant to run.
+  //   - immutability:        the @immutability scenario asserts evaluation-*context* immutability (spec 1.4.15) and
+  //                          has no step definitions here; enabling it needs those steps implemented. It is unrelated
+  //                          to hook-*hints* immutability (spec 4.5.3), which #247 enforces at the type level.
   excludeTags = Array("deprecated", "reason-codes-cached", "async", "immutability"),
   logLevel = "warning"
 )
@@ -260,7 +261,7 @@ object ConformanceSpec extends ZIOSteps[Any, World] {
 
   private def recordingHook(stages: Ref[Chunk[String]], details: Ref[Option[FlagResolution[Any]]]): OFFeatureHook =
     new OFFeatureHook {
-      override def before(c: HookContext, h: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+      override def before(c: HookContext, h: HookHints): UIO[Option[EvaluationContext]] =
         stages.update(_ :+ "before").as(None)
       override def after[A](c: HookContext, d: FlagResolution[A], h: HookHints): UIO[Unit] =
         stages.update(_ :+ "after") *> details.set(Some(d.asInstanceOf[FlagResolution[Any]]))
@@ -315,7 +316,7 @@ object ConformanceSpec extends ZIOSteps[Any, World] {
   // Per-invocation hook that tags each stage with its name, so we can assert both execution and ordering.
   private def orderedHook(name: String, log: Ref[Chunk[String]]): OFFeatureHook =
     new OFFeatureHook {
-      override def before(c: HookContext, h: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+      override def before(c: HookContext, h: HookHints): UIO[Option[EvaluationContext]] =
         log.update(_ :+ s"$name:before").as(None)
       override def after[A](c: HookContext, d: FlagResolution[A], h: HookHints): UIO[Unit] =
         log.update(_ :+ s"$name:after").unit
@@ -411,7 +412,7 @@ object ConformanceSpec extends ZIOSteps[Any, World] {
   }
 
   private def ctxHook(ctx: EvaluationContext): OFFeatureHook = new OFFeatureHook {
-    override def before(c: HookContext, h: HookHints): UIO[Option[(EvaluationContext, HookHints)]] = ZIO.some((ctx, h))
+    override def before(c: HookContext, h: HookHints): UIO[Option[EvaluationContext]] = ZIO.some(ctx)
   }
 
   When("Some flag was evaluated") {

--- a/conformance/src/test/scala/zio/openfeature/conformance/ConformanceSteps.scala
+++ b/conformance/src/test/scala/zio/openfeature/conformance/ConformanceSteps.scala
@@ -255,7 +255,7 @@ class ConformanceSteps extends ScalaDsl with EN {
   // Hooks
 
   private def recordingHook: FeatureHook = new FeatureHook {
-    override def before(c: HookContext, h: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+    override def before(c: HookContext, h: HookHints): UIO[Option[EvaluationContext]] =
       ZIO.succeed(hookStages.add("before")).as(None)
     override def after[A](c: HookContext, d: FlagResolution[A], h: HookHints): UIO[Unit] =
       ZIO.succeed { hookStages.add("after"); hookDetails = d.asInstanceOf[FlagResolution[Any]] }
@@ -331,8 +331,8 @@ class ConformanceSteps extends ScalaDsl with EN {
   }
 
   private def ctxHook(ctx: EvaluationContext): FeatureHook = new FeatureHook {
-    override def before(c: HookContext, h: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
-      ZIO.some((ctx, h))
+    override def before(c: HookContext, h: HookHints): UIO[Option[EvaluationContext]] =
+      ZIO.some(ctx)
   }
 
   When("""^Some flag was evaluated$""") { () =>

--- a/conformance/src/test/scala/zio/openfeature/conformance/RunConformance.scala
+++ b/conformance/src/test/scala/zio/openfeature/conformance/RunConformance.scala
@@ -11,6 +11,6 @@ import org.junit.runner.RunWith
   features = Array("classpath:zio/openfeature/conformance"),
   glue = Array("zio.openfeature.conformance"),
   plugin = Array("pretty"),
-  tags = "not @deprecated and not @reason-codes-cached and not @async and not @immutability and not @evaluation-options"
+  tags = "not @deprecated and not @reason-codes-cached and not @async and not @evaluation-options and not @immutability"
 )
 class RunConformance

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -259,11 +259,9 @@ final private[openfeature] class FeatureFlagsLive(
               case None => ZIO.refailCause(beforeCause)
             },
           beforeResult => {
-            val (effectiveCtx, hints) = beforeResult match {
-              case Some((modifiedCtx, h)) => (modifiedCtx, h)
-              case None                   => (context, initialHints)
-            }
-            val stageCtx = hookCtx.copy(evaluationContext = effectiveCtx)
+            val effectiveCtx = beforeResult.getOrElse(context)
+            val hints        = initialHints
+            val stageCtx     = hookCtx.copy(evaluationContext = effectiveCtx)
             finallyCtxRef.set((stageCtx, hints)) *>
               evaluate(effectiveCtx)
                 .tapBoth(

--- a/core/src/main/scala/zio/openfeature/Hook.scala
+++ b/core/src/main/scala/zio/openfeature/Hook.scala
@@ -128,7 +128,7 @@ trait FeatureHook {
     */
   def supportedFlagTypes: Set[FlagValueType] = FlagValueType.allTypes
 
-  def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+  def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
     ZIO.none
 
   def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
@@ -157,18 +157,16 @@ object FeatureHook {
     private def applicableHooks(flagType: FlagValueType): List[FeatureHook] =
       hooks.filter(_.supportedFlagTypes.contains(flagType))
 
-    override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+    override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
       ZIO
-        .foldLeft(applicableHooks(ctx.flagType))((ctx.evaluationContext, hints, false)) {
-          case ((currentCtx, currentHints, modified), hook) =>
-            hook.before(ctxForHook(ctx.copy(evaluationContext = currentCtx), hook), currentHints).map {
-              case Some((newCtx, newHints)) => (currentCtx.merge(newCtx), newHints, true)
-              case None                     => (currentCtx, currentHints, modified)
+        .foldLeft(applicableHooks(ctx.flagType))((ctx.evaluationContext, false)) {
+          case ((currentCtx, modified), hook) =>
+            hook.before(ctxForHook(ctx.copy(evaluationContext = currentCtx), hook), hints).map {
+              case Some(newCtx) => (currentCtx.merge(newCtx), true)
+              case None         => (currentCtx, modified)
             }
         }
-        .map { case (finalCtx, finalHints, wasModified) =>
-          if (wasModified) Some((finalCtx, finalHints)) else None
-        }
+        .map { case (finalCtx, wasModified) => if (wasModified) Some(finalCtx) else None }
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
       ZIO.foreachDiscard(applicableHooks(ctx.flagType).reverse)(hook =>
@@ -189,7 +187,7 @@ object FeatureHook {
     logAfter: Boolean = true,
     logError: Boolean = true
   ): FeatureHook = new FeatureHook {
-    override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+    override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
       ZIO
         .when(logBefore)(
           ZIO.logDebug(s"Evaluating flag '${ctx.flagKey}' (${ctx.flagType.name})")
@@ -286,7 +284,7 @@ object FeatureHook {
     // Uses HookData (per-hook mutable state) for start time instead of HookHints,
     // so that `before` can return None and avoid corrupting the compose pipeline's
     // context-modified tracking.
-    override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+    override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
       for {
         now <- Clock.nanoTime
         _   <- ZIO.succeed(ctx.hookData.set(startTimeKey, now))
@@ -342,15 +340,13 @@ object FeatureHook {
     new FeatureHook {
       private val startTimeKey = TypedKey[Long]("metrics.startTime")
 
-      override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
-        Clock.nanoTime.map { start =>
-          Some((ctx.evaluationContext, hints.add(startTimeKey, start)))
-        }
+      override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
+        Clock.nanoTime.flatMap(now => ZIO.succeed(ctx.hookData.set(startTimeKey, now))).as(None)
 
       override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
         for {
           end <- Clock.nanoTime
-          start    = hints.getOrElse(startTimeKey, end)
+          start    = ctx.hookData.get(startTimeKey).getOrElse(end)
           duration = Duration.fromNanos(end - start)
           _ <- onEvaluation(ctx.flagKey, duration, true)
         } yield ()
@@ -358,7 +354,7 @@ object FeatureHook {
       override def error(ctx: HookContext, err: FeatureFlagError, hints: HookHints): UIO[Unit] =
         for {
           end <- Clock.nanoTime
-          start    = hints.getOrElse(startTimeKey, end)
+          start    = ctx.hookData.get(startTimeKey).getOrElse(end)
           duration = Duration.fromNanos(end - start)
           _ <- onEvaluation(ctx.flagKey, duration, false)
         } yield ()
@@ -382,7 +378,7 @@ object FeatureHook {
   ): FeatureHook = new FeatureHook {
     private val startTimeKey = TypedKey[Long]("metricsDetailed.startTime")
 
-    override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+    override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
       for {
         now <- Clock.nanoTime
         _   <- ZIO.succeed(ctx.hookData.set(startTimeKey, now))
@@ -407,7 +403,7 @@ object FeatureHook {
     requireTargetingKey: Boolean = false,
     requiredAttributes: List[String] = Nil
   ): FeatureHook = new FeatureHook {
-    override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] = {
+    override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] = {
       val keyWarning = Option
         .when(requireTargetingKey && ctx.evaluationContext.targetingKey.isEmpty)(
           s"Missing targeting key for flag '${ctx.flagKey}'"

--- a/core/src/test/scala/zio/openfeature/HookDefectSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookDefectSpec.scala
@@ -46,7 +46,7 @@ object HookDefectSpec extends ZIOSpecDefault {
 
   // A hook stage that throws synchronously (not in a ZIO effect), which ZIO converts to a Die defect.
   private def throwingHook(stageName: String, calledRef: Ref[List[String]]): FeatureHook = new FeatureHook {
-    override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+    override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
       calledRef.update(_ :+ s"$stageName.before") *>
         ZIO.die(new RuntimeException(s"defect in $stageName.before"))
 
@@ -64,7 +64,7 @@ object HookDefectSpec extends ZIOSpecDefault {
   }
 
   private def safeHook(calledRef: Ref[List[String]]): FeatureHook = new FeatureHook {
-    override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+    override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
       calledRef.update(_ :+ "safe.before").as(None)
 
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
@@ -141,7 +141,7 @@ object HookDefectSpec extends ZIOSpecDefault {
         val called = new java.util.concurrent.atomic.AtomicBoolean(false)
         // This is the RECOMMENDED pattern: wrap untrusted hook code
         val safeWrapped = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             ZIO
               .attempt {
                 called.set(true)

--- a/core/src/test/scala/zio/openfeature/HookErrorRoutingSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookErrorRoutingSpec.scala
@@ -43,7 +43,7 @@ object HookErrorRoutingSpec extends ZIOSpecDefault {
   }
 
   private def recordingHook(log: Ref[List[String]]): FeatureHook = new FeatureHook {
-    override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+    override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
       log.update(_ :+ "before").as(None)
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
       log.update(_ :+ "after")
@@ -57,7 +57,7 @@ object HookErrorRoutingSpec extends ZIOSpecDefault {
     * before-hook defect.
     */
   private def beforeDiesHook(log: Ref[List[String]]): FeatureHook = new FeatureHook {
-    override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+    override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
       log.update(_ :+ "before") *> ZIO.die(new RuntimeException("defect in before"))
     override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
       log.update(_ :+ "after")
@@ -137,7 +137,7 @@ object HookErrorRoutingSpec extends ZIOSpecDefault {
           log  <- Ref.make[List[String]](Nil)
           gate <- Promise.make[Nothing, Unit]
           blockingHook = new FeatureHook {
-            override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+            override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
               log.update(_ :+ "before") *> gate.await.as(None)
             override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
               log.update(_ :+ "after")

--- a/core/src/test/scala/zio/openfeature/HookHintsImmutabilitySpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookHintsImmutabilitySpec.scala
@@ -1,0 +1,131 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderState,
+  Value
+}
+
+/** Verifies spec §4.5.3/§4.2.2.1: hook hints are immutable through the pipeline. Since `before` now returns
+  * `Option[EvaluationContext]` (no hints), a hook cannot alter the hints seen by later hooks/stages; per-hook state
+  * flows through `HookData` (the built-in `metrics` hook uses it for its start time).
+  */
+object HookHintsImmutabilitySpec extends ZIOSpecDefault {
+
+  private class SimpleProvider(evalDelayMillis: Long = 0L) extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "Simple" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) = {
+      if (evalDelayMillis > 0) Thread.sleep(evalDelayMillis) // so the metrics hook measures a non-zero duration
+      ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
+    }
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  private def buildFF(hooks: List[FeatureHook], evalDelayMillis: Long = 0L): ZIO[Scope, Throwable, FeatureFlags] = {
+    val api = OpenFeatureAPIFactory.create()
+    FeatureFlags.build(
+      new SimpleProvider(evalDelayMillis),
+      domain = Some(s"hook-hints-${java.util.UUID.randomUUID()}"),
+      version = None,
+      initialHooks = hooks,
+      statusRef = None,
+      addShutdownFinalizer = true,
+      apiOverride = Some(api),
+      evaluationTimeout = Some(5.seconds)
+    )
+  }
+
+  def spec = suite("HookHintsImmutabilitySpec")(
+    test("before can modify the evaluation context and later stages observe it (Option[EvaluationContext])") {
+      ZIO.scoped {
+        for {
+          sawMarker <- Ref.make(false)
+          hook = new FeatureHook {
+            override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
+              ZIO.succeed(Some(ctx.evaluationContext.withAttribute("marker", AttributeValue.StringValue("x"))))
+            override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+              sawMarker.set(ctx.evaluationContext.getString("marker").contains("x"))
+          }
+          ff  <- buildFF(List(hook))
+          _   <- ff.boolean("flag", default = false)
+          saw <- sawMarker.get
+        } yield assertTrue(saw)
+      }
+    },
+    test("a before hook cannot alter the hints seen by later stages") {
+      ZIO.scoped {
+        for {
+          beforeHints <- Ref.make("")
+          afterHints  <- Ref.make("")
+          hook = new FeatureHook {
+            override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
+              beforeHints.set(hints.toString).as(None)
+            override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+              afterHints.set(hints.toString)
+          }
+          ff <- buildFF(List(hook))
+          _  <- ff.boolean("flag", default = false)
+          b  <- beforeHints.get
+          a  <- afterHints.get
+        } yield assertTrue(b == a)
+      }
+    },
+    test("the built-in metrics hook reports a real (non-zero) duration via HookData, not hints") {
+      ZIO.scoped {
+        for {
+          captured <- Ref.make[Option[Duration]](None)
+          hook = FeatureHook.metrics((_, dur, _) => captured.set(Some(dur)))
+          // 60ms provider delay between the metrics hook's before and after: a duration >= 40ms proves the start time
+          // was genuinely captured in HookData (a broken capture falls back to `end`, giving a zero duration).
+          ff <- buildFF(List(hook), evalDelayMillis = 60L)
+          _  <- ff.boolean("flag", default = false)
+          c  <- captured.get
+        } yield assertTrue(c.exists(_ >= 40.millis))
+      }
+    },
+    test("two composed metrics hooks each measure their own duration (per-hook HookData scoping)") {
+      ZIO.scoped {
+        for {
+          cap1 <- Ref.make[Option[Duration]](None)
+          cap2 <- Ref.make[Option[Duration]](None)
+          h1 = FeatureHook.metrics((_, dur, _) => cap1.set(Some(dur)))
+          // A hook between the two metrics hooks whose `before` sleeps, so h1.before and h2.before capture start times
+          // ~120ms apart. If the two metrics hooks shared one HookData (scoping bug), h2.before would clobber h1's
+          // start time and both durations would be ~equal; per-hook scoping keeps h1's duration the larger by ~120ms.
+          spacer = new FeatureHook {
+            override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
+              ZIO.sleep(120.millis).as(None)
+          }
+          h2 = FeatureHook.metrics((_, dur, _) => cap2.set(Some(dur)))
+          ff <- buildFF(List(h1, spacer, h2))
+          _  <- ff.boolean("flag", default = false)
+          d1 <- cap1.get
+          d2 <- cap2.get
+        } yield assertTrue(
+          d1.isDefined,
+          d2.isDefined,
+          d1.exists(a => d2.exists(b => a >= b + 80.millis)) // h1 started ~120ms before h2 → independent start times
+        )
+      }
+    }
+  ) @@ sequential @@ withLiveClock
+}

--- a/core/src/test/scala/zio/openfeature/HookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookSpec.scala
@@ -145,14 +145,9 @@ object HookSpec extends ZIOSpecDefault {
       },
       test("compose before merges contexts preserving existing attributes") {
         val hook = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             ZIO.succeed(
-              Some(
-                (
-                  EvaluationContext.withAttributes("added" -> AttributeValue.string("value")),
-                  hints + ("hookRan" -> true)
-                )
-              )
+              Some(EvaluationContext.withAttributes("added" -> AttributeValue.string("value")))
             )
         }
 
@@ -164,32 +159,21 @@ object HookSpec extends ZIOSpecDefault {
         for {
           result <- composed.before(inputCtx, HookHints.empty)
         } yield assertTrue(result.isDefined) &&
-          assertTrue(result.get._1.getString("added").contains("value")) &&
-          assertTrue(result.get._1.getString("existing").contains("keep")) &&
-          assertTrue(result.get._2.get[Boolean]("hookRan").contains(true))
+          assertTrue(result.get.getString("added").contains("value")) &&
+          assertTrue(result.get.getString("existing").contains("keep"))
       },
       test("compose before merges contexts from multiple hooks") {
         val hook1 = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             ZIO.succeed(
-              Some(
-                (
-                  EvaluationContext.withAttributes("from-hook1" -> AttributeValue.string("h1")),
-                  hints + ("hook1" -> true)
-                )
-              )
+              Some(EvaluationContext.withAttributes("from-hook1" -> AttributeValue.string("h1")))
             )
         }
 
         val hook2 = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             ZIO.succeed(
-              Some(
-                (
-                  EvaluationContext.withAttributes("from-hook2" -> AttributeValue.string("h2")),
-                  hints + ("hook2" -> true)
-                )
-              )
+              Some(EvaluationContext.withAttributes("from-hook2" -> AttributeValue.string("h2")))
             )
         }
 
@@ -201,9 +185,9 @@ object HookSpec extends ZIOSpecDefault {
         for {
           result <- composed.before(inputCtx, HookHints.empty)
         } yield assertTrue(result.isDefined) &&
-          assertTrue(result.get._1.getString("original").contains("orig")) &&
-          assertTrue(result.get._1.getString("from-hook1").contains("h1")) &&
-          assertTrue(result.get._1.getString("from-hook2").contains("h2"))
+          assertTrue(result.get.getString("original").contains("orig")) &&
+          assertTrue(result.get.getString("from-hook1").contains("h1")) &&
+          assertTrue(result.get.getString("from-hook2").contains("h2"))
       }
     ),
     suite("FeatureHook.metrics")(
@@ -220,9 +204,8 @@ object HookSpec extends ZIOSpecDefault {
         val resolution = FlagResolution.default("metrics-test", true)
 
         for {
-          beforeResult <- hook.before(ctx, HookHints.empty)
-          hints = beforeResult.map(_._2).getOrElse(HookHints.empty)
-          _ <- hook.after(ctx, resolution, hints)
+          _ <- hook.before(ctx, HookHints.empty)
+          _ <- hook.after(ctx, resolution, HookHints.empty)
         } yield assertTrue(captured.isDefined) &&
           assertTrue(captured.get._1 == "metrics-test") &&
           assertTrue(captured.get._3 == true)
@@ -239,9 +222,8 @@ object HookSpec extends ZIOSpecDefault {
         val ctx = makeHookContext("error-test")
 
         for {
-          beforeResult <- hook.before(ctx, HookHints.empty)
-          hints = beforeResult.map(_._2).getOrElse(HookHints.empty)
-          _ <- hook.error(ctx, FeatureFlagError.FlagNotFound("error-test"), hints)
+          _ <- hook.before(ctx, HookHints.empty)
+          _ <- hook.error(ctx, FeatureFlagError.FlagNotFound("error-test"), HookHints.empty)
         } yield assertTrue(captured.isDefined) &&
           assertTrue(captured.get._1 == "error-test") &&
           assertTrue(captured.get._3 == false)
@@ -496,12 +478,12 @@ object HookSpec extends ZIOSpecDefault {
       },
       test("compose before without modifications returns None") {
         val hook1 = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             ZIO.none
         }
 
         val hook2 = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             ZIO.none
         }
 
@@ -538,7 +520,7 @@ object HookSpec extends ZIOSpecDefault {
       },
       test("hookData persists across hook stages") {
         val hook = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             ZIO.succeed {
               ctx.hookData.set("span", "my-span-id")
               None
@@ -567,7 +549,7 @@ object HookSpec extends ZIOSpecDefault {
         var hook2Value: Option[String] = None
 
         val hook1 = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             ZIO.succeed {
               ctx.hookData.set("owner", "hook1")
               None
@@ -578,7 +560,7 @@ object HookSpec extends ZIOSpecDefault {
         }
 
         val hook2 = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             ZIO.succeed {
               ctx.hookData.set("owner", "hook2")
               None

--- a/core/src/test/scala/zio/openfeature/HookStageContextSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookStageContextSpec.scala
@@ -86,8 +86,8 @@ object HookStageContextSpec extends ZIOSpecDefault {
     sawInFinally: Ref[Option[Boolean]]
   ): FeatureHook =
     new FeatureHook {
-      override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
-        ZIO.some((ctx.evaluationContext.withAttribute(marker, AttributeValue.BoolValue(true)), hints))
+      override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
+        ZIO.some(ctx.evaluationContext.withAttribute(marker, AttributeValue.BoolValue(true)))
 
       override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
         sawInAfter.set(Some(ctx.evaluationContext.getBoolean(marker).contains(true)))

--- a/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
@@ -122,7 +122,7 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
             override def before(
               ctx: HookContext,
               hints: HookHints
-            ): UIO[Option[(EvaluationContext, HookHints)]] =
+            ): UIO[Option[EvaluationContext]] =
               hookCalled.set(true).as(None)
           }
           ff     <- buildWithDomain(providerA)

--- a/core/src/test/scala/zio/openfeature/ZioApiHookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ZioApiHookSpec.scala
@@ -73,7 +73,7 @@ object ZioApiHookSpec extends ZIOSpecDefault {
 
   private def recordingHook(label: String, log: Ref[List[String]]): FeatureHook =
     new FeatureHook {
-      override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+      override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
         log.update(_ :+ label).as(None)
 
       override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =

--- a/testkit/src/test/scala/zio/openfeature/testkit/AsyncInitSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/AsyncInitSpec.scala
@@ -132,7 +132,7 @@ object AsyncInitSpec extends ZIOSpecDefault {
         for {
           hookCalled <- Ref.make(false)
           hook = new FeatureHook {
-            override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+            override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
               hookCalled.set(true).as(None)
           }
           tp     <- ZIO.service[TestFeatureProvider]

--- a/testkit/src/test/scala/zio/openfeature/testkit/FactoryMethodsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FactoryMethodsSpec.scala
@@ -92,7 +92,7 @@ object FactoryMethodsSpec extends ZIOSpecDefault {
         for {
           hookCalled <- Ref.make(false)
           hook = new FeatureHook {
-            override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+            override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
               hookCalled.set(true).as(None)
           }
           tp <- TestFeatureProvider.make(Map("flag" -> true))

--- a/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FeatureFlagsSpec.scala
@@ -261,7 +261,7 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         }
 
         val trackingHook = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             callsRef.update(_ :+ s"before:${ctx.flagKey}").as(None)
 
           override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
@@ -280,7 +280,7 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         }
 
         val invocationHook = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             callsRef.update(_ :+ s"invocation-before:${ctx.flagKey}").as(None)
 
           override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
@@ -299,12 +299,12 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         }
 
         val clientHook = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             callsRef.update(_ :+ "client-before").as(None)
         }
 
         val invocationHook = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             callsRef.update(_ :+ "invocation-before").as(None)
         }
 
@@ -349,7 +349,7 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         }
 
         val hintCheckHook = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             receivedHints.set(hints.get[String]("test-hint")).as(None)
         }
 
@@ -368,7 +368,7 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         val stringOnlyHook = new FeatureHook {
           override def supportedFlagTypes: Set[FlagValueType] = Set(FlagValueType.String)
 
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             callsRef.update(_ :+ s"before:${ctx.flagKey}").as(None)
 
           override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
@@ -779,7 +779,7 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         }
 
         val metaHook = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             capturedMeta.set(Some(ctx.clientMetadata)).as(None)
         }
 
@@ -796,7 +796,7 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         }
 
         val metaHook = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             capturedMeta.set(Some(ctx.providerMetadata)).as(None)
         }
 
@@ -855,7 +855,7 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         }
 
         val ctxCapture = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             capturedCtx.set(Some(ctx.evaluationContext)).as(None)
         }
 
@@ -889,7 +889,7 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         }
 
         val ctxCapture = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             capturedCtx.set(Some(ctx.evaluationContext)).as(None)
         }
 
@@ -975,7 +975,7 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         }
 
         val ctxCapture = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
             capturedCtxs
               .update(_ :+ (ctx.evaluationContext.targetingKey.getOrElse("unknown") -> ctx.evaluationContext))
               .as(None)
@@ -1113,8 +1113,8 @@ object FeatureFlagsSpec extends ZIOSpecDefault {
         }
 
         val hook = new FeatureHook {
-          override def before(ctx: HookContext, hints: HookHints): UIO[Option[(EvaluationContext, HookHints)]] =
-            ZIO.some((ctx.evaluationContext.withAttribute("enriched", AttributeValue.bool(true)), hints))
+          override def before(ctx: HookContext, hints: HookHints): UIO[Option[EvaluationContext]] =
+            ZIO.some(ctx.evaluationContext.withAttribute("enriched", AttributeValue.bool(true)))
 
           override def finallyAfter(ctx: HookContext, details: Option[FlagResolution[_]], hints: HookHints): UIO[Unit] =
             finallyRan.set(true)


### PR DESCRIPTION
## Summary

Hook hints were mutable through the pipeline: `FeatureHook.before` returned `Option[(EvaluationContext, HookHints)]`, and the returned hints were threaded into later hooks and all subsequent stages. Spec §4.5.3/§4.2.2.1 require hints to be immutable; `HookData` (§4.6) is the designated per-hook state channel.

**BREAKING change:** `FeatureHook.before` now returns `UIO[Option[EvaluationContext]]` — a `before` hook can still modify the evaluation context but can no longer alter the hints seen by later hooks and stages. The built-in `FeatureHook.metrics` hook was migrated to store its start time in `ctx.hookData` (mirroring `metricsDetailed`) instead of writing it into the hints.

**Migration:** a `before` that returned `Some((newContext, newHints))` should return `Some(newContext)` and move any per-hook state to `ctx.hookData`.

## Changes

- `Hook.scala`: `before` signature (trait + `compose` + built-in hooks); `metrics` migrated to `HookData`.
- `FeatureFlagsLive.runHookPipeline`: hints are the immutable `initialHints` for every stage; the before result contributes only the (optionally modified) context.
- ~35 `before`-override sites across core/testkit/conformance tests migrated to the new signature.

## Tests

New `HookHintsImmutabilitySpec`: before-modifies-context flows to later stages; hints are unchanged across stages; the metrics hook reports a real (non-zero) duration via `HookData`; two composed metrics hooks each measure their own duration (per-hook `HookData` scoping).

## Note

The `@immutability` conformance scenario asserts evaluation-*context* immutability (spec 1.4.15) and has no step definitions; it is unrelated to hook-*hints* immutability (spec 4.5.3) and remains excluded with an accurate rationale — re-enabling it needs those step definitions implemented (separate conformance-suite work).

## Verification

Full Scala 3 test suite (all modules), Scala 2.13 core cross-compile, `conformance/test`, `conformanceZioBdd/test` (Java 21), and `scalafmtCheckAll` pass (also enforced by the pre-push gate).

Closes #247

Milestone: 1.0-readiness