### PR TITLE
Stop silently coercing int-range Long values to Double (spec 3.1.2/1.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Int-range `Long` values are no longer silently coerced to `Double`** (#249). At several layers a `Long` was mapped
+  to `Double`, so even small longs reached providers as `Double` (breaking `instanceof Integer` targeting rules) and a
+  long-typed flag evaluated through the provider's double resolver could `TYPE_MISMATCH`. Now an int-range `Long` is
+  sent as an `Integer` in context attributes (`ContextConverter`), tracking details (`FeatureFlagsLive`), and HOCON
+  values (`HoconProvider`), and a long-typed flag evaluation routes through the SDK's integer resolver for int-range
+  values (`ClientEvaluator`). OpenFeature's `Value` has no `Long` type, so out-of-int-range longs still use `Double`
+  (exact for integers up to 2^53; larger values lose precision — this bound is now documented rather than silently
+  applied to all longs). Spec §3.1.2 (typed context values), §1.3.4 (typed evaluation).
+
 - **Provider-specific resolution reasons are preserved instead of collapsed to `Unknown`** (#248). Per spec §1.4.7
   reasons are provider-extensible strings, but any unrecognized reason was mapped to `ResolutionReason.Unknown`,
   discarding the provider's actual disposition (Optimizely/flagd emit custom reasons). Added

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -984,10 +984,13 @@ final private[openfeature] class FeatureFlagsLive(
 
   private def addAttributeToDetails(details: MutableTrackingEventDetails, key: String, value: Any): Unit =
     value match {
-      case b: Boolean                 => details.add(key, b)
-      case s: String                  => details.add(key, s)
-      case i: Int                     => details.add(key, Integer.valueOf(i))
-      case l: Long                    => details.add(key, java.lang.Double.valueOf(l.toDouble))
+      case b: Boolean => details.add(key, b)
+      case s: String  => details.add(key, s)
+      case i: Int     => details.add(key, Integer.valueOf(i))
+      // int-range long → Integer (no precision loss, matches integer targeting); else Double (lossy beyond 2^53).
+      case l: Long =>
+        if (l.isValidInt) details.add(key, Integer.valueOf(l.toInt))
+        else details.add(key, java.lang.Double.valueOf(l.toDouble))
       case d: Double                  => details.add(key, d)
       case f: Float                   => details.add(key, java.lang.Double.valueOf(f.toDouble))
       case instant: java.time.Instant => details.add(key, instant)

--- a/core/src/main/scala/zio/openfeature/internal/ClientEvaluator.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ClientEvaluator.scala
@@ -113,7 +113,9 @@ private[openfeature] object ClientEvaluator {
       details.getValue.asInstanceOf[java.lang.Integer].intValue()
   }
 
-  // Long uses Double SDK method (exact integers up to 2^53)
+  // An int-range long routes through the SDK's Integer method so a flag stored as an integer resolves against the
+  // provider's integer resolver (rather than its double resolver, which can TYPE_MISMATCH). Out-of-int-range longs
+  // still use the Double method (exact for integers up to 2^53). `extractValue` accepts either numeric result.
   implicit val longEvaluator: ClientEvaluator[Long] = new ClientEvaluator[Long] {
     def evaluate(
       client: OFClient,
@@ -121,12 +123,13 @@ private[openfeature] object ClientEvaluator {
       default: Long,
       context: dev.openfeature.sdk.EvaluationContext
     ): Task[FlagEvaluationDetails[_]] =
-      ZIO.attemptBlocking(
-        client.getDoubleDetails(key, java.lang.Double.valueOf(default.toDouble), context)
-      )
+      if (default.isValidInt)
+        ZIO.attemptBlocking(client.getIntegerDetails(key, Integer.valueOf(default.toInt), context))
+      else
+        ZIO.attemptBlocking(client.getDoubleDetails(key, java.lang.Double.valueOf(default.toDouble), context))
 
     def extractValue(details: FlagEvaluationDetails[_]): Long =
-      details.getValue.asInstanceOf[java.lang.Double].longValue()
+      details.getValue.asInstanceOf[java.lang.Number].longValue()
   }
 
   // Float uses Double SDK method with conversion

--- a/core/src/main/scala/zio/openfeature/internal/ContextConverter.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ContextConverter.scala
@@ -23,10 +23,14 @@ private[openfeature] object ContextConverter {
 
   private def addAttributeToContext(ctx: MutableContext, key: String, attr: AttributeValue): Unit =
     attr match {
-      case AttributeValue.BoolValue(b)     => ctx.add(key, b)
-      case AttributeValue.StringValue(s)   => ctx.add(key, s)
-      case AttributeValue.IntValue(i)      => ctx.add(key, Integer.valueOf(i))
-      case AttributeValue.LongValue(l)     => ctx.add(key, java.lang.Double.valueOf(l.toDouble))
+      case AttributeValue.BoolValue(b)   => ctx.add(key, b)
+      case AttributeValue.StringValue(s) => ctx.add(key, s)
+      case AttributeValue.IntValue(i)    => ctx.add(key, Integer.valueOf(i))
+      // OpenFeature's Value has no Long: send an int-range long as Integer so provider targeting rules that do
+      // `instanceof Integer` match, and only fall back to Double (lossy beyond 2^53) for out-of-int-range values.
+      case AttributeValue.LongValue(l) =>
+        if (l.isValidInt) ctx.add(key, Integer.valueOf(l.toInt))
+        else ctx.add(key, java.lang.Double.valueOf(l.toDouble))
       case AttributeValue.DoubleValue(d)   => ctx.add(key, d)
       case AttributeValue.InstantValue(dt) => ctx.add(key, dt)
       case AttributeValue.ListValue(list) =>
@@ -43,7 +47,7 @@ private[openfeature] object ContextConverter {
     case AttributeValue.BoolValue(b)     => new Value(b)
     case AttributeValue.StringValue(s)   => new Value(s)
     case AttributeValue.IntValue(i)      => new Value(i)
-    case AttributeValue.LongValue(l)     => new Value(l.toDouble)
+    case AttributeValue.LongValue(l)     => if (l.isValidInt) new Value(l.toInt) else new Value(l.toDouble)
     case AttributeValue.DoubleValue(d)   => new Value(d)
     case AttributeValue.InstantValue(dt) => new Value(dt)
     case AttributeValue.ListValue(list) =>

--- a/core/src/test/scala/zio/openfeature/LongCoercionSpec.scala
+++ b/core/src/test/scala/zio/openfeature/LongCoercionSpec.scala
@@ -1,0 +1,154 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderState,
+  TrackingEventDetails => OFTrackingEventDetails,
+  Value
+}
+import java.util.concurrent.atomic.AtomicReference
+
+/** Spec §3.1.2 / §1.3.4: int-range `Long`s must not be silently coerced to `Double`. A small long in the context
+  * reaches providers as an `Integer` (so `instanceof Integer` targeting rules match), and a long-typed flag evaluation
+  * routes through the provider's integer resolver rather than its double resolver.
+  */
+object LongCoercionSpec extends ZIOSpecDefault {
+
+  /** Records the runtime class of the `"id"` context attribute as the provider actually receives it. */
+  private class InspectingProvider(seen: AtomicReference[String]) extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "Inspecting" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) = {
+      val v = c.getValue("id")
+      seen.set(if (v == null) "absent" else v.asObject().getClass.getSimpleName)
+      ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
+    }
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  /** Returns distinct values from the integer vs double resolver, so we can tell which one `ff.long` dispatched to. */
+  private class ResolverProvider extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "Resolver" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](Integer.valueOf(7), "STATIC")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](java.lang.Double.valueOf(99.0), "STATIC")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  /** Records the runtime class of the `"id"` attribute as it arrives in the tracking details. */
+  private class TrackInspectingProvider(seen: AtomicReference[String]) extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "TrackInspecting" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def track(
+      eventName: String,
+      ctx: OFEvaluationContext,
+      details: OFTrackingEventDetails
+    ): Unit = {
+      val v = details.getValue("id")
+      seen.set(if (v == null) "absent" else v.asObject().getClass.getSimpleName)
+    }
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  private def buildFF(provider: EventProvider): ZIO[Scope, Throwable, FeatureFlags] = {
+    val api = OpenFeatureAPIFactory.create()
+    FeatureFlags.build(
+      provider,
+      domain = Some(s"long-${java.util.UUID.randomUUID()}"),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = true,
+      apiOverride = Some(api),
+      evaluationTimeout = Some(5.seconds)
+    )
+  }
+
+  def spec = suite("LongCoercionSpec")(
+    test("an int-range Long context attribute reaches the provider as an Integer, not a Double") {
+      val seen = new AtomicReference[String]("unset")
+      ZIO.scoped {
+        for {
+          ff <- buildFF(new InspectingProvider(seen))
+          ctx = EvaluationContext("user").withAttribute("id", AttributeValue.LongValue(42L))
+          _ <- ff.boolean("flag", default = false, ctx)
+        } yield assertTrue(seen.get() == "Integer")
+      }
+    },
+    test("an out-of-int-range Long context attribute still reaches the provider as a Double") {
+      val seen = new AtomicReference[String]("unset")
+      ZIO.scoped {
+        for {
+          ff <- buildFF(new InspectingProvider(seen))
+          ctx = EvaluationContext("user").withAttribute("id", AttributeValue.LongValue(Long.MaxValue))
+          _ <- ff.boolean("flag", default = false, ctx)
+        } yield assertTrue(seen.get() == "Double")
+      }
+    },
+    test("an int-range long flag evaluation routes through the provider's integer resolver") {
+      ZIO.scoped {
+        for {
+          ff <- buildFF(new ResolverProvider)
+          v  <- ff.long("flag", default = 0L)
+        } yield assertTrue(v == 7L) // 7 from the integer resolver, not 99 from the double resolver
+      }
+    },
+    test("an out-of-int-range long flag evaluation still routes through the double resolver") {
+      ZIO.scoped {
+        for {
+          ff <- buildFF(new ResolverProvider)
+          v  <- ff.long("flag", default = Long.MaxValue)
+        } yield assertTrue(v == 99L) // 99 from the double resolver
+      }
+    },
+    test("an int-range Long tracking attribute is sent as an Integer, not a Double") {
+      val seen = new AtomicReference[String]("unset")
+      ZIO.scoped {
+        for {
+          ff <- buildFF(new TrackInspectingProvider(seen))
+          _  <- ff.track("purchase", TrackingEventDetails(Map("id" -> 42L)))
+        } yield assertTrue(seen.get() == "Integer")
+      }
+    }
+  ) @@ sequential @@ withLiveClock
+}

--- a/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
@@ -105,9 +105,13 @@ final class HoconProvider private (
       case ConfigValueType.NUMBER =>
         cv.unwrapped() match {
           case i: java.lang.Integer => new Value(i.intValue())
-          case l: java.lang.Long    => new Value(l.doubleValue())
-          case d: java.lang.Double  => new Value(d)
-          case other                => new Value(other.toString)
+          // int-range long → Integer so it keeps an integer type (matching provider `instanceof Integer` targeting),
+          // rather than a Double; out-of-int-range longs fall back to Double (lossy beyond 2^53). Mostly defensive:
+          // HOCON parses int-range numbers as Integer already, so this branch typically sees only large values.
+          case l: java.lang.Long =>
+            if (l.longValue().isValidInt) new Value(l.intValue()) else new Value(l.doubleValue())
+          case d: java.lang.Double => new Value(d)
+          case other               => new Value(other.toString)
         }
       case ConfigValueType.STRING => new Value(cv.unwrapped().asInstanceOf[String])
       case ConfigValueType.OBJECT =>


### PR DESCRIPTION
## Summary

`Long` values were silently coerced to `Double` at several independent layers, so even small longs reached providers as `Double` (breaking `instanceof Integer` targeting rules) and a long-typed flag evaluated through the provider's double resolver could `TYPE_MISMATCH`. OpenFeature's `Value` has no `Long` type, so the fix routes int-range longs through `Integer` and only falls back to `Double` for out-of-int-range values.

- `ContextConverter` (context attributes → provider), `FeatureFlagsLive.addAttributeToDetails` (tracking), `HoconProvider.configValueToSdkValue`: int-range `Long` → `Integer`, else `Double`.
- `ClientEvaluator.longEvaluator`: an int-range long-typed evaluation now dispatches to the SDK's **integer** resolver (so an integer-stored flag matches), out-of-int-range still uses the double resolver.

Out-of-int-range longs still use `Double` (exact for integers up to 2^53; beyond that precision is lost — the bound is now documented rather than silently applied to every long). Optimizely `ContextTransformer` is a separate issue (#266) and is not touched here.

## Tests

`LongCoercionSpec`: int-range Long context attribute → `Integer` (and out-of-range → `Double`); long flag eval → integer resolver (and out-of-range → double resolver); int-range Long tracking attribute → `Integer`.

## Verification

Full Scala 3 suite (all modules), Scala 2.13 core+extras cross-compile, `conformance/test`, `conformanceZioBdd/test` (Java 21), scalafmt — all pass.

Closes #249

Milestone: 1.0-readiness