### PR TITLE
Centralize the provider status state machine (#244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Centralized provider-status state machine** (#244). Every provider-status write in `FeatureFlagsLive` and the async
+  init watchdog now goes through one pure, exhaustively-tested transition function
+  (`internal.ProviderStatusMachine`), replacing per-site ad-hoc guards. This fixes several concrete defects:
+  - **The init watchdog no longer Fatals (nor shuts down) a provider that was ever `Ready`.** It previously could not
+    distinguish "never initialized" from "was `Ready`, currently in a transient `Error`", so a recoverable
+    `PROVIDER_ERROR` just before the init deadline led to a permanent `Fatal` and shutdown of a live, recoverable
+    provider. The watchdog now tracks an `everReady` flag and only escalates a provider that never became usable; the
+    transient-error-at-deadline case leaves status `Error` with the provider running.
+  - **The watchdog `Fatal` transition now publishes a `ProviderEvent.Error`** carrying `ErrorCode.ProviderFatal` (it
+    previously published nothing), in addition to releasing the `onReady` latch.
+  - **A `PROVIDER_ERROR` event carrying `ErrorCode.PROVIDER_FATAL` now transitions to `Fatal`** (matching the Java SDK's
+    own `FATAL` state, spec 1.7.6), is sticky, and releases the `onReady` latch — previously every error event mapped to
+    the recoverable `Error`, so evaluations kept flowing to a provider the SDK considered dead.
+  - **Terminal states can no longer be clobbered or resurrected.** `Fatal` is sticky against every provider event; after
+    an explicit `shutdown` the terminal `NotReady` can no longer be moved by a late event from the dying provider; and a
+    `STALE` event can no longer stamp over `Fatal`/`ShuttingDown` (previously the stale handler had no guard at all).
+  - **The 500ms `nanoTime` swap-guard heuristics are gone**, replaced by provider-identity matching on the event's
+    stamped provider name: an event from a replaced/failed provider still queued on the SDK's emitter executor is
+    dropped (it is still published for observers, under the *emitting* provider's name — not the current one's).
+    Identity matching fails open when either the event or the current provider name is indeterminate (e.g. the SDK's
+    `MultiProvider`, whose metadata name only appears after `initialize()`), so a provider still drives its own status.
+    `shutdown` now also deregisters the event-bridge handlers before tearing the API down. A same-named hot-swap remains
+    indistinguishable by identity alone (the swap-in-progress window still covers the swap itself).
 - **Transaction overrides resolve while the provider is not ready** (#254). The provider-readiness gate
   (`checkProviderStatus`, which fail-fasts on `NotReady`/`Fatal`/`ShuttingDown`) ran before transaction override and
   transaction-cache lookup, so `transaction(overrides = Map(...))` was rejected during async init, after a failed

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -496,6 +496,13 @@ object FeatureFlags {
     */
   private[openfeature] val DefaultInitTimeout: Duration = 30.seconds
 
+  /** Fallback provider name stamped when a provider exposes no metadata/name at registration time. The event-bridge
+    * identity guard (`FeatureFlagsLive.fromCurrentProvider`) treats this as an indeterminate identity and fails open,
+    * so a provider whose real name only appears after `initialize()` (e.g. the SDK's MultiProvider) still drives its
+    * own status.
+    */
+  private[openfeature] val UnknownProviderName: String = "unknown"
+
   /** Default per-evaluation timeout: **1 second, applied to every evaluation unless overridden**. Any provider call
     * that takes longer is interrupted and the effect fails with `FeatureFlagError.ProviderError` wrapping a
     * `TimeoutException` — so a remote provider with cold-start latency can fail its first evaluations out of the box.
@@ -555,15 +562,13 @@ object FeatureFlags {
         case (Some(d), None)    => ZIO.attempt(api.getClient(d))
         case _                  => ZIO.attempt(api.getClient())
       }
-      providerName = Option(provider.getMetadata).map(_.getName).getOrElse("unknown")
+      providerName = Option(provider.getMetadata).map(_.getName).getOrElse(UnknownProviderName)
       providerRef <- Ref.make(provider)
       providerNameRef = new java.util.concurrent.atomic.AtomicReference(providerName)
       swapLock  <- Semaphore.make(1)
       baseState <- FeatureFlagsState.make
       state = statusRef.fold(baseState)(ref => baseState.copy(statusRef = ref))
       _ <- state.hooksRef.set(initialHooks)
-      // Only seed status when the caller didn't hand us a shared ref (testkit shares one).
-      _ <- statusRef.fold(state.statusRef.set(verified))(_ => ZIO.unit)
       ff = new FeatureFlagsLive(
         client,
         providerRef,
@@ -579,6 +584,9 @@ object FeatureFlags {
         onReady,
         evaluationTimeout
       )
+      // Only seed status when the caller didn't hand us a shared ref (testkit shares one). Routed through
+      // `seedStatus` so the machine's `everReady` flag records a Ready/Stale seed.
+      _ <- statusRef.fold(ff.seedStatus(verified))(_ => ZIO.unit)
       _ <- ff.startEventBridge
     } yield ff
 
@@ -767,7 +775,7 @@ object FeatureFlags {
       }
       // `ZIO.attempt` for the same reason as the registration above: a throwing `getMetadata` here must be a
       // typed failure, not a defect that strands the registry build fiber (see the `setProvider` note).
-      providerName <- ZIO.attempt(Option(provider.getMetadata).map(_.getName).getOrElse("unknown"))
+      providerName <- ZIO.attempt(Option(provider.getMetadata).map(_.getName).getOrElse(UnknownProviderName))
       providerRef  <- Ref.make(provider)
       providerNameRef = new java.util.concurrent.atomic.AtomicReference(providerName)
       swapLock  <- Semaphore.make(1)
@@ -791,25 +799,11 @@ object FeatureFlags {
       )
       // Start event bridge — if provider is already ready, replay fires immediately
       _ <- ff.startEventBridge
-      // Init watchdog: after initTimeout, if the provider still hasn't moved past NotReady/Error, atomically
-      // transition it to Fatal AND shut it down so its background threads (datafile pollers, HTTP clients) don't
-      // outlive the useful lifetime of this layer. The shutdown is gated on the transition actually happening, so a
-      // provider that became ready/stale before the timeout is left running untouched. The fiber is forked into the
-      // layer's Scope, so it is also interrupted when the layer is released.
-      _ <- (ZIO.sleep(initTimeout) *> state.statusRef
-        .modify {
-          case ProviderStatus.NotReady | ProviderStatus.Error => (true, ProviderStatus.Fatal)
-          case other                                          => (false, other)
-        }
-        .flatMap(transitioned =>
-          ZIO.when(transitioned)(
-            // Fatal is terminal. Shut the provider down (its poller/HTTP threads must not outlive the layer) and
-            // release the onReady latch so latch-waiters (registry handshake, `awaitReady` seeded from the latch)
-            // don't hang forever. The transition itself is observable via `statusRef.changes` (see `awaitReady`).
-            ZIO.attemptBlocking(provider.shutdown()).ignore *>
-              ZIO.succeed(onReady.foreach(_.countDown()))
-          )
-        )).forkScoped
+      // Init watchdog (#244): after initTimeout, escalate to Fatal ONLY if the provider never became usable
+      // (`everReady` gate inside the machine), shutting it down and releasing the onReady latch. A provider that was
+      // Ready and later dipped to a transient Error is left running. The fiber is forked into the layer's Scope, so
+      // it is also interrupted when the layer is released.
+      _ <- (ZIO.sleep(initTimeout) *> ff.escalateInitTimeout(provider, initTimeout)).forkScoped
     } yield ff
 
   /** Create a FeatureFlags layer from any OpenFeature provider (non-blocking).

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -2,7 +2,14 @@ package zio.openfeature
 
 import zio._
 import zio.stream._
-import zio.openfeature.internal.{ClientEvaluator, ContextConverter, ErrorCodeConverter, FeatureFlagsState}
+import zio.openfeature.internal.{
+  ClientEvaluator,
+  ContextConverter,
+  ErrorCodeConverter,
+  FeatureFlagsState,
+  ProviderStatusMachine
+}
+import zio.openfeature.internal.ProviderStatusMachine.Signal
 import dev.openfeature.sdk.{
   Client => OFClient,
   FeatureProvider => OFFeatureProvider,
@@ -34,35 +41,119 @@ final private[openfeature] class FeatureFlagsLive(
   evaluationTimeout: Option[Duration] = Some(FeatureFlags.DefaultEvaluationTimeout)
 ) extends FeatureFlags {
 
-  // Sentinel for "no swap has failed yet". Checked before computing the nanoTime difference so the
-  // subtraction can never operate on the sentinel (nanoTime has an arbitrary origin, so unlike wall-clock
-  // time there is no epoch value that is safely "long ago").
-  private val NoSwapFailure = Long.MinValue
-
-  // Records when a `setProvider` swap last failed (System.nanoTime, monotonic — wall-clock adjustments such as NTP
-  // steps must not widen or defeat the guard). Used by the async PROVIDER_READY bridge to decide whether an incoming
-  // Ready event is a real recovery signal or a stale event left over from a previous attach that's racing against the
-  // explicit Error transition set by the failed swap. See `setProvider` and `readyHandler` below.
-  private val recentSwapFailureAtNanos = new java.util.concurrent.atomic.AtomicLong(NoSwapFailure)
-
-  // Mirror of `recentSwapFailureAtNanos` for the opposite case: records when a `setProvider` swap last
-  // *succeeded*. Used by the async PROVIDER_ERROR bridge to recognize a stale Error event queued by a
-  // previous, now-replaced provider (e.g. one whose `initialize()` failed) that gets dispatched on the
-  // SDK's emitter executor *after* a subsequent swap has already taken over and moved the instance to
-  // Ready. Without this guard such a stale event clobbers the new provider's Ready status. See
-  // `setProvider` and `errorHandler` below.
-  private val recentSwapSuccessAtNanos = new java.util.concurrent.atomic.AtomicLong(NoSwapFailure)
-
-  // How long after a failed/successful swap an async PROVIDER_READY/PROVIDER_ERROR event should be ignored
-  // as a likely stale signal. Real recovery/failure scenarios (provider genuinely transitions on its own,
-  // well after the swap completed) happen on a much longer timescale than this; the race window we're
-  // closing is the SDK's emitter executor dispatching a queued event that pre-dates our explicit transition.
-  private val FailedSwapGuardNanos: Long = 500L * 1000000L
-
-  // True while `setProvider` holds the swap lock and is re-registering the provider. The PROVIDER_READY bridge must
-  // not transition NotReady => Ready in that window: a queued Ready event from the OLD provider's emitter would mark
-  // the instance Ready while the swap is still in flight. The successful swap sets Ready explicitly at the end.
+  // True while `setProvider` holds the swap lock and is re-registering the provider. Bridge events must not drive
+  // the status machine during that window: a queued event from the OLD provider would clobber the swap's own
+  // outcome. The successful swap sets Ready explicitly at the end.
   private val swapInProgress = new java.util.concurrent.atomic.AtomicBoolean(false)
+
+  // Set once the provider has ever been usable (Ready/Stale). Gates the init watchdog: a provider that was Ready and
+  // later dipped to a transient Error must never be escalated to Fatal (the core #244 bug).
+  private val everReady = new java.util.concurrent.atomic.AtomicBoolean(false)
+
+  // Set when an explicit `shutdown` has run to completion: the final NotReady is terminal for bridge events; only
+  // setProvider (which installs a new provider) clears it.
+  private val shutdownCompleted = new java.util.concurrent.atomic.AtomicBoolean(false)
+
+  // Set by startEventBridge; invoked by `shutdown` BEFORE teardown (so no emitter thread races it) and by the scope
+  // finalizer (idempotent — removeHandler on an already-removed handler is a no-op in the SDK, so double-invocation
+  // is safe).
+  private val bridgeDeregister =
+    new java.util.concurrent.atomic.AtomicReference[() => Unit](() => ())
+
+  /** The single door to statusRef (#244). Every status write except the sync-build seed and the testkit's shared-ref
+    * control surface goes through here. `SubscriptionRef` is a `Ref.Synchronized`, so `modify` serializes
+    * read-decide-write against every other signal. Returns Some(next) iff a transition happened, so callers can attach
+    * transition-gated side effects (watchdog shutdown, latch release).
+    */
+  private def applySignal(signal: Signal): UIO[Option[ProviderStatus]] =
+    state.statusRef.modify { current =>
+      val ctx = ProviderStatusMachine.Context(everReady.get(), swapInProgress.get(), shutdownCompleted.get())
+      ProviderStatusMachine.transition(current, signal, ctx) match {
+        case Some(next) =>
+          // Update the linearization-point flags INSIDE the serialized modify (SubscriptionRef is a
+          // Ref.Synchronized, so the function runs under exclusive access). The writes are idempotent and depend only
+          // on `signal`/`next`, so there is no read-stale window for a concurrent applySignal — closing the tap-lag
+          // gap where a pending `everReady` write could let the watchdog Fatal an already-Ready provider.
+          if (next == ProviderStatus.Ready || next == ProviderStatus.Stale) everReady.set(true)
+          signal match {
+            case Signal.ShutdownCompleted => shutdownCompleted.set(true)
+            case Signal.SwapStarted       => shutdownCompleted.set(false)
+            case _                        => ()
+          }
+          (Some(next), next)
+        case None => (None, current)
+      }
+    }
+
+  // The SDK stamps every dispatched event with the emitting provider's metadata name — or NULL when the provider has
+  // no metadata/name (verified sdk-1.21.0, OpenFeatureAPI.runHandlersForProvider). An event whose name differs from
+  // the CURRENT provider's is a stale event from a replaced/failed provider still queued on the SDK's emitter
+  // executor: it must not drive the status machine. We drop ONLY when both identities are known and differ. A null
+  // event name (unnamed provider) OR an indeterminate current name fails open — we cannot attribute the event to a
+  // *different* provider, so it must be allowed to drive status. The current name is indeterminate when it is the
+  // "unknown" fallback the factories stamp for metadata-less providers, or for a provider like the SDK's MultiProvider
+  // whose metadata name only materializes inside initialize() (so the async build captured "unknown", while the
+  // provider's own later events carry the real name). Same-named swaps are indistinguishable — see "Known limitation"
+  // in #244.
+  private def fromCurrentProvider(details: EventDetails): Boolean = {
+    val eventName   = details.getProviderName
+    val currentName = providerNameRef.get()
+    eventName == null ||
+    currentName == null ||
+    currentName == FeatureFlags.UnknownProviderName ||
+    eventName == currentName
+  }
+
+  // Truthful payloads: publish under the name the SDK stamped on the event (the actual emitter), falling back to the
+  // current provider only when the event carries none.
+  private def eventProviderMetadata(details: EventDetails): ProviderMetadata = {
+    val name = details.getProviderName
+    ProviderMetadata(if (name == null) providerNameRef.get() else name)
+  }
+
+  private def extractEventMetadata(details: EventDetails): FlagMetadata =
+    try {
+      val javaMeta = details.getEventMetadata
+      if (javaMeta == null || javaMeta.isEmpty) FlagMetadata.empty
+      else convertImmutableMetadata(javaMeta)
+    } catch {
+      case _: Exception => FlagMetadata.empty
+    }
+
+  // Bridge event bodies as pure effects (#244), so tests can drive them directly with a builder-constructed
+  // EventDetails. The Java-side Consumers registered in startEventBridge are thin wrappers that run these via
+  // `runHandler`. Events are ALWAYS published for observers; identity/machine gating applies only to the status
+  // transition and the onReady latch.
+
+  private[openfeature] def onReadyEvent(details: EventDetails): UIO[Unit] = {
+    val em      = extractEventMetadata(details)
+    val current = fromCurrentProvider(details)
+    (if (current) applySignal(Signal.EventReady) else ZIO.none) *>
+      state.eventHub.publish(ProviderEvent.Ready(eventProviderMetadata(details), em)).unit *>
+      ZIO.succeed(if (current) onReady.foreach(_.countDown()))
+  }
+
+  private[openfeature] def onErrorEvent(details: EventDetails): UIO[Unit] = {
+    val error     = new RuntimeException(Option(details.getMessage).getOrElse("Provider error"))
+    val errorCode = Option(details.getErrorCode).map(ErrorCodeConverter.fromJava)
+    val em        = extractEventMetadata(details)
+    val fatal     = errorCode.contains(ErrorCode.ProviderFatal)
+    (if (fromCurrentProvider(details)) applySignal(Signal.EventError(fatal)) else ZIO.none).flatMap { transitioned =>
+      // A Fatal transition must release latch waiters (registry handshake, awaitReady seeds) so they observe Fatal
+      // instead of stalling the full timeout.
+      ZIO.succeed(onReady.foreach(_.countDown())).when(transitioned.contains(ProviderStatus.Fatal))
+    } *>
+      state.eventHub
+        .publish(ProviderEvent.Error(error, eventProviderMetadata(details), errorCode, Option(details.getMessage), em))
+        .unit
+  }
+
+  private[openfeature] def onStaleEvent(details: EventDetails): UIO[Unit] = {
+    val reason = Option(details.getMessage).getOrElse("Provider stale")
+    val em     = extractEventMetadata(details)
+    (if (fromCurrentProvider(details)) applySignal(Signal.EventStale) else ZIO.none) *>
+      state.eventHub.publish(ProviderEvent.Stale(reason, eventProviderMetadata(details), em)).unit
+  }
 
   // Cache the Scala->Java context conversion by object identity. In the common case every per-call context layer
   // (transaction/client/fiber-local/invocation) is empty, so the merged context IS the (unchanged) global context
@@ -85,9 +176,6 @@ final private[openfeature] class FeatureFlagsLive(
 
   // Bridge Java SDK provider events to ZIO event system
   private[openfeature] def startEventBridge: ZIO[Scope, Nothing, Unit] = {
-    // Read provider name dynamically so events after a provider swap use the new name
-    def currentMetadata(): ProviderMetadata = ProviderMetadata(providerNameRef.get())
-
     // Run an event-publish effect from a Java SDK thread. Failures are logged via the ZIO logger
     // rather than thrown, so the Java SDK's event dispatch thread is never killed by a defect.
     def runHandler(runtime: Runtime[Any], label: String)(effect: UIO[Unit]): Unit =
@@ -98,84 +186,39 @@ final private[openfeature] class FeatureFlagsLive(
       }
 
     ZIO.runtime[Any].flatMap { runtime =>
-      def extractEventMetadata(details: EventDetails): FlagMetadata =
-        try {
-          val javaMeta = details.getEventMetadata
-          if (javaMeta == null || javaMeta.isEmpty) FlagMetadata.empty
-          else convertImmutableMetadata(javaMeta)
-        } catch {
-          case _: Exception => FlagMetadata.empty
-        }
+      // `suspendSucceed` defers the handler bodies (metadata extraction, identity check, payload construction) into the
+      // effect so a synchronous throw while building them on the Java emitter thread becomes a defect caught by
+      // `runHandler`'s `catchAllCause`, rather than escaping to kill the SDK's dispatch thread.
+      val readyHandler: java.util.function.Consumer[EventDetails] =
+        details => runHandler(runtime, "PROVIDER_READY")(ZIO.suspendSucceed(onReadyEvent(details)))
 
-      val readyHandler: java.util.function.Consumer[EventDetails] = details => {
-        val em = extractEventMetadata(details)
-        runHandler(runtime, "PROVIDER_READY")(
-          // Transition statusRef only from states where PROVIDER_READY is meaningful.
-          // - `NotReady => Ready` is suppressed while a swap holds the lock (`swapInProgress`): a Ready event arriving
-          //   then belongs to the OLD provider's emitter queue; the successful swap sets Ready explicitly at the end.
-          // - The `Error => Ready` arrow is valid per the OpenFeature spec (recovery from a recoverable error) but is
-          //   guarded by `FailedSwapGuardNanos`: if the most recent statusRef write was a failed-swap Error within that
-          //   window, a Ready event arriving now is almost certainly a stale signal queued on the SDK's emitter
-          //   executor before the swap, not a genuine recovery. Real recoveries happen on much longer timescales.
-          state.statusRef.update {
-            case ProviderStatus.NotReady =>
-              if (swapInProgress.get()) ProviderStatus.NotReady else ProviderStatus.Ready
-            case ProviderStatus.Stale => ProviderStatus.Ready
-            case ProviderStatus.Error =>
-              val stamp = recentSwapFailureAtNanos.get()
-              val withinGuard =
-                stamp != NoSwapFailure && (java.lang.System.nanoTime() - stamp) < FailedSwapGuardNanos
-              if (withinGuard) ProviderStatus.Error else ProviderStatus.Ready
-            case other => other
-          } *>
-            state.eventHub.publish(ProviderEvent.Ready(currentMetadata(), em)).unit
-        )
-        onReady.foreach(_.countDown())
-      }
+      val errorHandler: java.util.function.Consumer[EventDetails] =
+        details => runHandler(runtime, "PROVIDER_ERROR")(ZIO.suspendSucceed(onErrorEvent(details)))
 
-      val errorHandler: java.util.function.Consumer[EventDetails] = details => {
-        val error     = new RuntimeException(Option(details.getMessage).getOrElse("Provider error"))
-        val errorCode = Option(details.getErrorCode).map(ErrorCodeConverter.fromJava)
-        val em        = extractEventMetadata(details)
-        runHandler(runtime, "PROVIDER_ERROR")(
-          // Don't let a stale Error event clobber a newer provider's status: suppress the statusRef
-          // transition while a swap is in flight (the swap's own `tapError` already sets Error
-          // synchronously for *its* failure) or within `FailedSwapGuardNanos` of a swap that just
-          // succeeded (the event almost certainly predates that success). The event is still published
-          // either way so observers relying on the event stream see it.
-          ZIO
-            .succeed {
-              val stamp = recentSwapSuccessAtNanos.get()
-              val withinGuard =
-                stamp != NoSwapFailure && (java.lang.System.nanoTime() - stamp) < FailedSwapGuardNanos
-              !swapInProgress.get() && !withinGuard
-            }
-            .flatMap(shouldTransition => state.statusRef.set(ProviderStatus.Error).when(shouldTransition)) *>
-            state.eventHub
-              .publish(ProviderEvent.Error(error, currentMetadata(), errorCode, Option(details.getMessage), em))
-              .unit
-        )
-      }
+      val staleHandler: java.util.function.Consumer[EventDetails] =
+        details => runHandler(runtime, "PROVIDER_STALE")(ZIO.suspendSucceed(onStaleEvent(details)))
 
-      val staleHandler: java.util.function.Consumer[EventDetails] = details => {
-        val reason = Option(details.getMessage).getOrElse("Provider stale")
-        val em     = extractEventMetadata(details)
-        runHandler(runtime, "PROVIDER_STALE")(
-          state.statusRef.set(ProviderStatus.Stale) *>
-            state.eventHub.publish(ProviderEvent.Stale(reason, currentMetadata(), em)).unit
-        )
-      }
-
-      val configHandler: java.util.function.Consumer[EventDetails] = details => {
-        val flags = Option(details.getFlagsChanged)
-          .map(_.asScala.toSet)
-          .getOrElse(Set.empty[String])
-        val em = extractEventMetadata(details)
+      val configHandler: java.util.function.Consumer[EventDetails] = details =>
         runHandler(runtime, "PROVIDER_CONFIGURATION_CHANGED")(
-          state.eventHub
-            .publish(ProviderEvent.ConfigurationChanged(flags, currentMetadata(), em))
-            .unit
+          ZIO.suspendSucceed {
+            val flags = Option(details.getFlagsChanged)
+              .map(_.asScala.toSet)
+              .getOrElse(Set.empty[String])
+            val em = extractEventMetadata(details)
+            state.eventHub
+              .publish(ProviderEvent.ConfigurationChanged(flags, eventProviderMetadata(details), em))
+              .unit
+          }
         )
+
+      // Deregistration thunk stored on the instance so `shutdown` can remove the handlers BEFORE tearing down the API
+      // (no emitter thread can then race the teardown); the scope finalizer keeps calling it too (idempotent).
+      val deregister: () => Unit = () => {
+        client.removeHandler(JavaProviderEvent.PROVIDER_READY, readyHandler)
+        client.removeHandler(JavaProviderEvent.PROVIDER_ERROR, errorHandler)
+        client.removeHandler(JavaProviderEvent.PROVIDER_STALE, staleHandler)
+        client.removeHandler(JavaProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configHandler)
+        ()
       }
 
       for {
@@ -184,15 +227,10 @@ final private[openfeature] class FeatureFlagsLive(
           client.on(JavaProviderEvent.PROVIDER_ERROR, errorHandler)
           client.on(JavaProviderEvent.PROVIDER_STALE, staleHandler)
           client.on(JavaProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configHandler)
+          bridgeDeregister.set(deregister)
           ()
         }
-        _ <- ZIO.addFinalizer(ZIO.attempt {
-          client.removeHandler(JavaProviderEvent.PROVIDER_READY, readyHandler)
-          client.removeHandler(JavaProviderEvent.PROVIDER_ERROR, errorHandler)
-          client.removeHandler(JavaProviderEvent.PROVIDER_STALE, staleHandler)
-          client.removeHandler(JavaProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configHandler)
-          ()
-        }.ignore)
+        _ <- ZIO.addFinalizer(ZIO.attempt(deregister()).ignore)
       } yield ()
     }
   }
@@ -749,7 +787,36 @@ final private[openfeature] class FeatureFlagsLive(
   // `Error` (spec 1.7.6/1.7.7), but restoring `Ready` keeps `providerStatus` / `awaitReady` accurate for the usable
   // fallback (`Error` is not `canEvaluate`). Package-private — not part of the public API.
   private[openfeature] def forceReady: UIO[Unit] =
-    state.statusRef.set(ProviderStatus.Ready)
+    applySignal(Signal.ForceReady).unit
+
+  /** Async-init watchdog escalation (#244). Only when the machine actually transitions (the provider never became
+    * usable — the `everReady` gate) does it shut the provider down, publish a terminal Error event with code
+    * PROVIDER_FATAL, and release the onReady latch. A provider that was ever Ready is left running.
+    */
+  private[openfeature] def escalateInitTimeout(provider: OFFeatureProvider, initTimeout: Duration): UIO[Unit] =
+    applySignal(Signal.InitTimeout).flatMap {
+      case Some(_) =>
+        val msg = s"Provider initialization exceeded $initTimeout"
+        ZIO.attemptBlocking(provider.shutdown()).ignore *>
+          state.eventHub
+            .publish(
+              ProviderEvent.Error(
+                new java.util.concurrent.TimeoutException(msg),
+                ProviderMetadata(providerNameRef.get()),
+                Some(ErrorCode.ProviderFatal),
+                Some(msg)
+              )
+            )
+            .unit *>
+          ZIO.succeed(onReady.foreach(_.countDown()))
+      case None => ZIO.unit
+    }
+
+  /** Seed the initial status from the sync build path, recording ever-readiness for the machine. */
+  private[openfeature] def seedStatus(status: ProviderStatus): UIO[Unit] =
+    ZIO.succeed {
+      if (status == ProviderStatus.Ready || status == ProviderStatus.Stale) everReady.set(true)
+    } *> state.statusRef.set(status)
 
   override def awaitReady(within: Duration): UIO[ProviderStatus] =
     // `.changes` emits the current status first (so an already-Ready provider returns immediately) then every
@@ -936,13 +1003,13 @@ final private[openfeature] class FeatureFlagsLive(
         // Save old state for rollback on failure
         oldProvider <- providerRef.get
         oldName     <- ZIO.succeed(providerNameRef.get())
-        // 1. Transition to NOT_READY — new evaluations fail fast during swap. `swapInProgress` keeps the
-        //    PROVIDER_READY bridge from flipping NotReady => Ready off a stale event from the old provider.
+        // 1. Raise the gate BEFORE the NotReady transition: from here bridge events cannot drive the machine, so a
+        //    queued Ready event from the OLD provider cannot mark the instance Ready mid-swap.
         _ <- ZIO.succeed(swapInProgress.set(true))
-        _ <- state.statusRef.set(ProviderStatus.NotReady)
-        // 2. Update refs BEFORE registering with Java SDK, so the event bridge
-        //    (which fires PROVIDER_READY during setProviderAndWait) sees consistent metadata
-        newName = Option(newProvider.getMetadata).map(_.getName).getOrElse("unknown")
+        _ <- applySignal(Signal.SwapStarted)
+        // 2. Update refs BEFORE registering with Java SDK, so the event bridge (which fires PROVIDER_READY during
+        //    setProviderAndWait) and the identity guard see the new provider's metadata.
+        newName = Option(newProvider.getMetadata).map(_.getName).getOrElse(FeatureFlags.UnknownProviderName)
         _ <- providerRef.set(newProvider)
         _ <- ZIO.succeed(providerNameRef.set(newName))
         // 3. Register new provider with Java SDK (shuts down old, initializes new)
@@ -951,32 +1018,30 @@ final private[openfeature] class FeatureFlagsLive(
           case None    => ZIO.attemptBlocking(api.setProviderAndWait(newProvider))
         }).mapError(e => FeatureFlagError.ProviderInitializationFailed(e))
           .tapError(_ =>
-            // Rollback refs and set Error status so the instance is in a diagnosable state. Stamp
-            // `recentSwapFailureAtNanos` BEFORE the statusRef write so the async PROVIDER_READY handler sees a fresh
-            // failure timestamp and skips overwriting Error within the guard window.
-            ZIO.succeed(recentSwapFailureAtNanos.set(java.lang.System.nanoTime())) *>
-              providerRef.set(oldProvider) *>
+            // Roll back refs FIRST so the identity guard again reflects the (still registered) old provider, then
+            // record the failure via the machine.
+            providerRef.set(oldProvider) *>
               ZIO.succeed(providerNameRef.set(oldName)) *>
-              state.statusRef.set(ProviderStatus.Error)
+              applySignal(Signal.SwapFailed)
           )
-        // 4. Mark ready — the Java SDK event bridge will also fire PROVIDER_READY,
-        //    but we set it explicitly for immediate visibility. Stamp `recentSwapSuccessAtNanos`
-        //    first so a stale PROVIDER_ERROR from the just-replaced provider (see `errorHandler`)
-        //    can't race in and immediately overwrite the Ready we're about to set.
-        _ <- ZIO.succeed(recentSwapSuccessAtNanos.set(java.lang.System.nanoTime()))
-        _ <- state.statusRef.set(ProviderStatus.Ready)
+        // 4. Mark ready via the machine — the Java SDK bridge also fires PROVIDER_READY, but we set it explicitly for
+        //    immediate visibility.
+        _ <- applySignal(Signal.SwapSucceeded)
       } yield ()
-      // The guard must drop on every exit (success, failure, interruption) or the bridge would
-      // suppress legitimate NotReady => Ready transitions forever.
+      // The gate must drop on every exit (success, failure, interruption) or bridge events would be suppressed forever.
       swap.ensuring(ZIO.succeed(swapInProgress.set(false)))
     }
 
   // Shutdown API (spec 1.6.1, 1.6.2)
 
   override def shutdown: UIO[Unit] =
-    // ShuttingDown rejects evaluations for the duration of the teardown (checkProviderStatus);
-    // the terminal state after teardown is NotReady.
-    state.statusRef.set(ProviderStatus.ShuttingDown) *>
+    // ShuttingDown rejects evaluations for the duration of the teardown (checkProviderStatus); the terminal state
+    // after teardown is NotReady. The machine keeps both terminal: while ShuttingDown no bridge event transitions,
+    // and ShutdownCompleted makes the final NotReady stick against a late event from the dying provider.
+    applySignal(Signal.ShutdownStarted) *>
+      // Deregister the bridge handlers BEFORE tearing down the API so no emitter thread races the teardown (the scope
+      // finalizer also calls this — the SDK's removeHandler is idempotent).
+      ZIO.succeed(bridgeDeregister.get()()) *>
       state.hooksRef.set(List.empty) *>
       state.zioApiHooksRef.set(List.empty) *>
       state.globalContextRef.set(EvaluationContext.empty) *>
@@ -992,7 +1057,7 @@ final private[openfeature] class FeatureFlagsLive(
       // A non-owning `shutdown` therefore releases only this instance's own state (status/hooks/contexts/event hub,
       // torn down above); retire such clients via whatever owns the API (e.g. the registry).
       ZIO.when(ownsApi)(ZIO.attemptBlocking(api.shutdown()).ignore) *>
-      state.statusRef.set(ProviderStatus.NotReady)
+      applySignal(Signal.ShutdownCompleted).unit
 
   // Tracking API
 

--- a/core/src/main/scala/zio/openfeature/internal/ProviderStatusMachine.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ProviderStatusMachine.scala
@@ -1,0 +1,96 @@
+package zio.openfeature.internal
+
+import zio.openfeature.ProviderStatus
+
+/** Pure provider-status state machine (#244). Every status write in FeatureFlagsLive and the async init watchdog goes
+  * through `transition`, so the legal-transition table lives in exactly one place.
+  */
+private[openfeature] object ProviderStatusMachine {
+
+  /** Why a status write is being attempted. `Event*` signals originate from Java SDK emitter threads and are only
+    * applied after the event's provider identity has been checked; the rest are lifecycle signals from this library's
+    * own code paths and are authoritative.
+    */
+  sealed trait Signal
+  object Signal {
+    case object EventReady extends Signal
+
+    /** `fatal = true` when the event carries ErrorCode.PROVIDER_FATAL — the Java SDK's state manager maps that to FATAL
+      * (spec 1.7.6); mirror it.
+      */
+    final case class EventError(fatal: Boolean) extends Signal
+    case object EventStale                      extends Signal
+    case object SwapStarted                     extends Signal
+    case object SwapSucceeded                   extends Signal
+    case object SwapFailed                      extends Signal
+    case object InitTimeout                     extends Signal
+    case object ShutdownStarted                 extends Signal
+    case object ShutdownCompleted               extends Signal
+
+    /** fromAcquireAsync: a failed hot-swap rolled back to a still-live fallback. */
+    case object ForceReady extends Signal
+  }
+
+  /** Cross-thread context the table needs but the public ProviderStatus cannot represent. */
+  final case class Context(
+    everReady: Boolean,
+    swapInProgress: Boolean,
+    shutdownCompleted: Boolean
+  )
+
+  /** Some(next) => apply the transition (and any transition-gated side effects); None => ignore the signal. Lifecycle
+    * signals always yield Some — they are this library's own authoritative writes.
+    */
+  def transition(current: ProviderStatus, signal: Signal, ctx: Context): Option[ProviderStatus] = {
+    import ProviderStatus._
+    signal match {
+      // Lifecycle: authoritative from anywhere. setProvider is the ONLY exit from Fatal and from
+      // post-shutdown NotReady — it installs a NEW provider, so the old one's irrecoverability
+      // (spec 1.7.6) no longer applies.
+      case Signal.ShutdownStarted   => Some(ShuttingDown)
+      case Signal.ShutdownCompleted => Some(NotReady)
+      case Signal.SwapStarted       => Some(NotReady)
+      case Signal.SwapSucceeded     => Some(Ready)
+      case Signal.SwapFailed        => Some(Error)
+      case Signal.ForceReady        => Some(Ready)
+
+      // Non-lifecycle signals (the init watchdog and every bridge event) never take effect during a swap (the swap
+      // sets its own outcome) nor after an explicit shutdown has completed (post-shutdown NotReady is terminal; a
+      // late event — or the still-scheduled watchdog fiber, which `shutdown` does not cancel — must not resurrect the
+      // instance). Checked before InitTimeout so the watchdog cannot Fatal a swapped/shut-down provider.
+      case _ if ctx.swapInProgress || ctx.shutdownCompleted => None
+
+      // Watchdog: escalate ONLY a provider that never became usable. Ready-then-transient-Error must
+      // never be Fataled (the core #244 bug).
+      case Signal.InitTimeout =>
+        current match {
+          case NotReady | Error if !ctx.everReady => Some(Fatal)
+          case _                                  => None
+        }
+
+      case Signal.EventReady =>
+        current match {
+          // Error => Ready is genuine recovery (identity-checked, so no time guard needed);
+          // Fatal/ShuttingDown are sticky; Ready is already there.
+          case NotReady | Stale | Error     => Some(Ready)
+          case Ready | Fatal | ShuttingDown => None
+        }
+
+      case Signal.EventError(fatal) =>
+        current match {
+          case Fatal | ShuttingDown => None
+          case _ if fatal           => Some(Fatal)
+          case Error                => None        // already there
+          case _                    => Some(Error) // NotReady | Ready | Stale
+        }
+
+      case Signal.EventStale =>
+        current match {
+          // STALE means "serving cached data" — only meaningful from Ready (never over Fatal/ShuttingDown,
+          // which staleHandler can do today).
+          case Ready => Some(Stale)
+          case _     => None
+        }
+    }
+  }
+}

--- a/core/src/test/scala/zio/openfeature/ProviderStatusBridgeSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderStatusBridgeSpec.scala
@@ -1,0 +1,206 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.stream.SubscriptionRef
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  ErrorCode => OFErrorCode,
+  EvaluationContext => OFEvaluationContext,
+  EventDetails,
+  FeatureProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderState,
+  Value
+}
+import java.util.concurrent.CountDownLatch
+
+/** Bridge-level tests (#244): provider-identity gating, PROVIDER_FATAL mapping, terminal-state stickiness, and truthful
+  * event payloads. Handlers are driven directly via the extracted `onReadyEvent`/`onErrorEvent`/ `onStaleEvent` methods
+  * with builder-constructed `EventDetails`, so no SDK emitter thread is involved.
+  */
+object ProviderStatusBridgeSpec extends ZIOSpecDefault {
+
+  private def uniqueDomain(prefix: String): String = s"$prefix-${java.util.UUID.randomUUID()}"
+
+  /** Provider named `nm` whose initialize() blocks so the async build never fires PROVIDER_READY; the test drives the
+    * shared status ref directly. The gate is released on shutdown() (scope close), so no executor thread leaks.
+    */
+  private class InertProvider(nm: String) extends FeatureProvider {
+    private val gate = new CountDownLatch(1)
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { override def getName: String = nm }
+    override def getState: ProviderState                    = ProviderState.NOT_READY
+    override def initialize(ctx: OFEvaluationContext): Unit = gate.await()
+    override def shutdown(): Unit                           = gate.countDown()
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+  }
+
+  /** Mimics the SDK's MultiProvider: no metadata name at registration time (the async build captures "unknown"), while
+    * the provider's own later events carry a real name.
+    */
+  private class LateMetadataProvider extends InertProvider("late") {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata = null
+  }
+
+  private def buildProvider(
+    ref: SubscriptionRef[ProviderStatus],
+    provider: FeatureProvider
+  ): ZIO[Scope, Throwable, FeatureFlagsLive] =
+    FeatureFlags.buildAsync(
+      provider,
+      domain = Some(uniqueDomain("bridge")),
+      version = None,
+      initialHooks = Nil,
+      statusRef = Some(ref),
+      addShutdownFinalizer = true,
+      apiOverride = Some(OpenFeatureAPIFactory.create()),
+      initTimeout = 1.hour
+    )
+
+  private def build(ref: SubscriptionRef[ProviderStatus], name: String): ZIO[Scope, Throwable, FeatureFlagsLive] =
+    FeatureFlags.buildAsync(
+      new InertProvider(name),
+      domain = Some(uniqueDomain("bridge")),
+      version = None,
+      initialHooks = Nil,
+      statusRef = Some(ref),
+      addShutdownFinalizer = true,
+      apiOverride = Some(OpenFeatureAPIFactory.create()),
+      initTimeout = 1.hour
+    )
+
+  private def details(name: String, message: String = null, code: OFErrorCode = null): EventDetails = {
+    val b = EventDetails.builder()
+    if (name != null) b.providerName(name)
+    if (message != null) b.message(message)
+    if (code != null) b.errorCode(code)
+    b.build().asInstanceOf[EventDetails]
+  }
+
+  def spec = suite("ProviderStatusBridgeSpec")(
+    test("mismatched provider name: status unchanged, event still published under the stamped name") {
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.Ready)
+        out <- ZIO.scoped {
+          build(ref, "current").flatMap { ff =>
+            for {
+              collected <- Ref.make(List.empty[ProviderEvent])
+              cancel    <- ff.on(ProviderEventType.Error, e => collected.update(_ :+ e))
+              _         <- ff.onErrorEvent(details("stale-other", message = "boom"))
+              evs       <- Live.live(collected.get.repeatUntil(_.nonEmpty).timeout(5.seconds)).map(_.getOrElse(Nil))
+              status    <- ff.providerStatus
+              _         <- cancel
+            } yield assertTrue(
+              status == ProviderStatus.Ready, // mismatch => status untouched
+              evs.collectFirst { case e: ProviderEvent.Error => e.providerMetadata.name }.contains("stale-other")
+            )
+          }
+        }
+      } yield out
+    },
+    test("indeterminate current name (unknown) fails open: a named event from our own provider drives status") {
+      // The SDK's MultiProvider builds its metadata name inside initialize(), so the async build captured "unknown";
+      // its own later READY carries the real name. The guard must not reject the provider's own event.
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
+        out <- ZIO.scoped {
+          buildProvider(ref, new LateMetadataProvider).flatMap { ff =>
+            ff.onReadyEvent(details("multiprovider")) *> ff.providerStatus.map(s =>
+              assertTrue(s == ProviderStatus.Ready)
+            )
+          }
+        }
+      } yield out
+    },
+    test("null provider name fails open: transition applies") {
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
+        out <- ZIO.scoped {
+          build(ref, "current").flatMap { ff =>
+            ff.onReadyEvent(details(null)) *> ff.providerStatus.map(s => assertTrue(s == ProviderStatus.Ready))
+          }
+        }
+      } yield out
+    },
+    test("PROVIDER_ERROR with PROVIDER_FATAL => Fatal, sticky against a later READY, evaluations fail ProviderFatal") {
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.Ready)
+        out <- ZIO.scoped {
+          build(ref, "current").flatMap { ff =>
+            for {
+              _        <- ff.onErrorEvent(details("current", message = "dead", code = OFErrorCode.PROVIDER_FATAL))
+              afterErr <- ff.providerStatus
+              _        <- ff.onReadyEvent(details("current")) // must be ignored — Fatal is sticky
+              afterRdy <- ff.providerStatus
+              eval     <- ff.boolean("x", default = true).either
+            } yield assertTrue(
+              afterErr == ProviderStatus.Fatal,
+              afterRdy == ProviderStatus.Fatal,
+              eval == Left(FeatureFlagError.ProviderFatal)
+            )
+          }
+        }
+      } yield out
+    },
+    test("Error => Ready on a current-provider READY is accepted (no time guard)") {
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.Error)
+        out <- ZIO.scoped {
+          build(ref, "current").flatMap { ff =>
+            ff.onReadyEvent(details("current")) *> ff.providerStatus.map(s => assertTrue(s == ProviderStatus.Ready))
+          }
+        }
+      } yield out
+    },
+    test("EventStale only transitions from Ready; a stale event over Error is ignored") {
+      for {
+        refR <- SubscriptionRef.make[ProviderStatus](ProviderStatus.Ready)
+        refE <- SubscriptionRef.make[ProviderStatus](ProviderStatus.Error)
+        fromReady <- ZIO.scoped {
+          build(refR, "current").flatMap(ff => ff.onStaleEvent(details("current")) *> ff.providerStatus)
+        }
+        fromError <- ZIO.scoped {
+          build(refE, "current").flatMap(ff => ff.onStaleEvent(details("current")) *> ff.providerStatus)
+        }
+      } yield assertTrue(fromReady == ProviderStatus.Stale, fromError == ProviderStatus.Error)
+    },
+    test("after shutdown, late error/stale events cannot move status off terminal NotReady") {
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.Ready)
+        out <- ZIO.scoped {
+          build(ref, "current").flatMap { ff =>
+            for {
+              _         <- ff.shutdown
+              afterShut <- ff.providerStatus
+              // The status gate (applySignal) runs before the publish; after shutdown the event hub is closed, so the
+              // publish step interrupts (in production runHandler's catchAllCause swallows it). Tolerate it with .exit.
+              _          <- ff.onErrorEvent(details("current", message = "late error")).exit
+              afterErr   <- ff.providerStatus
+              _          <- ff.onStaleEvent(details("current")).exit
+              afterStale <- ff.providerStatus
+              _          <- ff.onReadyEvent(details("current")).exit
+              afterReady <- ff.providerStatus
+            } yield assertTrue(
+              afterShut == ProviderStatus.NotReady,
+              afterErr == ProviderStatus.NotReady,
+              afterStale == ProviderStatus.NotReady,
+              afterReady == ProviderStatus.NotReady
+            )
+          }
+        }
+      } yield out
+    }
+  ) @@ TestAspect.sequential
+}

--- a/core/src/test/scala/zio/openfeature/ProviderStatusMachineSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderStatusMachineSpec.scala
@@ -1,0 +1,159 @@
+package zio.openfeature
+
+import zio.test._
+import zio.openfeature.internal.ProviderStatusMachine
+import zio.openfeature.internal.ProviderStatusMachine.{Context, Signal}
+
+/** Pure, exhaustive coverage of the centralized provider-status transition table (#244). */
+object ProviderStatusMachineSpec extends ZIOSpecDefault {
+
+  import ProviderStatus._
+
+  private val allStatuses: List[ProviderStatus] =
+    List(NotReady, Ready, Error, Stale, Fatal, ShuttingDown)
+
+  // everReady x swapInProgress x shutdownCompleted
+  private val allContexts: List[Context] =
+    for {
+      ever <- List(false, true)
+      swap <- List(false, true)
+      shut <- List(false, true)
+    } yield Context(ever, swap, shut)
+
+  private def t(current: ProviderStatus, signal: Signal, ctx: Context): Option[ProviderStatus] =
+    ProviderStatusMachine.transition(current, signal, ctx)
+
+  private val lifecycle: List[(Signal, ProviderStatus)] = List(
+    Signal.ShutdownStarted   -> ShuttingDown,
+    Signal.ShutdownCompleted -> NotReady,
+    Signal.SwapStarted       -> NotReady,
+    Signal.SwapSucceeded     -> Ready,
+    Signal.SwapFailed        -> Error,
+    Signal.ForceReady        -> Ready
+  )
+
+  def spec = suite("ProviderStatusMachineSpec")(
+    test("lifecycle signals are authoritative from every status and every context") {
+      val checks = for {
+        (signal, target) <- lifecycle
+        status           <- allStatuses
+        ctx              <- allContexts
+      } yield assertTrue(t(status, signal, ctx) == Some(target))
+      TestResult.allSuccesses(checks)
+    },
+    test("Fatal is sticky under every Event* and InitTimeout, from every context") {
+      val eventSignals =
+        List(
+          Signal.EventReady,
+          Signal.EventError(fatal = false),
+          Signal.EventError(fatal = true),
+          Signal.EventStale,
+          Signal.InitTimeout
+        )
+      val checks = for {
+        signal <- eventSignals
+        ctx    <- allContexts
+      } yield assertTrue(t(Fatal, signal, ctx).isEmpty)
+      TestResult.allSuccesses(checks)
+    },
+    test("Fatal exits only via lifecycle signals") {
+      val checks = for {
+        (signal, target) <- lifecycle
+        ctx              <- allContexts
+      } yield assertTrue(t(Fatal, signal, ctx) == Some(target))
+      TestResult.allSuccesses(checks)
+    },
+    suite("InitTimeout (watchdog)")(
+      test("escalates to Fatal from NotReady/Error only when never Ready and not swapping/shutting down") {
+        assertTrue(
+          t(NotReady, Signal.InitTimeout, Context(false, false, false)) == Some(Fatal),
+          t(Error, Signal.InitTimeout, Context(false, false, false)) == Some(Fatal)
+        )
+      },
+      test("is a no-op during a swap or after shutdown completed (must not resurrect a torn-down provider)") {
+        val checks = for {
+          status <- List(NotReady, Error)
+          ctx    <- allContexts if !ctx.everReady && (ctx.swapInProgress || ctx.shutdownCompleted)
+        } yield assertTrue(t(status, Signal.InitTimeout, ctx).isEmpty)
+        TestResult.allSuccesses(checks)
+      },
+      test("is a no-op when everReady, from every status") {
+        val checks = for {
+          status <- allStatuses
+          ctx    <- allContexts.filter(_.everReady)
+        } yield assertTrue(t(status, Signal.InitTimeout, ctx).isEmpty)
+        TestResult.allSuccesses(checks)
+      },
+      test("is a no-op from Ready/Stale/ShuttingDown even when never Ready") {
+        val checks = for {
+          status <- List(Ready, Stale, ShuttingDown)
+          ctx    <- allContexts.filterNot(_.everReady)
+        } yield assertTrue(t(status, Signal.InitTimeout, ctx).isEmpty)
+        TestResult.allSuccesses(checks)
+      }
+    ),
+    suite("bridge events gated by swap/shutdown context")(
+      test("every Event* is a no-op when swapInProgress") {
+        val eventSignals = List(Signal.EventReady, Signal.EventError(false), Signal.EventError(true), Signal.EventStale)
+        val checks = for {
+          signal <- eventSignals
+          status <- allStatuses
+        } yield assertTrue(t(status, signal, Context(everReady = false, swapInProgress = true, false)).isEmpty)
+        TestResult.allSuccesses(checks)
+      },
+      test("every Event* is a no-op when shutdownCompleted") {
+        val eventSignals = List(Signal.EventReady, Signal.EventError(false), Signal.EventError(true), Signal.EventStale)
+        val checks = for {
+          signal <- eventSignals
+          status <- allStatuses
+        } yield assertTrue(t(status, signal, Context(everReady = false, false, shutdownCompleted = true)).isEmpty)
+        TestResult.allSuccesses(checks)
+      }
+    ),
+    suite("EventReady")(
+      test("NotReady/Stale/Error => Ready (ungated)") {
+        val checks = List(NotReady, Stale, Error).map(s =>
+          assertTrue(t(s, Signal.EventReady, Context(false, false, false)) == Some(Ready))
+        )
+        TestResult.allSuccesses(checks)
+      },
+      test("Ready/Fatal/ShuttingDown => no-op (ungated)") {
+        val checks = List(Ready, Fatal, ShuttingDown).map(s =>
+          assertTrue(t(s, Signal.EventReady, Context(false, false, false)).isEmpty)
+        )
+        TestResult.allSuccesses(checks)
+      }
+    ),
+    suite("EventError")(
+      test("fatal=true => Fatal from NotReady/Ready/Stale/Error (ungated)") {
+        val checks = List(NotReady, Ready, Stale, Error).map(s =>
+          assertTrue(t(s, Signal.EventError(fatal = true), Context(false, false, false)) == Some(Fatal))
+        )
+        TestResult.allSuccesses(checks)
+      },
+      test("fatal=false => Error from NotReady/Ready/Stale; no-op from Error") {
+        assertTrue(
+          t(NotReady, Signal.EventError(false), Context(false, false, false)) == Some(Error),
+          t(Ready, Signal.EventError(false), Context(false, false, false)) == Some(Error),
+          t(Stale, Signal.EventError(false), Context(false, false, false)) == Some(Error),
+          t(Error, Signal.EventError(false), Context(false, false, false)).isEmpty
+        )
+      },
+      test("no-op from Fatal/ShuttingDown regardless of fatal flag") {
+        assertTrue(
+          t(Fatal, Signal.EventError(true), Context(false, false, false)).isEmpty,
+          t(Fatal, Signal.EventError(false), Context(false, false, false)).isEmpty,
+          t(ShuttingDown, Signal.EventError(true), Context(false, false, false)).isEmpty,
+          t(ShuttingDown, Signal.EventError(false), Context(false, false, false)).isEmpty
+        )
+      }
+    ),
+    test("EventStale only Ready => Stale; no-op everywhere else (ungated)") {
+      val checks = allStatuses.map { s =>
+        val expected = if (s == Ready) Some(Stale) else None
+        assertTrue(t(s, Signal.EventStale, Context(false, false, false)) == expected)
+      }
+      TestResult.allSuccesses(checks)
+    }
+  )
+}

--- a/core/src/test/scala/zio/openfeature/WatchdogEscalationSpec.scala
+++ b/core/src/test/scala/zio/openfeature/WatchdogEscalationSpec.scala
@@ -1,0 +1,118 @@
+package zio.openfeature
+
+import zio._
+import zio.test._
+import zio.stream.SubscriptionRef
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventDetails,
+  FeatureProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderState,
+  Value
+}
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Init-watchdog escalation (#244): the core fix — a provider that was ever Ready must NOT be Fataled/shut down on a
+  * transient post-Ready error; a never-ready provider is escalated to Fatal, shut down, and reported.
+  */
+object WatchdogEscalationSpec extends ZIOSpecDefault {
+
+  private def uniqueDomain(prefix: String): String = s"$prefix-${java.util.UUID.randomUUID()}"
+
+  private class CountingProvider(nm: String, shutdowns: AtomicInteger) extends FeatureProvider {
+    private val gate = new CountDownLatch(1)
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { override def getName: String = nm }
+    override def getState: ProviderState                    = ProviderState.NOT_READY
+    override def initialize(ctx: OFEvaluationContext): Unit = gate.await()
+    override def shutdown(): Unit                           = { shutdowns.incrementAndGet(); gate.countDown() }
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of(d, "DEFAULT")
+  }
+
+  private def build(
+    ref: SubscriptionRef[ProviderStatus],
+    provider: FeatureProvider,
+    onReady: Option[CountDownLatch]
+  ): ZIO[Scope, Throwable, FeatureFlagsLive] =
+    FeatureFlags.buildAsync(
+      provider,
+      domain = Some(uniqueDomain("wd")),
+      version = None,
+      initialHooks = Nil,
+      statusRef = Some(ref),
+      addShutdownFinalizer = true,
+      apiOverride = Some(OpenFeatureAPIFactory.create()),
+      onReady = onReady,
+      initTimeout = 1.hour
+    )
+
+  private def details(name: String): EventDetails =
+    EventDetails.builder().providerName(name).build().asInstanceOf[EventDetails]
+
+  def spec = suite("WatchdogEscalationSpec")(
+    test("ever-Ready then transient Error at the deadline: escalation is a no-op, provider left running") {
+      val shutdowns = new AtomicInteger(0)
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
+        out <- ZIO.scoped {
+          build(ref, new CountingProvider("p", shutdowns), None).flatMap { ff =>
+            for {
+              _        <- ff.onReadyEvent(details("p")) // provider becomes Ready => everReady set
+              _        <- ff.onErrorEvent(details("p")) // transient error => Error
+              beforeWd <- ff.providerStatus
+              _        <- ff.escalateInitTimeout(new CountingProvider("p", shutdowns), 1.hour)
+              afterWd  <- ff.providerStatus
+              count    <- ZIO.succeed(shutdowns.get())
+            } yield assertTrue(
+              beforeWd == ProviderStatus.Error,
+              afterWd == ProviderStatus.Error, // NOT Fatal
+              count == 0                       // provider was never shut down
+            )
+          }
+        }
+      } yield out
+    },
+    test(
+      "never-ready: escalation Fatals, shuts the provider down once, publishes Error(ProviderFatal), releases latch"
+    ) {
+      val shutdowns = new AtomicInteger(0)
+      val provider  = new CountingProvider("p", shutdowns)
+      val latch     = new CountDownLatch(1)
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
+        out <- ZIO.scoped {
+          build(ref, provider, Some(latch)).flatMap { ff =>
+            for {
+              collected <- Ref.make(List.empty[ProviderEvent])
+              cancel    <- ff.on(ProviderEventType.Error, e => collected.update(_ :+ e))
+              _         <- ff.escalateInitTimeout(provider, 30.seconds)
+              status    <- ff.providerStatus
+              evs       <- Live.live(collected.get.repeatUntil(_.nonEmpty).timeout(5.seconds)).map(_.getOrElse(Nil))
+              count     <- ZIO.succeed(shutdowns.get())
+              latchN    <- ZIO.succeed(latch.getCount)
+              _         <- cancel
+            } yield assertTrue(
+              status == ProviderStatus.Fatal,
+              count == 1,
+              latchN == 0L,
+              evs.collectFirst { case e: ProviderEvent.Error => e.errorCode }.flatten.contains(ErrorCode.ProviderFatal)
+            )
+          }
+        }
+      } yield out
+    }
+  ) @@ TestAspect.sequential
+}

--- a/docs/optimizely.md
+++ b/docs/optimizely.md
@@ -92,7 +92,7 @@ FeatureFlags.fromProviderAsync(
 )
 ```
 
-When `initTimeout` elapses without the datafile arriving, the layer's watchdog flips `providerStatus` to `Fatal`. Application code that polls `providerStatus` (or registers `onProviderReady` / `onProviderError`) sees this immediately and can fail loud:
+When `initTimeout` elapses without the datafile ever arriving, the layer's watchdog flips `providerStatus` to `Fatal` and shuts the provider down. This `Fatal` is terminal (the provider is stopped, so a late datafile cannot resurrect it — install a new provider via `setProvider` or rebuild the layer to recover). Application code that polls `providerStatus` (or registers `onProviderReady` / `onProviderError`) sees this immediately and can fail loud:
 
 ```scala
 val ready = for

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -447,7 +447,7 @@ val layer = FeatureFlags.fromMultiProvider(
 Every `fromProvider` and `fromProviderAsync` factory bounds initialization at **30 seconds by default**. The bound applies to both modes:
 
 - **Sync (`fromProvider`)**: if `setProviderAndWait` takes longer than `initTimeout`, the layer build fails with a `TimeoutException`. After init returns, the library verifies the provider's actual state — anything other than `READY` / `STALE` fails the build with an `IllegalStateException`, so a wrong SDK key or unreachable endpoint surfaces at startup instead of returning default values on every evaluation.
-- **Async (`fromProviderAsync`)**: a watchdog fiber forked into the layer's `Scope` sleeps `initTimeout`, then atomically transitions `ProviderStatus` from `NotReady` / `Error` to `Fatal`. Callers polling `providerStatus` stop waiting.
+- **Async (`fromProviderAsync`)**: a watchdog fiber forked into the layer's `Scope` sleeps `initTimeout`, then escalates to `Fatal` **only if the provider never became usable** — i.e. it is still `NotReady` / `Error` and has never reached `Ready` / `Stale`. A provider that reached `Ready` before the deadline (even if it has since dipped into a transient `Error`) is left running untouched. On escalation the watchdog also shuts the provider down (so its poller/HTTP threads don't outlive the layer) and publishes a `ProviderEvent.Error` carrying `ErrorCode.ProviderFatal`. Callers polling `providerStatus` stop waiting. Because the provider is shut down, this `Fatal` is terminal (see [Recovery semantics under `Fatal`](#recovery-semantics-under-fatal)).
 
 Override via the explicit-`initTimeout` overload:
 
@@ -464,7 +464,7 @@ FeatureFlags.fromProvider(provider, evaluationTimeout = 500.millis, initTimeout 
 
 ### Async Variants (Non-Blocking Initialization)
 
-Every factory method has an async counterpart that uses the Java SDK's non-blocking `setProvider` instead of `setProviderAndWait`. The provider initializes in the background; evaluations fail with `ProviderNotReady` until the provider is ready. The init-timeout watchdog described above still applies — after the configured `initTimeout` elapses, status transitions to `Fatal` so callers stop polling for ready.
+Every factory method has an async counterpart that uses the Java SDK's non-blocking `setProvider` instead of `setProviderAndWait`. The provider initializes in the background; evaluations fail with `ProviderNotReady` until the provider is ready. The init-timeout watchdog described above still applies — after the configured `initTimeout` elapses, a provider that never became usable transitions to `Fatal` (and is shut down) so callers stop polling for ready.
 
 This is useful for microservices that need fast startup and can tolerate returning default flag values during the brief initialization window.
 
@@ -555,7 +555,7 @@ Provider construction has two orthogonal dimensions: **how long the layer build 
 The 30-second default applies to both `fromProvider` and `fromProviderAsync`. Its effect differs:
 
 - **Sync**: bounds the *blocking* call. If `setProviderAndWait` (the underlying Java SDK call) doesn't return within `initTimeout`, the layer build fails with a `TimeoutException`. After it returns successfully, the library reads the provider's `getState()` — anything other than `READY`/`STALE` fails the build with `IllegalStateException`. Translation: in sync mode, `initTimeout` is a hard ceiling on cold-start latency and the layer never lands in a half-initialised state.
-- **Async**: a daemon fiber forked into the layer's `Scope` sleeps `initTimeout` then atomically transitions `NotReady`/`Error` → `Fatal`. The transition isn't terminal — if `PROVIDER_READY` fires later (e.g. network came back), status flips `Fatal → Ready` and evaluations resume. Translation: in async mode, `initTimeout` is the **bounded uncertainty window** at boot; after it elapses you have a reliable signal you can act on.
+- **Async**: a daemon fiber forked into the layer's `Scope` sleeps `initTimeout` then escalates to `Fatal` **only if the provider never became usable** (still `NotReady`/`Error`, never reached `Ready`/`Stale`) — a provider that reached `Ready` and later dipped into a transient `Error` is left running, not Fataled. On escalation it also shuts the provider down. Translation: in async mode, `initTimeout` is the **bounded uncertainty window** at boot; after it elapses you have a reliable, terminal signal you can act on (see [Recovery semantics](#recovery-semantics-under-fatal)).
 
 ### The "all defaults" gap
 
@@ -586,9 +586,11 @@ In every async configuration without a same-process fallback, there is a window 
 
 ### Recovery semantics under `Fatal`
 
-`Fatal` is a "stop waiting, take operator action" signal — not a tombstone. If the watchdog fires it at t = 30 s but Optimizely's poller succeeds at t = 90 s, the event bridge fires `PROVIDER_READY` and status transitions `Fatal → Ready`. Long-running pods recover naturally; you don't need to restart them to resume normal evaluation.
+`Fatal` is a **terminal** "stop waiting, take operator action" signal (OpenFeature spec 1.7.6: `FATAL` is irrecoverable). The watchdog only ever escalates a provider that **never became usable** within `initTimeout`, and it shuts that provider down as it does so — so there is no live poller left to recover, and a later `PROVIDER_READY` from the same provider cannot resurrect it. To resume evaluation after a `Fatal`, install a new provider via `setProvider` (or rebuild the layer); `setProvider` is the only exit from `Fatal`.
 
-Healthchecks that gate on `Ready`/`Stale` will see the pod un-route during the `Fatal` window and re-route after recovery, which is usually what you want.
+The transient case is handled *before* it can reach `Fatal`: a provider that reached `Ready` and later hits a recoverable `PROVIDER_ERROR` stays in `Error` (spec 1.7.6/1.7.7 keeps evaluations flowing to a provider that commonly still serves cached values), and a genuine `PROVIDER_READY` restores it to `Ready`. Only a provider that carries `ErrorCode.PROVIDER_FATAL` (mirroring the Java SDK's own `FATAL` state) goes terminal on its own.
+
+Healthchecks that gate on `Ready`/`Stale` will see the pod un-route once a provider goes `Fatal`; because that state is terminal, treat it as a signal to replace the provider or recycle the pod rather than waiting for self-recovery.
 
 ### Tuning `initTimeout`
 


### PR DESCRIPTION
Centralizes every provider-status write in `FeatureFlagsLive` and the async-init watchdog behind one pure, exhaustively-tested transition function (`internal.ProviderStatusMachine`), reached through a single `applySignal` door (a `SubscriptionRef.modify` linearization point). Replaces the per-site ad-hoc guards.

What changed:
- The init watchdog no longer Fatals/shuts down a provider that was ever `Ready` (an `everReady` gate); it only escalates a never-usable provider, and on escalation shuts it down and publishes `ProviderEvent.Error(ProviderFatal)` plus releasing the `onReady` latch.
- `Fatal` / post-shutdown `NotReady` / `ShuttingDown` are terminal against bridge events; `Stale` only from `Ready`; a `PROVIDER_ERROR` carrying `ErrorCode.PROVIDER_FATAL` now maps to `Fatal`.
- The 500ms `nanoTime` swap-guard heuristics are removed, replaced by provider-identity matching on the event's stamped provider name (fails open when either identity is indeterminate, e.g. the SDK's `MultiProvider`). `shutdown` deregisters the event-bridge handlers before tearing down the API; events publish under the emitting provider's name.
- Public API is additive only (`FeatureFlags.UnknownProviderName`).

Tests: new `ProviderStatusMachineSpec` (exhaustive pure table), `ProviderStatusBridgeSpec`, `WatchdogEscalationSpec`; full core/testkit/extras suites green on Scala 3 and 2.13, plus conformance and conformanceZioBdd. Docs/CHANGELOG updated.

Closes #244