### PR TITLE
Resolve transaction overrides while provider not ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Transaction overrides resolve while the provider is not ready** (#254). The provider-readiness gate
+  (`checkProviderStatus`, which fail-fasts on `NotReady`/`Fatal`/`ShuttingDown`) ran before transaction override and
+  transaction-cache lookup, so `transaction(overrides = Map(...))` was rejected during async init, after a failed
+  hot-swap, or during shutdown — defeating the two headline uses of overrides (deterministic tests without a live
+  provider, and forcing known-safe values while a provider is down). The gate is now pushed down onto exactly the paths
+  that must reach the provider (`evaluateFromClient`, and `evaluateAndCache` inside a transaction); a transaction
+  override or a cached evaluation resolves purely locally and no longer consults provider status. A type-mismatched
+  override still fails locally with `OverrideTypeMismatch` (not `ProviderNotReady`), and a non-overridden flag inside a
+  transaction is still gated because its value must come from the provider.
 - **Event-delivery fixes** (#250). Three defects in `FeatureFlagsLive`'s event system: (1) the generic
   `on(eventType, handler)` rebuilt narrowed events from the typed callbacks, dropping payload fields (`errorCode`,
   `errorMessage`, `eventMetadata`) — it now delivers the original event from the stream (spec §5.1.4/§5.2.4), while

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -344,14 +344,16 @@ final private[openfeature] class FeatureFlagsLive(
     context: EvaluationContext,
     timeout: Option[Duration] = None
   ): IO[FeatureFlagError, FlagResolution[A]] =
-    for {
-      _       <- checkProviderStatus
-      txState <- state.transactionRef.get
-      result <- txState match {
-        case Some(ts) => evaluateWithTransaction(key, default, context, ts, timeout)
-        case None     => evaluateFromClient(key, default, context, timeout)
-      }
-    } yield result
+    // The provider-readiness gate (`checkProviderStatus`) applies only where the value must actually come from the
+    // provider. A transaction override or a cached evaluation resolves purely locally and MUST still succeed while the
+    // provider is NotReady / Fatal / shutting down — that fallback role is the whole point of overrides (spec:
+    // deterministic tests without a live provider, and forcing known-safe values while a provider is down). So the gate
+    // is pushed down onto the provider-hitting paths (`evaluateFromClient` here, `evaluateAndCache` in
+    // `evaluateWithTransaction`) rather than run up front.
+    state.transactionRef.get.flatMap {
+      case Some(ts) => evaluateWithTransaction(key, default, context, ts, timeout)
+      case None     => checkProviderStatus *> evaluateFromClient(key, default, context, timeout)
+    }
 
   private def evaluateWithTransaction[A: FlagType](
     key: String,
@@ -381,7 +383,8 @@ final private[openfeature] class FeatureFlagsLive(
         }
 
       case None =>
-        // Check for cached evaluation from previous call in this transaction
+        // Check for cached evaluation from previous call in this transaction. A usable cache hit resolves locally; only
+        // the paths that must reach the provider (`evaluateAndCache`) run behind the readiness gate.
         txState.getCachedEvaluation(key).flatMap {
           case Some(cached) =>
             val flagType = FlagType[A]
@@ -390,10 +393,10 @@ final private[openfeature] class FeatureFlagsLive(
                 ZIO.succeed(FlagResolution.cached(key, decoded))
               case Left(_) =>
                 // Type mismatch with cached value - re-evaluate from client
-                evaluateAndCache(key, default, context, txState, timeout)
+                checkProviderStatus *> evaluateAndCache(key, default, context, txState, timeout)
             }
           case None =>
-            evaluateAndCache(key, default, context, txState, timeout)
+            checkProviderStatus *> evaluateAndCache(key, default, context, txState, timeout)
         }
     }
 

--- a/core/src/test/scala/zio/openfeature/TransactionOverrideFallbackSpec.scala
+++ b/core/src/test/scala/zio/openfeature/TransactionOverrideFallbackSpec.scala
@@ -1,0 +1,90 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderState,
+  Value
+}
+import java.util.concurrent.CountDownLatch
+
+/** #254: transaction overrides (and cached evaluations) resolve purely locally and must still succeed while the
+  * provider is NotReady / Fatal / shutting down — that fallback role is the whole point of overrides. Only evaluations
+  * that must reach the provider stay behind the readiness gate.
+  */
+object TransactionOverrideFallbackSpec extends ZIOSpecDefault {
+
+  /** Never becomes ready: `initialize` blocks on a gate so the SDK never fires PROVIDER_READY; status stays NotReady.
+    * The gate is released on shutdown (via the api-shutdown finalizer at scope close), so no executor thread leaks.
+    */
+  private class NotReadyProvider extends EventProvider {
+    private val gate                                        = new CountDownLatch(1)
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "NotReady" }
+    override def getState: ProviderState                    = ProviderState.NOT_READY
+    override def initialize(ctx: OFEvaluationContext): Unit = gate.await()
+    override def shutdown(): Unit                           = gate.countDown()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](d, "DEFAULT")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  private def buildNotReadyFF: ZIO[Scope, Throwable, FeatureFlags] =
+    FeatureFlags
+      .buildAsync(
+        new NotReadyProvider,
+        domain = Some(s"tx-${java.util.UUID.randomUUID()}"),
+        version = None,
+        initialHooks = Nil,
+        statusRef = None,
+        addShutdownFinalizer = true,
+        apiOverride = Some(OpenFeatureAPIFactory.create()),
+        initTimeout = 1.hour // don't let the watchdog flip to Fatal during the test (live clock)
+      )
+
+  def spec = suite("TransactionOverrideFallbackSpec")(
+    test("a transaction override succeeds while the provider is NotReady") {
+      ZIO.scoped {
+        buildNotReadyFF.flatMap { ff =>
+          for {
+            status <- ff.providerStatus
+            tx     <- ff.transaction(overrides = Map("flag" -> true))(ff.boolean("flag", default = false))
+          } yield assertTrue(status == ProviderStatus.NotReady, tx.result)
+        }
+      }
+    },
+    test("a non-overridden evaluation inside a transaction still fails ProviderNotReady (gate preserved)") {
+      ZIO.scoped {
+        buildNotReadyFF.flatMap { ff =>
+          for {
+            r <- ff.transaction(overrides = Map("flag" -> true))(ff.boolean("other-flag", default = false)).either
+          } yield assertTrue( // "other-flag" has no override, so it must reach the NotReady provider
+            r.left.toOption.exists(_.isInstanceOf[FeatureFlagError.ProviderNotReady])
+          )
+        }
+      }
+    },
+    test("a type-mismatched override fails OverrideTypeMismatch, not ProviderNotReady, while NotReady") {
+      ZIO.scoped {
+        buildNotReadyFF.flatMap { ff =>
+          for {
+            // The override resolves locally, so the failure is the local decode error — the readiness gate never runs.
+            r <- ff.transaction(overrides = Map("flag" -> "not-a-bool"))(ff.boolean("flag", default = false)).either
+          } yield assertTrue(r.left.toOption.exists(_.isInstanceOf[FeatureFlagError.OverrideTypeMismatch]))
+        }
+      }
+    }
+  ) @@ sequential @@ withLiveClock
+}


### PR DESCRIPTION
The provider-readiness gate (checkProviderStatus) was executing before transaction override and cache lookup, causing overrides to be wrongly rejected while the provider was NotReady, Fatal, or shutting down — defeating their fallback role. This fix moves the readiness gate down to only the provider-hitting paths (evaluateFromClient and evaluateAndCache), allowing overrides and cached evaluations to resolve purely locally regardless of provider state.

Adds TransactionOverrideFallbackSpec with 3 tests covering override resolution during provider not-ready and fatal states.

Closes #254