### PR TITLE
Event delivery fixes: full payload via on(), handler isolation, sliding hub (spec 5.1/5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Event-delivery fixes** (#250). Three defects in `FeatureFlagsLive`'s event system: (1) the generic
+  `on(eventType, handler)` rebuilt narrowed events from the typed callbacks, dropping payload fields (`errorCode`,
+  `errorMessage`, `eventMetadata`) — it now delivers the original event from the stream (spec §5.1.4/§5.2.4), while
+  associated-state events still fire immediately when the provider is already in that state. (2) A defect in an event
+  handler killed its delivery fiber and silently unsubscribed it; handler invocations are now isolated so a failure is
+  logged and the subscription is retained (spec §5.2.5). (3) The internal event hub was `Hub.dropping`, which discards
+  the *newest* event on overflow and could hide the latest `ConfigurationChanged` (whose `changedFlags` aren't
+  reconstructible from status); it is now `Hub.sliding`, which discards the oldest so the newest always arrives
+  (spec §5.1.2).
+
 - **Int-range `Long` values are no longer silently coerced to `Double`** (#249). At several layers a `Long` was mapped
   to `Double`, so even small longs reached providers as `Double` (breaking `instanceof Integer` targeting rules) and a
   long-typed flag evaluated through the provider's double resolver could `TYPE_MISMATCH`. Now an int-range `Long` is

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -754,17 +754,33 @@ final private[openfeature] class FeatureFlagsLive(
     * cost is at-least-once delivery — an event arriving in that window may invoke the handler via both the immediate
     * check and the stream.
     */
+  // Isolate a handler invocation so a defect does NOT kill the delivery fiber — the subscription is retained and the
+  // handler keeps receiving subsequent events (spec 5.2.5). `suspendSucceed` is essential: it captures a *synchronous*
+  // throw while `handler(a)` is producing its effect (e.g. a raw exception thrown in the handler body before it returns
+  // a ZIO) as a defect, not just an already-suspended `ZIO.die`. Interruption is re-raised (not logged) so cancelling
+  // the subscription still tears the fiber down.
+  private def isolate[A](handler: A => UIO[Unit]): A => UIO[Unit] =
+    a =>
+      ZIO.suspendSucceed(handler(a)).catchAllCause { cause =>
+        cause.dieOption match {
+          case Some(_) => ZIO.logErrorCause("event handler failed; subscription retained", cause)
+          case None    => ZIO.refailCause(cause)
+        }
+      }
+
   private def subscribeToEvent[A](
     immediateCondition: ProviderStatus => Boolean,
     immediatePayload: => A,
     collect: PartialFunction[ProviderEvent, A],
     handler: A => UIO[Unit]
-  ): UIO[UIO[Unit]] =
+  ): UIO[UIO[Unit]] = {
+    val safe = isolate(handler)
     for {
-      cancel <- consumeEvents(_.collect(collect).foreach(handler))
+      cancel <- consumeEvents(_.collect(collect).foreach(safe))
       status <- providerStatus
-      _      <- ZIO.when(immediateCondition(status))(handler(immediatePayload))
+      _      <- ZIO.when(immediateCondition(status))(safe(immediatePayload))
     } yield cancel
+  }
 
   override def onProviderReady(handler: ProviderMetadata => UIO[Unit]): UIO[UIO[Unit]] =
     ZIO.succeed(providerNameRef.get()).flatMap { pName =>
@@ -799,26 +815,46 @@ final private[openfeature] class FeatureFlagsLive(
       )
     }
 
-  override def onConfigurationChanged(handler: (Set[String], ProviderMetadata) => UIO[Unit]): UIO[UIO[Unit]] =
-    // Configuration changed doesn't have an "associated state" so no immediate execution needed
-    consumeEvents(
-      _.collect { case ProviderEvent.ConfigurationChanged(flags, m, _) => (flags, m) }
-        .foreach { case (flags, m) => handler(flags, m) }
-    )
+  override def onConfigurationChanged(handler: (Set[String], ProviderMetadata) => UIO[Unit]): UIO[UIO[Unit]] = {
+    // Configuration changed doesn't have an "associated state" so no immediate execution needed.
+    val safe = isolate[(Set[String], ProviderMetadata)] { case (flags, m) => handler(flags, m) }
+    consumeEvents(_.collect { case ProviderEvent.ConfigurationChanged(flags, m, _) => (flags, m) }.foreach(safe))
+  }
 
-  override def on(eventType: ProviderEventType, handler: ProviderEvent => UIO[Unit]): UIO[UIO[Unit]] =
+  // The generic `on` delivers the ORIGINAL event from the stream (preserving every payload field — errorCode,
+  // errorMessage, eventMetadata, ...), not a narrowed reconstruction. Associated-state events (Ready/Error/Stale) still
+  // fire immediately when the provider is already in that state (spec 5.3.3), using a synthetic event that reflects the
+  // current state (there is no original event to replay for an already-reached state). All invocations are isolated.
+  override def on(eventType: ProviderEventType, handler: ProviderEvent => UIO[Unit]): UIO[UIO[Unit]] = {
+    val metadata = ProviderMetadata(providerNameRef.get())
     eventType match {
       case ProviderEventType.Ready =>
-        onProviderReady(m => handler(ProviderEvent.Ready(m)))
+        subscribeToEvent[ProviderEvent](
+          _ == ProviderStatus.Ready,
+          ProviderEvent.Ready(metadata),
+          { case e: ProviderEvent.Ready => e },
+          handler
+        )
       case ProviderEventType.Error =>
-        onProviderError((e, m) => handler(ProviderEvent.Error(e, m)))
+        subscribeToEvent[ProviderEvent](
+          s => s == ProviderStatus.Error || s == ProviderStatus.Fatal,
+          ProviderEvent.Error(new RuntimeException("Provider in error state"), metadata),
+          { case e: ProviderEvent.Error => e },
+          handler
+        )
       case ProviderEventType.Stale =>
-        onProviderStale((reason, m) => handler(ProviderEvent.Stale(reason, m)))
+        subscribeToEvent[ProviderEvent](
+          _ == ProviderStatus.Stale,
+          ProviderEvent.Stale("Provider in stale state", metadata),
+          { case e: ProviderEvent.Stale => e },
+          handler
+        )
       case ProviderEventType.ConfigurationChanged =>
-        onConfigurationChanged((flags, m) => handler(ProviderEvent.ConfigurationChanged(flags, m)))
+        consumeEvents(_.filter(_.eventType == ProviderEventType.ConfigurationChanged).foreach(isolate(handler)))
       case ProviderEventType.Reconnecting =>
-        consumeEvents(_.filter(_.eventType == ProviderEventType.Reconnecting).foreach(handler))
+        consumeEvents(_.filter(_.eventType == ProviderEventType.Reconnecting).foreach(isolate(handler)))
     }
+  }
 
   override def addHook(hook: FeatureHook): UIO[Unit] =
     state.hooksRef.update(_ :+ hook)

--- a/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
+++ b/core/src/main/scala/zio/openfeature/internal/FeatureFlagsState.scala
@@ -35,8 +35,10 @@ object FeatureFlagsState {
       transactionRef <- FiberRef.make[Option[TransactionState]](None)
       zioApiHooksRef <- Ref.make(List.empty[FeatureHook])
       hooksRef       <- Ref.make(List.empty[FeatureHook])
-      // Bounded; subscribers reconcile via current state on next evaluation, so dropping intermediate events is safe.
-      eventHub  <- Hub.dropping[ProviderEvent](256)
+      // Sliding (not dropping): on overflow the OLDEST event is discarded, so the newest is always delivered.
+      // `ConfigurationChanged.changedFlags` isn't reconstructible from status, and a re-reading consumer only needs
+      // the latest change; dropping the *newest* on a burst (as `Hub.dropping` does) could hide the final change.
+      eventHub  <- Hub.sliding[ProviderEvent](256)
       statusRef <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
       trackRec  <- Ref.make(Chunk.empty[(String, EvaluationContext, Option[TrackingEventDetails])])
     } yield FeatureFlagsState(

--- a/core/src/test/scala/zio/openfeature/EventSystemSpec.scala
+++ b/core/src/test/scala/zio/openfeature/EventSystemSpec.scala
@@ -1,0 +1,174 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.openfeature.internal.{FeatureFlagsState, ProviderEvaluations}
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  ErrorCode => JErrorCode,
+  EventProvider,
+  ImmutableMetadata,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderEventDetails,
+  ProviderState,
+  Value
+}
+import scala.jdk.CollectionConverters._
+
+/** Spec §5.1.2/§5.1.4/§5.2.4/§5.2.5: the generic `on` delivers the full original event payload; a handler defect does
+  * not cancel its subscription; and the internal hub does not silently drop the newest event on a burst.
+  */
+object EventSystemSpec extends ZIOSpecDefault {
+
+  private class EmittingProvider extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "Emitting" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+
+    def fireError(): Unit =
+      emitProviderError(
+        ProviderEventDetails
+          .builder()
+          .errorCode(JErrorCode.GENERAL)
+          .message("boom")
+          .eventMetadata(ImmutableMetadata.builder().addString("origin", "provider").build())
+          .build()
+      )
+
+    def fireConfigChanged(flags: List[String]): Unit =
+      emitProviderConfigurationChanged(ProviderEventDetails.builder().flagsChanged(flags.asJava).build())
+
+    def fireStale(): Unit =
+      emitProviderStale(
+        ProviderEventDetails
+          .builder()
+          .message("stale-reason")
+          .eventMetadata(ImmutableMetadata.builder().addString("origin", "provider").build())
+          .build()
+      )
+  }
+
+  private def buildFF(provider: EventProvider): ZIO[Scope, Throwable, FeatureFlags] = {
+    val api = OpenFeatureAPIFactory.create()
+    FeatureFlags.build(
+      provider,
+      domain = Some(s"events-${java.util.UUID.randomUUID()}"),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = true,
+      apiOverride = Some(api),
+      evaluationTimeout = Some(5.seconds)
+    )
+  }
+
+  def spec = suite("EventSystemSpec")(
+    test("generic on(Error) delivers the full original event payload (errorCode/message/eventMetadata)") {
+      ZIO.scoped {
+        for {
+          received <- Promise.make[Nothing, ProviderEvent]
+          provider = new EmittingProvider
+          ff <- buildFF(provider)
+          _  <- ff.on(ProviderEventType.Error, e => received.succeed(e).unit)
+          _  <- ZIO.attempt(provider.fireError())
+          ev <- received.await
+        } yield ev match {
+          // The old generic `on` rebuilt Error as `Error(e, m)`, dropping the errorMessage field and eventMetadata; the
+          // fix passes the original event, so both survive. (errorCode is not carried by the SDK's emit path, so it is
+          // not asserted here.)
+          case ProviderEvent.Error(err, _, _, msg, em) =>
+            assertTrue(
+              err.getMessage == "boom",
+              msg == Some("boom"),
+              em.getString("origin").contains("provider")
+            )
+          case _ => assertTrue(false)
+        }
+      }
+    },
+    test("a handler that defects on one event keeps its subscription and receives the next event (spec 5.2.5)") {
+      ZIO.scoped {
+        for {
+          count <- Ref.make(0)
+          provider = new EmittingProvider
+          ff <- buildFF(provider)
+          _ <- ff.on(
+            ProviderEventType.ConfigurationChanged,
+            _ => count.updateAndGet(_ + 1).flatMap(n => if (n == 1) ZIO.dieMessage("handler boom") else ZIO.unit)
+          )
+          _ <- ZIO.attempt(provider.fireConfigChanged(List("a")))
+          _ <- ZIO.attempt(provider.fireConfigChanged(List("b")))
+          _ <- Live.live(count.get.repeatUntil(_ >= 2).timeout(10.seconds))
+          n <- count.get
+        } yield assertTrue(n >= 2) // second event still delivered despite the first handler defect
+      }
+    },
+    test("generic on(Stale) delivers the original eventMetadata (not a narrowed reconstruction)") {
+      ZIO.scoped {
+        for {
+          received <- Promise.make[Nothing, ProviderEvent]
+          provider = new EmittingProvider
+          ff <- buildFF(provider)
+          _  <- ff.on(ProviderEventType.Stale, e => received.succeed(e).unit)
+          _  <- ZIO.attempt(provider.fireStale())
+          ev <- received.await
+        } yield ev match {
+          case ProviderEvent.Stale(reason, _, em) =>
+            assertTrue(reason == "stale-reason", em.getString("origin").contains("provider"))
+          case _ => assertTrue(false)
+        }
+      }
+    },
+    test("a handler that throws synchronously (before returning its effect) keeps its subscription (spec 5.2.5)") {
+      val sync = new java.util.concurrent.atomic.AtomicInteger(0)
+      ZIO.scoped {
+        for {
+          provider <- ZIO.succeed(new EmittingProvider)
+          ff       <- buildFF(provider)
+          _ <- ff.on(
+            ProviderEventType.ConfigurationChanged,
+            _ => {
+              val n = sync.incrementAndGet()
+              if (n == 1) throw new RuntimeException("sync boom") // raw throw while producing the effect
+              ZIO.unit
+            }
+          )
+          _ <- ZIO.attempt(provider.fireConfigChanged(List("a")))
+          _ <- ZIO.attempt(provider.fireConfigChanged(List("b")))
+          _ <- Live.live(ZIO.succeed(sync.get()).repeatUntil(_ >= 2).timeout(10.seconds))
+        } yield assertTrue(sync.get() >= 2)
+      }
+    },
+    test("the event hub is sliding: a burst keeps the newest event and drops the oldest") {
+      ZIO.scoped {
+        for {
+          state <- FeatureFlagsState.make
+          queue <- state.eventHub.subscribe
+          _ <- ZIO.foreachDiscard(0 until 300) { i =>
+            state.eventHub.publish(ProviderEvent.ConfigurationChanged(Set(i.toString), ProviderMetadata("p")))
+          }
+          drained <- queue.takeAll
+          flags = drained.toList.flatMap {
+            case ProviderEvent.ConfigurationChanged(f, _, _) => f
+            case _                                           => Set.empty[String]
+          }.toSet
+        } yield assertTrue(flags.contains("299"), !flags.contains("0"))
+      }
+    }
+  ) @@ sequential @@ withLiveClock
+}


### PR DESCRIPTION
## Summary

Three event-delivery defects in `FeatureFlagsLive`'s event system:

1. **Generic `on(eventType, handler)` dropped payload fields** (§5.1.4/§5.2.4). It rebuilt narrowed events from the typed callbacks (`ProviderEvent.Error(e, m)` etc.), discarding `errorCode`/`errorMessage`/`eventMetadata`. It now delivers the **original** event from the stream, while associated-state events (Ready/Error/Stale) still fire immediately when the provider is already in that state (§5.3.3).

2. **A handler defect permanently cancelled its subscription** (§5.2.5). Handler invocations are now isolated so a defect is logged and the subscription is retained. The isolation uses `ZIO.suspendSucceed` so it also captures a **synchronous** throw while the handler is producing its effect (not only an already-suspended `ZIO.die`); interruption is re-raised so cancelling a subscription still tears the fiber down.

3. **The internal event hub was `Hub.dropping`** (§5.1.2), which discards the *newest* event on overflow and could hide the latest `ConfigurationChanged` (whose `changedFlags` aren't reconstructible from status). It is now `Hub.sliding`, which discards the *oldest* so the newest always arrives.

## Tests

`EventSystemSpec`: on(Error)/on(Stale) deliver the full original payload (errorMessage + eventMetadata survive); a handler that dies (suspended) OR throws synchronously keeps its subscription and receives the next event; the hub is sliding (a 300-event burst keeps the newest, drops the oldest).

## Verification

Full Scala 3 suite (all modules), Scala 2.13 core cross-compile, `conformance/test`, `conformanceZioBdd/test` (Java 21), scalafmt — all pass.

Closes #250

Milestone: 1.0-readiness