### PR TITLE
Add total (never-fails) evaluation variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Total (never-fails) evaluation variants** (#256, spec §1.4.10 / §1.1.7). `booleanOrDefault`, `stringOrDefault`,
+  `intOrDefault`, `longOrDefault`, `doubleOrDefault`, `objOrDefault`, and `valueOrDefault[A]` return `UIO[A]` — they never
+  fail, absorbing any evaluation error into the supplied default, matching the spec's promise that evaluation "MUST NOT
+  throw ... always return the default value." A `resolveOrDefault[A]` details variant returns `UIO[FlagResolution[A]]`
+  with `reason = Error` and `errorCode`/`errorMessage` populated, so callers can still see why the default was served.
+  Both typed `FeatureFlagError`s and defects (unexpected exceptions) are absorbed (the opt-in "give me a value no matter
+  what" contract), while fiber interruption is always propagated so cancellation still works. Implemented once in the
+  `FeatureFlags` trait and exposed through matching companion accessors; the fallible methods are unchanged for callers
+  who want to handle errors.
+
 - **`FeatureFlags.transactionEither`** — a typed, cross-version transaction error channel (#255). On Scala 2.13,
   `transaction`'s error channel is `Compat.OrError[E, FeatureFlagError]`, which erases to `Any` (2.13 has no union
   types), disabling all typed recovery — `catchAll` yields an untyped value, `mapError`/`orElse` composition breaks, and

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -104,6 +104,83 @@ trait FeatureFlags {
   def value[A: FlagType](key: String, default: A, ctx: EvaluationContext): IO[FeatureFlagError, A] =
     valueDetails(key, default, ctx).map(_.value)
 
+  // Total (never-fails) evaluation variants (spec §1.4.10 / §1.1.7: evaluation "MUST NOT throw ... always return the
+  // default value"). Any evaluation error is absorbed into the supplied default: `*OrDefault` returns the value,
+  // `resolveOrDefault` returns the full `FlagResolution` with `reason = Error` and `errorCode`/`errorMessage` populated
+  // so the caller can still see WHY the default was served. Both typed `FeatureFlagError`s and defects (unexpected
+  // exceptions) are absorbed — the opt-in "give me a value no matter what" contract — but fiber interruption is always
+  // propagated, so cancellation still works. The non-total methods above remain for callers who want to handle errors.
+
+  def booleanOrDefault(key: String, default: Boolean, ctx: EvaluationContext = EvaluationContext.empty): UIO[Boolean] =
+    totalResolution(booleanDetails(key, default, ctx), key, default).map(_.value)
+
+  def stringOrDefault(key: String, default: String, ctx: EvaluationContext = EvaluationContext.empty): UIO[String] =
+    totalResolution(stringDetails(key, default, ctx), key, default).map(_.value)
+
+  def intOrDefault(key: String, default: Int, ctx: EvaluationContext = EvaluationContext.empty): UIO[Int] =
+    totalResolution(intDetails(key, default, ctx), key, default).map(_.value)
+
+  def longOrDefault(key: String, default: Long, ctx: EvaluationContext = EvaluationContext.empty): UIO[Long] =
+    totalResolution(longDetails(key, default, ctx), key, default).map(_.value)
+
+  def doubleOrDefault(key: String, default: Double, ctx: EvaluationContext = EvaluationContext.empty): UIO[Double] =
+    totalResolution(doubleDetails(key, default, ctx), key, default).map(_.value)
+
+  def objOrDefault(
+    key: String,
+    default: Map[String, Any],
+    ctx: EvaluationContext = EvaluationContext.empty
+  ): UIO[Map[String, Any]] =
+    totalResolution(objDetails(key, default, ctx), key, default).map(_.value)
+
+  def valueOrDefault[A: FlagType](key: String, default: A, ctx: EvaluationContext = EvaluationContext.empty): UIO[A] =
+    totalResolution(valueDetails(key, default, ctx), key, default).map(_.value)
+
+  /** Total details variant: like [[valueDetails]] but never fails — an evaluation error yields a `FlagResolution` whose
+    * `reason` is `Error`, `value` is `default`, and `errorCode`/`errorMessage` describe the failure (spec §1.4.10).
+    */
+  def resolveOrDefault[A: FlagType](
+    key: String,
+    default: A,
+    ctx: EvaluationContext = EvaluationContext.empty,
+    options: EvaluationOptions = EvaluationOptions.empty
+  ): UIO[FlagResolution[A]] =
+    totalResolution(valueDetails(key, default, ctx, options), key, default)
+
+  private def totalResolution[A](
+    details: IO[FeatureFlagError, FlagResolution[A]],
+    key: String,
+    default: A
+  ): UIO[FlagResolution[A]] =
+    details.foldCauseZIO(
+      cause =>
+        // Propagate ONLY pure external cancellation, so structured cancellation still works. A collateral interrupt that
+        // co-occurs with a typed failure or defect (e.g. from parallelism inside a `*Details` implementation) is not
+        // cancellation — the real outcome is that failure, which we absorb into the default per the never-fails
+        // contract. In this branch the cause has no `Fail` nodes, so `stripFailures` only re-types it to `Cause[Nothing]`
+        // (keeping the effect in the `UIO` channel).
+        if (cause.isInterruptedOnly) ZIO.refailCause(cause.stripFailures)
+        else
+          cause.failureOption match {
+            case Some(e) =>
+              ZIO.succeed(FlagResolution.error(key, default, FeatureFlagError.toErrorCode(e), e.message))
+            case None =>
+              // A defect is an unexpected bug, not an expected provider error. Absorb it per spec §1.1.7, but leave a
+              // breadcrumb — the value-only `*OrDefault` variants discard the resolution, so without this a swallowed
+              // bug would be entirely invisible.
+              ZIO.logWarningCause(s"Total evaluation of '$key' absorbed a defect; serving the default", cause) *>
+                ZIO.succeed(
+                  FlagResolution.error(
+                    key,
+                    default,
+                    ErrorCode.General,
+                    cause.dieOption.fold("evaluation defect")(_.toString)
+                  )
+                )
+          },
+      ZIO.succeed(_)
+    )
+
   def setGlobalContext(ctx: EvaluationContext): UIO[Unit]
   def globalContext: UIO[EvaluationContext]
 
@@ -297,6 +374,65 @@ object FeatureFlags {
 
   def value[A: FlagType](key: String, default: A, ctx: EvaluationContext): ZIO[FeatureFlags, FeatureFlagError, A] =
     ZIO.serviceWithZIO(_.value(key, default, ctx))
+
+  // Service Accessors - total (never-fails) evaluation (spec §1.4.10)
+
+  def booleanOrDefault(
+    key: String,
+    default: Boolean,
+    ctx: EvaluationContext = EvaluationContext.empty
+  ): ZIO[FeatureFlags, Nothing, Boolean] =
+    ZIO.serviceWithZIO(_.booleanOrDefault(key, default, ctx))
+
+  def stringOrDefault(
+    key: String,
+    default: String,
+    ctx: EvaluationContext = EvaluationContext.empty
+  ): ZIO[FeatureFlags, Nothing, String] =
+    ZIO.serviceWithZIO(_.stringOrDefault(key, default, ctx))
+
+  def intOrDefault(
+    key: String,
+    default: Int,
+    ctx: EvaluationContext = EvaluationContext.empty
+  ): ZIO[FeatureFlags, Nothing, Int] =
+    ZIO.serviceWithZIO(_.intOrDefault(key, default, ctx))
+
+  def longOrDefault(
+    key: String,
+    default: Long,
+    ctx: EvaluationContext = EvaluationContext.empty
+  ): ZIO[FeatureFlags, Nothing, Long] =
+    ZIO.serviceWithZIO(_.longOrDefault(key, default, ctx))
+
+  def doubleOrDefault(
+    key: String,
+    default: Double,
+    ctx: EvaluationContext = EvaluationContext.empty
+  ): ZIO[FeatureFlags, Nothing, Double] =
+    ZIO.serviceWithZIO(_.doubleOrDefault(key, default, ctx))
+
+  def objOrDefault(
+    key: String,
+    default: Map[String, Any],
+    ctx: EvaluationContext = EvaluationContext.empty
+  ): ZIO[FeatureFlags, Nothing, Map[String, Any]] =
+    ZIO.serviceWithZIO(_.objOrDefault(key, default, ctx))
+
+  def valueOrDefault[A: FlagType](
+    key: String,
+    default: A,
+    ctx: EvaluationContext = EvaluationContext.empty
+  ): ZIO[FeatureFlags, Nothing, A] =
+    ZIO.serviceWithZIO(_.valueOrDefault(key, default, ctx))
+
+  def resolveOrDefault[A: FlagType](
+    key: String,
+    default: A,
+    ctx: EvaluationContext = EvaluationContext.empty,
+    options: EvaluationOptions = EvaluationOptions.empty
+  ): ZIO[FeatureFlags, Nothing, FlagResolution[A]] =
+    ZIO.serviceWithZIO(_.resolveOrDefault(key, default, ctx, options))
 
   // Service Accessors - detailed evaluation (with default parameters)
 

--- a/core/src/test/scala/zio/openfeature/TotalEvaluationDefectSpec.scala
+++ b/core/src/test/scala/zio/openfeature/TotalEvaluationDefectSpec.scala
@@ -1,0 +1,92 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.stream.ZStream
+
+/** #256: the total (never-fails) methods are concrete on the `FeatureFlags` trait, so they must behave correctly for
+  * ANY `*Details` implementation — including ones that die or get interrupted. The real provider pipeline funnels every
+  * failure through `ZIO.attemptBlocking` into the typed channel, so it can never produce a defect; these branches are
+  * reachable only via a custom implementation. `BoomFlags` is a minimal such implementation whose `*Details` fail via a
+  * configurable `boom` effect (a defect or an interruption).
+  */
+object TotalEvaluationDefectSpec extends ZIOSpecDefault {
+
+  abstract private class BoomFlags extends FeatureFlags {
+    protected def boom[A]: IO[FeatureFlagError, FlagResolution[A]]
+
+    override def booleanDetails(k: String, d: Boolean, ctx: EvaluationContext, o: EvaluationOptions)      = boom
+    override def stringDetails(k: String, d: String, ctx: EvaluationContext, o: EvaluationOptions)        = ???
+    override def intDetails(k: String, d: Int, ctx: EvaluationContext, o: EvaluationOptions)              = ???
+    override def longDetails(k: String, d: Long, ctx: EvaluationContext, o: EvaluationOptions)            = ???
+    override def doubleDetails(k: String, d: Double, ctx: EvaluationContext, o: EvaluationOptions)        = ???
+    override def objDetails(k: String, d: Map[String, Any], ctx: EvaluationContext, o: EvaluationOptions) = ???
+    override def valueDetails[A: FlagType](k: String, d: A, ctx: EvaluationContext, o: EvaluationOptions) = boom
+
+    override def setGlobalContext(ctx: EvaluationContext): UIO[Unit]                           = ???
+    override def globalContext: UIO[EvaluationContext]                                         = ???
+    override def setClientContext(ctx: EvaluationContext): UIO[Unit]                           = ???
+    override def clientContext: UIO[EvaluationContext]                                         = ???
+    override def withContext[R, E, A](ctx: EvaluationContext)(zio: ZIO[R, E, A]): ZIO[R, E, A] = ???
+    override def transaction[R, E, A](o: Map[String, Any], c: EvaluationContext, ce: Boolean)(
+      zio: ZIO[R, E, A]
+    ): ZIO[R, Compat.OrError[E, FeatureFlagError], TransactionResult[A]] = ???
+    override def transactionEither[R, E, A](o: Map[String, Any], c: EvaluationContext, ce: Boolean)(
+      zio: ZIO[R, E, A]
+    ): ZIO[R, Either[E, FeatureFlagError], TransactionResult[A]] = ???
+    override def inTransaction: UIO[Boolean]                                                             = ???
+    override def currentEvaluatedFlags: UIO[Map[String, FlagEvaluation[_]]]                              = ???
+    override def events: ZStream[Any, Nothing, ProviderEvent]                                            = ???
+    override def providerStatus: UIO[ProviderStatus]                                                     = ???
+    override def awaitReady(within: Duration): UIO[ProviderStatus]                                       = ???
+    override def providerMetadata: UIO[ProviderMetadata]                                                 = ???
+    override def clientMetadata: UIO[ClientMetadata]                                                     = ???
+    override def onProviderReady(h: ProviderMetadata => UIO[Unit]): UIO[UIO[Unit]]                       = ???
+    override def onProviderError(h: (Throwable, ProviderMetadata) => UIO[Unit]): UIO[UIO[Unit]]          = ???
+    override def onProviderStale(h: (String, ProviderMetadata) => UIO[Unit]): UIO[UIO[Unit]]             = ???
+    override def onConfigurationChanged(h: (Set[String], ProviderMetadata) => UIO[Unit]): UIO[UIO[Unit]] = ???
+    override def on(t: ProviderEventType, h: ProviderEvent => UIO[Unit]): UIO[UIO[Unit]]                 = ???
+    override def addHook(hook: FeatureHook): UIO[Unit]                                                   = ???
+    override def addHooks(hooks: List[FeatureHook]): UIO[Unit]                                           = ???
+    override def clearHooks: UIO[Unit]                                                                   = ???
+    override def hooks: UIO[List[FeatureHook]]                                                           = ???
+    override def addZioApiHook(hook: FeatureHook): UIO[Unit]                                             = ???
+    override def addZioApiHooks(hooks: List[FeatureHook]): UIO[Unit]                                     = ???
+    override def clearZioApiHooks: UIO[Unit]                                                             = ???
+    override def zioApiHooks: UIO[List[FeatureHook]]                                                     = ???
+    override def addApiHook(hook: dev.openfeature.sdk.Hook[_]): UIO[Unit]                                = ???
+    override def clearApiHooks: UIO[Unit]                                                                = ???
+    override def setProvider(p: dev.openfeature.sdk.FeatureProvider): IO[FeatureFlagError, Unit]         = ???
+    override def shutdown: UIO[Unit]                                                                     = ???
+    override def track(eventName: String): IO[FeatureFlagError, Unit]                                    = ???
+    override def track(eventName: String, context: EvaluationContext): IO[FeatureFlagError, Unit]        = ???
+    override def track(eventName: String, details: TrackingEventDetails): IO[FeatureFlagError, Unit]     = ???
+    override def track(
+      eventName: String,
+      context: EvaluationContext,
+      details: TrackingEventDetails
+    ): IO[FeatureFlagError, Unit] = ???
+    override def trackedEvents: UIO[List[(String, EvaluationContext, Option[TrackingEventDetails])]] = ???
+  }
+
+  private def dying: BoomFlags = new BoomFlags {
+    protected def boom[A]: IO[FeatureFlagError, FlagResolution[A]] = ZIO.die(new RuntimeException("boom"))
+  }
+  private def interrupting: BoomFlags = new BoomFlags {
+    protected def boom[A]: IO[FeatureFlagError, FlagResolution[A]] = ZIO.interrupt
+  }
+
+  def spec = suite("TotalEvaluationDefectSpec")(
+    test("booleanOrDefault absorbs a defect from *Details and serves the default") {
+      dying.booleanOrDefault("k", default = true).map(v => assertTrue(v))
+    },
+    test("resolveOrDefault maps a defect to reason=Error with errorCode General") {
+      dying.resolveOrDefault[Boolean]("k", default = true).map { res =>
+        assertTrue(res.value, res.reason == ResolutionReason.Error, res.errorCode.contains(ErrorCode.General))
+      }
+    },
+    test("booleanOrDefault propagates interruption instead of absorbing it into the default") {
+      interrupting.booleanOrDefault("k", default = true).exit.map(ex => assertTrue(ex.isInterrupted))
+    }
+  )
+}

--- a/core/src/test/scala/zio/openfeature/TotalEvaluationSpec.scala
+++ b/core/src/test/scala/zio/openfeature/TotalEvaluationSpec.scala
@@ -1,0 +1,124 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderState,
+  Value
+}
+import java.util.concurrent.CountDownLatch
+
+/** #256 / spec §1.4.10 / §1.1.7: total ("never-fails") evaluation. `*OrDefault` and `resolveOrDefault` MUST NOT fail —
+  * any evaluation error is absorbed into the supplied default. The `UIO` return type is itself the primary guarantee
+  * (the effect has no typed error channel); these tests confirm the runtime behavior on both the success and error
+  * paths.
+  */
+object TotalEvaluationSpec extends ZIOSpecDefault {
+
+  private class ReadyBoolProvider(value: Boolean) extends EventProvider {
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "Ready" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](value, "TARGETING_MATCH")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  /** Never becomes ready: `initialize` blocks so the SDK never fires PROVIDER_READY; every evaluation fails
+    * `ProviderNotReady` (a typed error). The gate is released on shutdown via the api-shutdown finalizer.
+    */
+  private class NotReadyProvider extends EventProvider {
+    private val gate                                        = new CountDownLatch(1)
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "NotReady" }
+    override def getState: ProviderState                    = ProviderState.NOT_READY
+    override def initialize(ctx: OFEvaluationContext): Unit = gate.await()
+    override def shutdown(): Unit                           = gate.countDown()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](d, "DEFAULT")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  private def buildReady(value: Boolean): ZIO[Scope, Throwable, FeatureFlags] =
+    FeatureFlags.build(
+      new ReadyBoolProvider(value),
+      domain = Some(s"total-r-${java.util.UUID.randomUUID()}"),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = true,
+      apiOverride = Some(OpenFeatureAPIFactory.create()),
+      evaluationTimeout = Some(5.seconds)
+    )
+
+  private def buildNotReady: ZIO[Scope, Throwable, FeatureFlags] =
+    FeatureFlags.buildAsync(
+      new NotReadyProvider,
+      domain = Some(s"total-nr-${java.util.UUID.randomUUID()}"),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = true,
+      apiOverride = Some(OpenFeatureAPIFactory.create()),
+      initTimeout = 1.hour
+    )
+
+  def spec = suite("TotalEvaluationSpec")(
+    test("booleanOrDefault returns the provider value on success (does not clobber with the default)") {
+      ZIO.scoped {
+        buildReady(true).flatMap(ff => ff.booleanOrDefault("flag", default = false).map(v => assertTrue(v)))
+      }
+    },
+    test("booleanOrDefault returns the default (never fails) when the provider is NotReady") {
+      ZIO.scoped {
+        buildNotReady.flatMap { ff =>
+          // No `.either` — the effect is UIO, so it cannot fail; the value IS the default.
+          ff.booleanOrDefault("flag", default = true).map(v => assertTrue(v))
+        }
+      }
+    },
+    test("resolveOrDefault yields reason=Error with errorCode populated and value=default on a typed failure") {
+      ZIO.scoped {
+        buildNotReady.flatMap { ff =>
+          ff.resolveOrDefault[Boolean]("flag", default = true).map { res =>
+            assertTrue(
+              res.value,
+              res.reason == ResolutionReason.Error,
+              res.errorCode.contains(ErrorCode.ProviderNotReady),
+              res.errorMessage.isDefined
+            )
+          }
+        }
+      }
+    },
+    test("resolveOrDefault preserves the successful resolution (reason is not Error) when evaluation succeeds") {
+      ZIO.scoped {
+        buildReady(true).flatMap { ff =>
+          ff.resolveOrDefault[Boolean]("flag", default = false).map { res =>
+            assertTrue(res.value, res.reason != ResolutionReason.Error, res.errorCode.isEmpty)
+          }
+        }
+      }
+    }
+  ) @@ sequential @@ withLiveClock
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,6 +136,29 @@ details.map { resolution =>
 }
 ```
 
+### Total Evaluation (never fails)
+
+The methods above surface evaluation errors in a typed error channel. When you would rather always get a value —
+falling back to the default on any error, per the OpenFeature spec's "total" evaluation (§1.4.10) — use the
+`*OrDefault` variants. They return `UIO`, so there is no error to handle:
+
+```scala
+val enabled: ZIO[FeatureFlags, Nothing, Boolean] =
+  FeatureFlags.booleanOrDefault("feature-toggle", default = false)
+```
+
+`resolveOrDefault` is the total form of `booleanDetails`/`valueDetails`: it never fails, but the returned
+`FlagResolution` still tells you *why* the default was served — `reason` is `Error` and `errorCode`/`errorMessage`
+are populated when a fallback occurred.
+
+```scala
+FeatureFlags.resolveOrDefault[Boolean]("feature-toggle", default = false).map { resolution =>
+  if (resolution.errorCode.isDefined) println(s"Served default: ${resolution.errorMessage}")
+}
+```
+
+Both typed errors and unexpected defects are absorbed into the default; only fiber interruption still propagates.
+
 ## Using Evaluation Context
 
 Pass user and environment information for targeted flag evaluation:


### PR DESCRIPTION
Adds spec §1.4.10 total ("never-fails") evaluation variants — booleanOrDefault/stringOrDefault/intOrDefault/longOrDefault/doubleOrDefault/objOrDefault/valueOrDefault return UIO and always yield a value, absorbing any evaluation error into the supplied default. A resolveOrDefault details variant returns UIO[FlagResolution] with reason=Error and errorCode/errorMessage populated so callers still see why the default was served. Both typed errors and defects are absorbed; fiber interruption still propagates. Implemented once on the FeatureFlags trait with matching companion accessors; the fallible methods are unchanged. Adds TotalEvaluationSpec + TotalEvaluationDefectSpec.

Closes #256