### PR TITLE
Short-circuit empty context merges and cache the Scala->Java conversion (perf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Per-evaluation context handling avoids per-call allocation in the common case** (#252, performance). Context
+  merging now short-circuits empty layers — `merge` returns an existing instance (identity) instead of allocating a new
+  context and merged map when either side is empty, so the four merge passes per evaluation cost nothing when the
+  transaction/client/fiber-local/invocation layers are empty (the overwhelmingly common case). The Scala→Java context
+  conversion is cached by object identity, so when the merged context is the unchanged global context it is converted
+  once and reused rather than rebuilt (a fresh `MutableContext` + one `Value` per attribute) on every call; a different
+  context — after `setGlobalContext` or a non-empty invocation layer — misses and is re-converted, so no explicit
+  invalidation is needed, and reuse is safe because the OpenFeature contract treats the provider-facing context as
+  read-only. No behavior change. (The redundant per-stage hook filter in `FeatureHook.compose` is intentionally kept —
+  it is part of that public method's self-contained contract, and the pre-filter already makes it a no-op.)
+
 - **BREAKING: per-evaluation timeout is now an `EvaluationTimeout` ADT** (#251). `EvaluationOptions.timeout` changed from
   `Option[Duration]` to `EvaluationTimeout` (`Default` | `Disabled` | `After(d)`), so a single call can now express
   "no timeout" — previously impossible (`None` fell through to the global default, whose only escape was

--- a/core/src/main/scala/zio/openfeature/EvaluationContext.scala
+++ b/core/src/main/scala/zio/openfeature/EvaluationContext.scala
@@ -5,10 +5,15 @@ final case class EvaluationContext(
   attributes: Map[String, AttributeValue]
 ) {
   def merge(other: EvaluationContext): EvaluationContext =
-    EvaluationContext(
-      targetingKey = other.targetingKey.orElse(targetingKey),
-      attributes = EvaluationContext.mergeAttributes(attributes, other.attributes)
-    )
+    // Short-circuit the common per-evaluation case (most layers are empty): merging with an empty context is identity,
+    // so return an existing instance instead of allocating a new context + merged map.
+    if (other.isEmpty) this
+    else if (isEmpty) other
+    else
+      EvaluationContext(
+        targetingKey = other.targetingKey.orElse(targetingKey),
+        attributes = EvaluationContext.mergeAttributes(attributes, other.attributes)
+      )
 
   def withTargetingKey(key: String): EvaluationContext =
     copy(targetingKey = Some(key))
@@ -38,17 +43,20 @@ object EvaluationContext {
     base: Map[String, AttributeValue],
     overrides: Map[String, AttributeValue]
   ): Map[String, AttributeValue] =
-    base ++ overrides.map { case (key, overrideVal) =>
-      key -> (base.get(key) match {
-        case Some(AttributeValue.StructValue(baseFields)) =>
-          overrideVal match {
-            case AttributeValue.StructValue(overrideFields) =>
-              AttributeValue.StructValue(mergeAttributes(baseFields, overrideFields))
-            case other => other
-          }
-        case _ => overrideVal
-      })
-    }
+    if (overrides.isEmpty) base
+    else if (base.isEmpty) overrides // no key collisions against an empty base, so no struct-merge is possible
+    else
+      base ++ overrides.map { case (key, overrideVal) =>
+        key -> (base.get(key) match {
+          case Some(AttributeValue.StructValue(baseFields)) =>
+            overrideVal match {
+              case AttributeValue.StructValue(overrideFields) =>
+                AttributeValue.StructValue(mergeAttributes(baseFields, overrideFields))
+              case other => other
+            }
+          case _ => overrideVal
+        })
+      }
 
   val empty: EvaluationContext = EvaluationContext(None, Map.empty)
 

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -64,6 +64,25 @@ final private[openfeature] class FeatureFlagsLive(
   // the instance Ready while the swap is still in flight. The successful swap sets Ready explicitly at the end.
   private val swapInProgress = new java.util.concurrent.atomic.AtomicBoolean(false)
 
+  // Cache the Scala->Java context conversion by object identity. In the common case every per-call context layer
+  // (transaction/client/fiber-local/invocation) is empty, so the merged context IS the (unchanged) global context
+  // object — converting it once and reusing it avoids a fresh MutableContext plus one Value per attribute on every
+  // call. Keyed on identity: a different context (after `setGlobalContext`, or a non-empty invocation layer) misses and
+  // is re-converted, so no explicit invalidation is needed. Reuse is safe because the OpenFeature contract treats the
+  // context passed to a provider as read-only.
+  private val javaContextCache =
+    new java.util.concurrent.atomic.AtomicReference[(EvaluationContext, dev.openfeature.sdk.EvaluationContext)](null)
+
+  private def toJavaContext(context: EvaluationContext): dev.openfeature.sdk.EvaluationContext = {
+    val cached = javaContextCache.get()
+    if (cached != null && (cached._1 eq context)) cached._2
+    else {
+      val converted = ContextConverter.toOpenFeature(context)
+      javaContextCache.set((context, converted))
+      converted
+    }
+  }
+
   // Bridge Java SDK provider events to ZIO event system
   private[openfeature] def startEventBridge: ZIO[Scope, Nothing, Unit] = {
     // Read provider name dynamically so events after a provider swap use the new name
@@ -398,7 +417,7 @@ final private[openfeature] class FeatureFlagsLive(
     timeout: Option[Duration] = None
   ): IO[FeatureFlagError, FlagResolution[A]] = {
     val flagType  = FlagType[A]
-    val ofContext = ContextConverter.toOpenFeature(context)
+    val ofContext = toJavaContext(context)
 
     def withTimeout[B](effect: Task[B]): Task[B] =
       timeout match {
@@ -987,7 +1006,7 @@ final private[openfeature] class FeatureFlagsLive(
       recordTrack(eventName, merged, details) *>
         ZIO
           .attemptBlocking {
-            val ofContext = ContextConverter.toOpenFeature(merged)
+            val ofContext = toJavaContext(merged)
             details match {
               case Some(d) => client.track(eventName, ofContext, toOpenFeatureDetails(d))
               case None    => client.track(eventName, ofContext)

--- a/core/src/test/scala/zio/openfeature/ContextMergeAndCacheSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ContextMergeAndCacheSpec.scala
@@ -1,0 +1,101 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderEvaluation,
+  ProviderState,
+  Value
+}
+import java.util.concurrent.atomic.AtomicReference
+
+/** #252: per-evaluation context merging short-circuits the empty-layer case (identity, no allocation) and the
+  * Scala->Java conversion is cached by identity — while still being correct (no stale context after
+  * `setGlobalContext`).
+  */
+object ContextMergeAndCacheSpec extends ZIOSpecDefault {
+
+  /** Records the targeting key the provider actually receives. */
+  private class InspectingProvider(seen: AtomicReference[String]) extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "Inspecting" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) = {
+      seen.set(Option(c.getTargetingKey).getOrElse("none"))
+      ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
+    }
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  private def buildFF(seen: AtomicReference[String]): ZIO[Scope, Throwable, FeatureFlags] = {
+    val api = OpenFeatureAPIFactory.create()
+    FeatureFlags.build(
+      new InspectingProvider(seen),
+      domain = Some(s"ctx-${java.util.UUID.randomUUID()}"),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = true,
+      apiOverride = Some(api),
+      evaluationTimeout = Some(5.seconds)
+    )
+  }
+
+  def spec = suite("ContextMergeAndCacheSpec")(
+    test("merge with an empty context returns the same instance (identity short-circuit)") {
+      val a = EvaluationContext("user").withAttribute("k", AttributeValue.StringValue("v"))
+      assertTrue(
+        a.merge(EvaluationContext.empty) eq a,
+        EvaluationContext.empty.merge(a) eq a
+      )
+    },
+    test("merge still combines non-empty contexts correctly (semantics preserved)") {
+      val a = EvaluationContext("user").withAttribute("a", AttributeValue.StringValue("1"))
+      val b = EvaluationContext.empty.withAttribute("b", AttributeValue.StringValue("2"))
+      val m = a.merge(b)
+      assertTrue(
+        m.targetingKey.contains("user"),
+        m.getString("a").contains("1"),
+        m.getString("b").contains("2")
+      )
+    },
+    test(
+      "merge of a targeting-key-only context with an attributes-only context preserves both (mergeAttributes empty-base branch)"
+    ) {
+      val keyOnly = EvaluationContext("user-1") // targeting key, no attributes -> non-empty, so no merge short-circuit
+      val attrsOnly = EvaluationContext.empty.withAttribute("b", AttributeValue.StringValue("1"))
+      val m         = keyOnly.merge(attrsOnly)
+      assertTrue(m.targetingKey.contains("user-1"), m.getString("b").contains("1"))
+    },
+    test("the Java-context conversion cache does not serve a stale context after setGlobalContext") {
+      val seen = new AtomicReference[String]("unset")
+      ZIO.scoped {
+        buildFF(seen).flatMap { ff =>
+          for {
+            _ <- ff.setGlobalContext(EvaluationContext("A"))
+            _ <- ff.boolean("flag", default = false)
+            a <- ZIO.succeed(seen.get())
+            _ <- ff.setGlobalContext(EvaluationContext("B"))
+            _ <- ff.boolean("flag", default = false)
+            b <- ZIO.succeed(seen.get())
+          } yield assertTrue(a == "A", b == "B") // B, not a stale cached A
+        }
+      }
+    }
+  ) @@ sequential @@ withLiveClock
+}


### PR DESCRIPTION
## Summary

Every evaluation performed four context merge passes and a fresh Scala→Java context conversion, allocating on every call in the common case (global context set once; transaction/client/fiber-local/invocation empty). No behavior change.

- **`EvaluationContext.merge` / `mergeAttributes` short-circuit empty layers** — merging with an empty context is identity, so `merge` returns an existing instance (`this` / `other`) instead of allocating a new context and merged map. The four merge passes now cost nothing when the per-call layers are empty.
- **`FeatureFlagsLive.toJavaContext` caches the Scala→Java conversion by object identity.** In the common case the merged context IS the (unchanged) global context object, so it is converted once and reused rather than rebuilding a `MutableContext` + one `Value` per attribute every call. A different context (after `setGlobalContext`, or a non-empty invocation layer) misses and is re-converted — no explicit invalidation needed. Reuse is safe because the OpenFeature contract treats the provider-facing context as read-only (verified: the SDK only reads it and wraps it in a fresh per-call layered context).

The related "redundant per-stage hook filter" micro-fix is intentionally left: it is part of `FeatureHook.compose`'s self-contained public contract, and the pre-filter already makes it a no-op.

## Tests

`ContextMergeAndCacheSpec`: merge-with-empty returns the same instance; merge still combines non-empty contexts (incl. the empty-base attribute branch) correctly; the conversion cache serves the new context after `setGlobalContext` (no staleness).

## Verification

Full Scala 3 suite (all modules), Scala 2.13 core cross-compile, `conformance/test`, `conformanceZioBdd/test` (Java 21), scalafmt — all pass.

Closes #252

Milestone: 1.0-readiness