### PR TITLE
Per-evaluation timeout: EvaluationTimeout ADT with per-call disable; fix hidden-1s-default docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: per-evaluation timeout is now an `EvaluationTimeout` ADT** (#251). `EvaluationOptions.timeout` changed from
+  `Option[Duration]` to `EvaluationTimeout` (`Default` | `Disabled` | `After(d)`), so a single call can now express
+  "no timeout" — previously impossible (`None` fell through to the global default, whose only escape was
+  `withTimeout(365.days)`). `EvaluationOptions.empty.withTimeout(d)` still bounds a call; new `.withoutTimeout` disables
+  it and skips the timeout scaffolding (a per-call fiber + timer race) entirely, which matters for microsecond-latency
+  in-memory providers. The 1-second default (applied to every evaluation unless overridden — a real behavioral cliff for
+  cold-start remote providers) is now documented prominently, and the `EvaluationOptions` doc that wrongly claimed the
+  default was "no timeout" is corrected. Migration: code that set `timeout = Some(d)` / `None` directly should use
+  `.withTimeout(d)` / `.withoutTimeout` (or `EvaluationTimeout.After(d)` / `Disabled` / `Default`).
+
 - **BREAKING: `FeatureHook.before` no longer returns hook hints** (#247). Its signature changed from
   `UIO[Option[(EvaluationContext, HookHints)]]` to `UIO[Option[EvaluationContext]]`, so a `before` hook can modify the
   evaluation context but can no longer alter the hook hints seen by later hooks and stages — hints are now immutable

--- a/core/src/main/scala-2/zio/openfeature/EvaluationTimeout.scala
+++ b/core/src/main/scala-2/zio/openfeature/EvaluationTimeout.scala
@@ -1,0 +1,19 @@
+package zio.openfeature
+
+import zio.Duration
+
+/** Per-evaluation timeout selection.
+  *
+  *   - [[EvaluationTimeout.Default]] — use the global evaluation timeout configured on the `FeatureFlags` instance
+  *     (1 second unless overridden at the factory).
+  *   - [[EvaluationTimeout.Disabled]] — no timeout for this evaluation; the timeout scaffolding (a per-call fiber +
+  *     timer race) is skipped entirely, which matters for in-memory/local providers whose evaluation is microseconds.
+  *   - [[EvaluationTimeout.After]] — bound this evaluation at the given duration.
+  */
+sealed trait EvaluationTimeout extends Product with Serializable
+
+object EvaluationTimeout {
+  case object Default                         extends EvaluationTimeout
+  case object Disabled                        extends EvaluationTimeout
+  final case class After(duration: Duration)  extends EvaluationTimeout
+}

--- a/core/src/main/scala-3/zio/openfeature/EvaluationTimeout.scala
+++ b/core/src/main/scala-3/zio/openfeature/EvaluationTimeout.scala
@@ -1,0 +1,16 @@
+package zio.openfeature
+
+import zio.Duration
+
+/** Per-evaluation timeout selection.
+  *
+  *   - [[EvaluationTimeout.Default]] — use the global evaluation timeout configured on the `FeatureFlags` instance (1
+  *     second unless overridden at the factory).
+  *   - [[EvaluationTimeout.Disabled]] — no timeout for this evaluation; the timeout scaffolding (a per-call fiber +
+  *     timer race) is skipped entirely, which matters for in-memory/local providers whose evaluation is microseconds.
+  *   - [[EvaluationTimeout.After]] — bound this evaluation at the given duration.
+  */
+enum EvaluationTimeout:
+  case Default
+  case Disabled
+  case After(duration: Duration)

--- a/core/src/main/scala/zio/openfeature/EvaluationOptions.scala
+++ b/core/src/main/scala/zio/openfeature/EvaluationOptions.scala
@@ -10,13 +10,15 @@ package zio.openfeature
   * @param hookHints
   *   Read-only hints passed to hooks
   * @param timeout
-  *   Maximum duration for this evaluation. Overrides the global evaluation timeout set on the `FeatureFlags` instance.
-  *   `None` means use the global default (which itself defaults to no timeout).
+  *   Timeout selection for this evaluation. [[EvaluationTimeout.Default]] uses the global evaluation timeout set on the
+  *   `FeatureFlags` instance — which itself defaults to **1 second** (not "no timeout"). Use
+  *   [[EvaluationTimeout.After]] (via `withTimeout`) to bound this call, or [[EvaluationTimeout.Disabled]] (via
+  *   `withoutTimeout`) to run it with no timeout at all.
   */
 final case class EvaluationOptions(
   hooks: List[FeatureHook] = Nil,
   hookHints: HookHints = HookHints.empty,
-  timeout: Option[zio.Duration] = None
+  timeout: EvaluationTimeout = EvaluationTimeout.Default
 ) {
   def withHook(hook: FeatureHook): EvaluationOptions =
     copy(hooks = hooks :+ hook)
@@ -27,8 +29,13 @@ final case class EvaluationOptions(
   def withHint(key: String, value: Any): EvaluationOptions =
     copy(hookHints = hookHints + (key -> value))
 
+  /** Bound this evaluation at `duration`, overriding the global default. */
   def withTimeout(duration: zio.Duration): EvaluationOptions =
-    copy(timeout = Some(duration))
+    copy(timeout = EvaluationTimeout.After(duration))
+
+  /** Run this evaluation with no timeout, overriding the global default. */
+  def withoutTimeout: EvaluationOptions =
+    copy(timeout = EvaluationTimeout.Disabled)
 }
 
 object EvaluationOptions {

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -476,10 +476,12 @@ object FeatureFlags {
     */
   private[openfeature] val DefaultInitTimeout: Duration = 30.seconds
 
-  /** Default per-evaluation timeout. Any provider call that takes longer is interrupted and the effect fails with
-    * `FeatureFlagError.ProviderError` wrapping a `TimeoutException`. Per-call overrides via `EvaluationOptions.timeout`
-    * take precedence over this global default. Pass `evaluationTimeout = Some(veryLargeDuration)` to a factory method
-    * to raise the bound; use `EvaluationOptions.empty.withTimeout(...)` at individual call sites for finer control.
+  /** Default per-evaluation timeout: **1 second, applied to every evaluation unless overridden**. Any provider call
+    * that takes longer is interrupted and the effect fails with `FeatureFlagError.ProviderError` wrapping a
+    * `TimeoutException` — so a remote provider with cold-start latency can fail its first evaluations out of the box.
+    * To change it: pass `evaluationTimeout = Some(otherDuration)` (or `None` to disable globally) to a factory method;
+    * per call, `EvaluationOptions.empty.withTimeout(d)` bounds a single evaluation and `.withoutTimeout` disables it
+    * (the latter also skips the timeout scaffolding, which matters for microsecond-latency in-memory providers).
     */
   val DefaultEvaluationTimeout: Duration = 1.second
 

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -644,8 +644,13 @@ final private[openfeature] class FeatureFlagsLive(
     ctx: EvaluationContext,
     options: EvaluationOptions
   ): IO[FeatureFlagError, FlagResolution[A]] = {
-    // Per-call timeout overrides global; None means no timeout (backward compatible)
-    val timeout = options.timeout.orElse(evaluationTimeout)
+    // Resolve the per-call selection against the instance's global timeout. `After` and `Disabled` override the global;
+    // `Default` defers to it. The result is `Option[Duration]` (None => skip the timeout scaffolding entirely).
+    val timeout = options.timeout match {
+      case EvaluationTimeout.After(d) => Some(d)
+      case EvaluationTimeout.Disabled => None
+      case EvaluationTimeout.Default  => evaluationTimeout
+    }
     effectiveContext(ctx).flatMap { effectCtx =>
       runWithHooks(
         key,

--- a/core/src/test/scala/zio/openfeature/EvaluationTimeoutAdtSpec.scala
+++ b/core/src/test/scala/zio/openfeature/EvaluationTimeoutAdtSpec.scala
@@ -1,0 +1,107 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderState,
+  Value
+}
+import java.util.concurrent.TimeoutException
+
+/** #251: the per-evaluation timeout is expressed by the `EvaluationTimeout` ADT. `Default` uses the instance's global
+  * timeout (1s unless overridden), `After(d)` bounds a single call, and `Disabled` (via `withoutTimeout`) runs with no
+  * timeout — skipping the timeout scaffolding entirely.
+  */
+object EvaluationTimeoutAdtSpec extends ZIOSpecDefault {
+
+  private class SlowProvider(sleepMillis: Long) extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "Slow" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) = {
+      Thread.sleep(sleepMillis)
+      ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
+    }
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  private def buildFF(globalTimeout: Option[Duration]): ZIO[Scope, Throwable, FeatureFlags] = {
+    val api = OpenFeatureAPIFactory.create()
+    FeatureFlags.build(
+      new SlowProvider(200L),
+      domain = Some(s"timeout-${java.util.UUID.randomUUID()}"),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = true,
+      apiOverride = Some(api),
+      evaluationTimeout = globalTimeout
+    )
+  }
+
+  private def isTimeout(e: FeatureFlagError): Boolean = e match {
+    case FeatureFlagError.ProviderError(t) => t.isInstanceOf[TimeoutException]
+    case _                                 => false
+  }
+
+  def spec = suite("EvaluationTimeoutAdtSpec")(
+    test("Default uses the global timeout: a slow evaluation times out") {
+      ZIO.scoped {
+        buildFF(Some(50.millis)).flatMap { ff =>
+          ff.booleanDetails("flag", default = false)
+            .either
+            .map(r => assertTrue(r.isLeft, r.left.exists(isTimeout)))
+        }
+      }
+    },
+    test("withoutTimeout (Disabled) runs with no timeout: the slow evaluation succeeds") {
+      ZIO.scoped {
+        buildFF(Some(50.millis)).flatMap { ff =>
+          ff.booleanDetails("flag", default = false, EvaluationContext.empty, EvaluationOptions.empty.withoutTimeout)
+            .map(r => assertTrue(r.value))
+        }
+      }
+    },
+    test("withTimeout(d) bounds a single evaluation and can time it out even when the global is disabled") {
+      ZIO.scoped {
+        buildFF(None).flatMap { ff =>
+          ff.booleanDetails(
+            "flag",
+            default = false,
+            EvaluationContext.empty,
+            EvaluationOptions.empty.withTimeout(30.millis)
+          ).either
+            .map(r => assertTrue(r.isLeft, r.left.exists(isTimeout)))
+        }
+      }
+    },
+    test("withTimeout(d) with a generous bound lets the evaluation complete") {
+      ZIO.scoped {
+        buildFF(Some(50.millis)).flatMap { ff =>
+          ff.booleanDetails(
+            "flag",
+            default = false,
+            EvaluationContext.empty,
+            EvaluationOptions.empty.withTimeout(2.seconds)
+          ).map(r => assertTrue(r.value))
+        }
+      }
+    }
+  ) @@ sequential @@ withLiveClock
+}

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -279,21 +279,24 @@ You can also set a timeout on individual evaluations via `EvaluationOptions`, wh
 
 ```scala
 // This evaluation times out after 100ms, regardless of the global setting
-val result = ff.booleanDetails(
-  "flag",
-  default = false,
-  options = EvaluationOptions.empty.withTimeout(100.millis)
-)
+val bounded = ff.booleanDetails("flag", default = false, options = EvaluationOptions.empty.withTimeout(100.millis))
+
+// This evaluation runs with NO timeout, regardless of the global setting (and skips the timeout scaffolding)
+val unbounded = ff.booleanDetails("flag", default = false, options = EvaluationOptions.empty.withoutTimeout)
 ```
+
+`EvaluationOptions.timeout` is an `EvaluationTimeout` — `Default` (defer to the instance global), `Disabled` (via
+`withoutTimeout`), or `After(d)` (via `withTimeout(d)`).
 
 | Setting | Scope | Default |
 |:--------|:------|:--------|
 | `fromProvider(provider, evaluationTimeout)` | All evaluations on this instance | `Some(1.second)` — `FeatureFlags.DefaultEvaluationTimeout` |
-| `EvaluationOptions.empty.withTimeout(duration)` | Single evaluation call | `None` (uses global) |
+| `EvaluationOptions.empty.withTimeout(duration)` / `.withoutTimeout` | Single evaluation call | `EvaluationTimeout.Default` (uses the global) |
 
-Per-call timeout takes precedence over global. As of 1.0.0 the global default is **1 second** (previously `None`), so
-a hung provider can no longer block a fiber indefinitely out of the box. Pass `evaluationTimeout = Some(largerDuration)`
-to raise the bound, or `evaluationTimeout = None` to disable it entirely.
+Per-call timeout takes precedence over global. The global default is **1 second**, applied to every evaluation unless
+overridden — so a hung provider can't block a fiber indefinitely out of the box, but a cold-start remote provider may
+time out on its first calls. Pass `evaluationTimeout = Some(largerDuration)` to raise the bound or
+`evaluationTimeout = None` to disable it globally; per call, use `.withTimeout(d)` / `.withoutTimeout`.
 
 ### Runtime provider replacement (hot-swap)
 


### PR DESCRIPTION
## Summary

The per-evaluation timeout had a hidden 1-second default, was documented incorrectly, and could not be disabled per call.

**BREAKING:** `EvaluationOptions.timeout` changed from `Option[Duration]` to a new `EvaluationTimeout` ADT (`Default | Disabled | After(d)`), so a single evaluation can now express "no timeout" — previously impossible (`None` fell through to the global default; the only escape was `withTimeout(365.days)`).

- `EvaluationOptions.empty.withTimeout(d)` bounds a call (`After(d)`); new `.withoutTimeout` disables it (`Disabled`) and **skips the timeout scaffolding** (a per-call fiber + timer race), which matters for microsecond-latency in-memory providers.
- `FeatureFlagsLive` resolves `After(d) => Some(d)`, `Disabled => None`, `Default => the instance global`.
- The 1-second global default (applied to every evaluation unless overridden — a real behavioral cliff for cold-start remote providers) is now documented prominently in the factory ScalaDoc, and the `EvaluationOptions` doc that wrongly claimed the default was "no timeout" is corrected. `docs/providers.md` updated.

Migration: `timeout = Some(d)` / `None` → `.withTimeout(d)` / `.withoutTimeout` (or `EvaluationTimeout.After(d)` / `Disabled` / `Default`).

## Tests

`EvaluationTimeoutAdtSpec`: Default uses the global (slow eval times out); `withoutTimeout` runs unbounded (slow eval succeeds despite a short global); `withTimeout(d)` bounds a call even when the global is disabled, and a generous bound completes.

## Verification

Full Scala 3 suite (all modules), Scala 2.13 core cross-compile, `conformance/test`, `conformanceZioBdd/test` (Java 21), scalafmt — all pass.

Closes #251

Milestone: 1.0-readiness