### PR TITLE
Preserve provider-specific resolution reasons instead of collapsing to Unknown (spec 1.4.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Provider-specific resolution reasons are preserved instead of collapsed to `Unknown`** (#248). Per spec §1.4.7
+  reasons are provider-extensible strings, but any unrecognized reason was mapped to `ResolutionReason.Unknown`,
+  discarding the provider's actual disposition (Optimizely/flagd emit custom reasons). Added
+  `ResolutionReason.Other(value)` and route non-null unrecognized reasons to it verbatim; `Unknown` now means only a
+  genuinely absent (null) reason. Note: `ResolutionReason` gained a case, so exhaustive matches on it must handle
+  `Other`.
+
 - **Hook pipeline stage routing now matches the spec** (#246). Two violations in `runHookPipeline`: (1) a returned
   resolution carrying an error code (`FLAG_NOT_FOUND`, `TYPE_MISMATCH`, ...) ran *both* the `after` and `error` stages —
   per spec §4.3.6/§4.4.6 an error-code resolution is abnormal execution, so it now runs `error` only (`after` runs only

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
@@ -174,6 +174,7 @@ object ConformanceSpec extends ZIOSteps[Any, World] {
     case ResolutionReason.Unknown        => "UNKNOWN"
     case ResolutionReason.Stale          => "STALE"
     case ResolutionReason.Error          => "ERROR"
+    case ResolutionReason.Other(v)       => v
   }
 
   private def errorCodeName(c: ErrorCode): String = c match {

--- a/conformance/src/test/scala/zio/openfeature/conformance/ConformanceSteps.scala
+++ b/conformance/src/test/scala/zio/openfeature/conformance/ConformanceSteps.scala
@@ -176,6 +176,7 @@ class ConformanceSteps extends ScalaDsl with EN {
     case ResolutionReason.Unknown        => "UNKNOWN"
     case ResolutionReason.Stale          => "STALE"
     case ResolutionReason.Error          => "ERROR"
+    case ResolutionReason.Other(v)       => v
   }
 
   private def errorCodeName(c: ErrorCode): String = c match {

--- a/core/src/main/scala-2/zio/openfeature/FlagResolution.scala
+++ b/core/src/main/scala-2/zio/openfeature/FlagResolution.scala
@@ -11,6 +11,9 @@ object ResolutionReason {
   case object Unknown        extends ResolutionReason
   case object Stale          extends ResolutionReason
   case object Error          extends ResolutionReason
+  // Provider-specific reason passed through verbatim (spec 1.4.7 — reasons are provider-extensible strings). `Unknown`
+  // is reserved for a genuinely absent (null) reason.
+  final case class Other(value: String) extends ResolutionReason
 }
 
 sealed trait MetadataValue extends Product with Serializable {

--- a/core/src/main/scala-3/zio/openfeature/FlagResolution.scala
+++ b/core/src/main/scala-3/zio/openfeature/FlagResolution.scala
@@ -10,6 +10,9 @@ enum ResolutionReason:
   case Unknown
   case Stale
   case Error
+  // Provider-specific reason passed through verbatim (spec 1.4.7 — reasons are provider-extensible strings). `Unknown`
+  // is reserved for a genuinely absent (null) reason.
+  case Other(value: String)
 
 enum MetadataValue:
   case BooleanValue(value: Boolean)

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -503,20 +503,24 @@ final private[openfeature] class FeatureFlagsLive(
     }
 
   private def toResolutionReason(reason: String): ResolutionReason =
-    Option(reason)
-      .map(_.toUpperCase)
-      .map {
-        case "STATIC"          => ResolutionReason.Static
-        case "DEFAULT"         => ResolutionReason.Default
-        case "TARGETING_MATCH" => ResolutionReason.TargetingMatch
-        case "SPLIT"           => ResolutionReason.Split
-        case "CACHED"          => ResolutionReason.Cached
-        case "DISABLED"        => ResolutionReason.Disabled
-        case "STALE"           => ResolutionReason.Stale
-        case "ERROR"           => ResolutionReason.Error
-        case _                 => ResolutionReason.Unknown
-      }
-      .getOrElse(ResolutionReason.Unknown)
+    Option(reason) match {
+      // `Unknown` is reserved for a genuinely absent reason. A non-null but unrecognized reason is a provider-specific
+      // one and must be passed through verbatim (spec 1.4.7), not collapsed — otherwise Optimizely/flagd custom reasons
+      // are lost to hooks, analytics, and debugging.
+      case None => ResolutionReason.Unknown
+      case Some(r) =>
+        r.toUpperCase match {
+          case "STATIC"          => ResolutionReason.Static
+          case "DEFAULT"         => ResolutionReason.Default
+          case "TARGETING_MATCH" => ResolutionReason.TargetingMatch
+          case "SPLIT"           => ResolutionReason.Split
+          case "CACHED"          => ResolutionReason.Cached
+          case "DISABLED"        => ResolutionReason.Disabled
+          case "STALE"           => ResolutionReason.Stale
+          case "ERROR"           => ResolutionReason.Error
+          case _                 => ResolutionReason.Other(r)
+        }
+    }
 
   private def convertImmutableMetadata(javaMeta: dev.openfeature.sdk.ImmutableMetadata): FlagMetadata = {
     val javaMap = javaMeta.asUnmodifiableMap()

--- a/core/src/test/scala/zio/openfeature/CustomResolutionReasonSpec.scala
+++ b/core/src/test/scala/zio/openfeature/CustomResolutionReasonSpec.scala
@@ -1,0 +1,80 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderState,
+  Value
+}
+
+/** Spec §1.4.7: resolution reasons are provider-extensible strings. A provider-specific reason must be passed through
+  * verbatim as `ResolutionReason.Other(value)`, not collapsed to `Unknown` (which is reserved for an absent reason).
+  */
+object CustomResolutionReasonSpec extends ZIOSpecDefault {
+
+  private class ReasonProvider(reason: String) extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "Reason" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](true, reason)
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, reason)
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, reason)
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, reason)
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, reason)
+  }
+
+  private def buildFF(reason: String): ZIO[Scope, Throwable, FeatureFlags] = {
+    val api = OpenFeatureAPIFactory.create()
+    FeatureFlags.build(
+      new ReasonProvider(reason),
+      domain = Some(s"reason-${java.util.UUID.randomUUID()}"),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = true,
+      apiOverride = Some(api),
+      evaluationTimeout = Some(5.seconds)
+    )
+  }
+
+  def spec = suite("CustomResolutionReasonSpec")(
+    test("a provider-specific reason is passed through as Other, not collapsed to Unknown") {
+      ZIO.scoped {
+        for {
+          ff  <- buildFF("PROVIDER_SPECIFIC")
+          res <- ff.booleanDetails("flag", default = false)
+        } yield assertTrue(res.reason == ResolutionReason.Other("PROVIDER_SPECIFIC"))
+      }
+    },
+    test("a recognized reason still maps to its canonical case") {
+      ZIO.scoped {
+        for {
+          ff  <- buildFF("TARGETING_MATCH")
+          res <- ff.booleanDetails("flag", default = false)
+        } yield assertTrue(res.reason == ResolutionReason.TargetingMatch)
+      }
+    },
+    test("a null reason maps to Unknown, not Other") {
+      ZIO.scoped {
+        for {
+          ff  <- buildFF(null)
+          res <- ff.booleanDetails("flag", default = false)
+        } yield assertTrue(res.reason == ResolutionReason.Unknown)
+      }
+    }
+  ) @@ sequential @@ withLiveClock
+}


### PR DESCRIPTION
## Summary

Any unrecognized provider resolution reason was collapsed to `ResolutionReason.Unknown`, discarding information the spec says must pass through (§1.4.7: reasons are provider-extensible strings; the Java SDK forwards them verbatim). Providers like Optimizely/flagd emit custom reasons that users could not observe in `FlagResolution` or hooks.

- Added `ResolutionReason.Other(value: String)` (both Scala 3 and Scala 2 sources).
- `toResolutionReason` now routes a non-null unrecognized reason to `Other(reason)` verbatim; `Unknown` is reserved for a genuinely absent (null) reason.
- Updated the two conformance `reasonName` reverse-mappings for the new case (`Other(v) => v`).

Note: `ResolutionReason` gained a case, so any exhaustive match on it must handle `Other`.

## Tests

New `CustomResolutionReasonSpec`: a provider-specific reason surfaces as `Other(...)`; recognized reasons still map to their canonical case; a null reason maps to `Unknown`.

## Verification

Full Scala 3 test suite (all modules), Scala 2.13 core cross-compile, `conformance/test`, `conformanceZioBdd/test` (Java 21), and `scalafmtCheckAll` pass.

Closes #248

Milestone: 1.0-readiness