### PR TITLE
Add transactionEither for typed cross-version error channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`FeatureFlags.transactionEither`** — a typed, cross-version transaction error channel (#255). On Scala 2.13,
+  `transaction`'s error channel is `Compat.OrError[E, FeatureFlagError]`, which erases to `Any` (2.13 has no union
+  types), disabling all typed recovery — `catchAll` yields an untyped value, `mapError`/`orElse` composition breaks, and
+  a for-comprehension infers `Any` for the whole chain. `transactionEither` returns
+  `ZIO[R, Either[E, FeatureFlagError], TransactionResult[A]]` identically on Scala 2.13 and 3: `Left(e)` carries the
+  caller's own error from `zio`, `Right(ffe)` carries a transaction-machinery error (e.g. `NestedTransactionNotAllowed`).
+  Errors are tagged at their source, which is the only place the two can be told apart — once merged into a single
+  channel an `E` that equals `FeatureFlagError` is indistinguishable from a machinery error. `transaction` is now defined
+  in terms of `transactionEither` (merging the tag back into `OrError`), so its behavior and error channel are unchanged.
+
 - **Non-blocking provider initialization** (#241). Three additions so provider construction never sits on the
   application boot path:
   - **`FeatureFlags.fromAcquireAsync`** — a fallback-first async factory (`URLayer[Scope, FeatureFlags]`). It takes the

--- a/core/src/main/scala-2/zio/openfeature/Compat.scala
+++ b/core/src/main/scala-2/zio/openfeature/Compat.scala
@@ -2,4 +2,10 @@ package zio.openfeature
 
 object Compat {
   type OrError[+E1, +E2] = Any
+
+  /** Collapse a source-tagged `Either[E1, E2]` back into the [[OrError]] channel. Scala 2.13 has no union types, so
+    * [[OrError]] erases to `Any` and the tag is dropped, matching the legacy `transaction` error channel. The typed
+    * `Either` remains available through `transactionEither`.
+    */
+  def merge[E1, E2](e: Either[E1, E2]): OrError[E1, E2] = e.fold(l => l, r => r)
 }

--- a/core/src/main/scala-3/zio/openfeature/Compat.scala
+++ b/core/src/main/scala-3/zio/openfeature/Compat.scala
@@ -2,3 +2,8 @@ package zio.openfeature
 
 object Compat:
   type OrError[+E1, +E2] = E1 | E2
+
+  /** Collapse a source-tagged `Either[E1, E2]` back into the [[OrError]] channel. On Scala 3 that is the union `E1 |
+    * E2`, so the tag is dropped and the raw error value flows through unchanged.
+    */
+  def merge[E1, E2](e: Either[E1, E2]): OrError[E1, E2] = e.fold(l => l, r => r)

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -122,14 +122,27 @@ trait FeatureFlags {
   /** Run `zio` inside a flag transaction with optional overrides and per-call evaluation caching.
     *
     * Error channel: on Scala 3, `Compat.OrError[E, FeatureFlagError]` is the union `E | FeatureFlagError`. Scala 2.13
-    * has no union types, so there it erases to `Any` — when handling transaction errors on 2.13, match on
-    * `FeatureFlagError` cases (e.g. `NestedTransactionNotAllowed`) and your own `E` explicitly.
+    * has no union types, so there it erases to `Any`, which disables typed recovery. For a typed error channel on both
+    * versions, use [[transactionEither]], whose `Either[E, FeatureFlagError]` this method is built on.
     */
   def transaction[R, E, A](
     overrides: Map[String, Any] = Map.empty,
     context: EvaluationContext = EvaluationContext.empty,
     cacheEvaluations: Boolean = true
   )(zio: ZIO[R, E, A]): ZIO[R, Compat.OrError[E, FeatureFlagError], TransactionResult[A]]
+
+  /** Like [[transaction]], but with a uniform, cross-version typed error channel: `Either[E, FeatureFlagError]` on both
+    * Scala 2.13 and 3. `Left(e)` carries the caller's own error from `zio`; `Right(ffe)` carries a
+    * transaction-machinery error (e.g. `NestedTransactionNotAllowed`). Prefer this on Scala 2.13, where
+    * [[transaction]]'s error channel erases to `Any` (no union types) and disables typed recovery. On both versions
+    * this is the source-tagged form `transaction` is built on, so the two never disagree about which side an error came
+    * from.
+    */
+  def transactionEither[R, E, A](
+    overrides: Map[String, Any] = Map.empty,
+    context: EvaluationContext = EvaluationContext.empty,
+    cacheEvaluations: Boolean = true
+  )(zio: ZIO[R, E, A]): ZIO[R, Either[E, FeatureFlagError], TransactionResult[A]]
 
   def inTransaction: UIO[Boolean]
   def currentEvaluatedFlags: UIO[Map[String, FlagEvaluation[_]]]
@@ -364,6 +377,13 @@ object FeatureFlags {
     cacheEvaluations: Boolean = true
   )(zio: ZIO[R, E, A]): ZIO[R with FeatureFlags, Compat.OrError[E, FeatureFlagError], TransactionResult[A]] =
     ZIO.serviceWithZIO[FeatureFlags](_.transaction(overrides, context, cacheEvaluations)(zio))
+
+  def transactionEither[R, E, A](
+    overrides: Map[String, Any] = Map.empty,
+    context: EvaluationContext = EvaluationContext.empty,
+    cacheEvaluations: Boolean = true
+  )(zio: ZIO[R, E, A]): ZIO[R with FeatureFlags, Either[E, FeatureFlagError], TransactionResult[A]] =
+    ZIO.serviceWithZIO[FeatureFlags](_.transactionEither(overrides, context, cacheEvaluations)(zio))
 
   def inTransaction: ZIO[FeatureFlags, Nothing, Boolean] =
     ZIO.serviceWithZIO(_.inTransaction)

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -707,13 +707,25 @@ final private[openfeature] class FeatureFlagsLive(
     context: EvaluationContext,
     cacheEvaluations: Boolean
   )(zio: ZIO[R, E, A]): ZIO[R, Compat.OrError[E, FeatureFlagError], TransactionResult[A]] =
+    // Built on the source-tagged form so the two never disagree; `Compat.merge` drops the tag back into `OrError`
+    // (the raw `E | FeatureFlagError` union on Scala 3, `Any` on 2.13) — preserving the legacy error channel exactly.
+    transactionEither(overrides, context, cacheEvaluations)(zio).mapError(Compat.merge)
+
+  override def transactionEither[R, E, A](
+    overrides: Map[String, Any],
+    context: EvaluationContext,
+    cacheEvaluations: Boolean
+  )(zio: ZIO[R, E, A]): ZIO[R, Either[E, FeatureFlagError], TransactionResult[A]] =
+    // Errors are tagged at their source: `Left` is the caller's own `E` from `zio`, `Right` is a transaction-machinery
+    // error. This is the only place the two can be told apart — once merged into a single channel (as `transaction`
+    // does) an `E` that happens to equal `FeatureFlagError` is indistinguishable from a machinery error.
     for {
       current <- state.transactionRef.get
       _ <- ZIO.when(current.isDefined)(
-        ZIO.fail(FeatureFlagError.NestedTransactionNotAllowed)
+        ZIO.fail(Right(FeatureFlagError.NestedTransactionNotAllowed): Either[E, FeatureFlagError])
       )
       txState  <- TransactionState.make(overrides, context, cacheEvaluations)
-      result   <- state.transactionRef.locally(Some(txState))(zio)
+      result   <- state.transactionRef.locally(Some(txState))(zio).mapError(Left(_): Either[E, FeatureFlagError])
       txResult <- txState.toResult(result)
     } yield txResult
 

--- a/core/src/test/scala/zio/openfeature/TransactionErrorChannelSpec.scala
+++ b/core/src/test/scala/zio/openfeature/TransactionErrorChannelSpec.scala
@@ -1,0 +1,88 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{EvaluationContext => OFEvaluationContext, EventProvider, Metadata, ProviderState, Value}
+import dev.openfeature.sdk.OpenFeatureAPIFactory
+
+/** #255: on Scala 2.13 `transaction`'s error channel erased to `Any` (no union types), disabling typed recovery.
+  * `transactionEither` gives a uniform, cross-version typed channel `Either[E, FeatureFlagError]` — `Left` is the
+  * caller's own error, `Right` is a transaction-machinery error — while `transaction`'s legacy behavior is preserved.
+  *
+  * The first test is the key gate: it recovers `Left(msg)` and calls `msg.length`, which compiles ONLY if the left side
+  * is statically `String`. On the pre-fix `Any` channel there was no typed `Left` at all, so this would not build.
+  */
+object TransactionErrorChannelSpec extends ZIOSpecDefault {
+
+  private class NoopProvider extends EventProvider {
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "Noop" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](d, "DEFAULT")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  private def buildFF: ZIO[Scope, Throwable, FeatureFlags] =
+    FeatureFlags.build(
+      new NoopProvider,
+      domain = Some(s"txec-${java.util.UUID.randomUUID()}"),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = true,
+      apiOverride = Some(OpenFeatureAPIFactory.create()),
+      evaluationTimeout = Some(5.seconds)
+    )
+
+  def spec = suite("TransactionErrorChannelSpec")(
+    test("transactionEither exposes the caller's own error as a typed Left (statically String, not Any)") {
+      ZIO.scoped {
+        buildFF.flatMap { ff =>
+          for {
+            out <- ff.transactionEither()(ZIO.fail("boom"): IO[String, Int]).catchAll {
+              case Left(msg) => ZIO.succeed(msg.length) // msg: String — would not compile on the old Any channel
+              case Right(_)  => ZIO.succeed(-1)
+            }
+          } yield assertTrue(out == 4)
+        }
+      }
+    },
+    test("transactionEither surfaces a transaction-machinery error as a typed Right(FeatureFlagError)") {
+      ZIO.scoped {
+        buildFF.flatMap { ff =>
+          for {
+            // Establish an outer transaction so the inner transactionEither hits the nesting guard.
+            out <- ff
+              .transaction() {
+                ff.transactionEither()(ZIO.unit).map(_ => Option.empty[FeatureFlagError]).catchAll {
+                  case Right(ffe) => ZIO.succeed(Some(ffe)) // ffe: FeatureFlagError — typed
+                  case Left(_)    => ZIO.succeed(Option.empty[FeatureFlagError])
+                }
+              }
+              .either
+          } yield assertTrue(out.toOption.flatMap(_.result).contains(FeatureFlagError.NestedTransactionNotAllowed))
+        }
+      }
+    },
+    test("transaction still surfaces the caller's own error raw (not Either-wrapped) — legacy behavior preserved") {
+      ZIO.scoped {
+        buildFF.flatMap { ff =>
+          for {
+            out <- ff.transaction()(ZIO.fail("boom"): IO[String, Int]).either
+          } yield assertTrue(out == Left("boom"))
+        }
+      }
+    }
+  ) @@ sequential @@ withLiveClock
+}


### PR DESCRIPTION
On Scala 2.13, transaction's error channel (Compat.OrError) erases to Any because 2.13 has no union types, disabling typed recovery (catchAll/mapError/orElse all break). This adds transactionEither returning ZIO[R, Either[E, FeatureFlagError], TransactionResult[A]] uniformly on Scala 2.13 and 3 — Left carries the caller's own error, Right a transaction-machinery error — tagging errors at their source (the only place they can be told apart). transaction is now defined in terms of transactionEither so its behavior is unchanged. Adds TransactionErrorChannelSpec (passes on both Scala versions).

Closes #255