### PR TITLE
Enable reason-codes-cached and align conformance runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`zio.openfeature.testkit.CachingReasonProvider`** (#257). A `FeatureProvider` decorator that reports the OpenFeature
+  `CACHED` reason (spec §1.4.7) on the second and subsequent evaluation of a given flag key, delegating everything else
+  to the wrapped provider. It lets tests exercise the `ResolutionReason.Cached` path against a provider (like the stock
+  in-memory one) that never emits `CACHED` on its own. Not to be confused with `extras.CachingProvider`, which caches
+  evaluation results — this only rewrites the reason and always re-delegates the evaluation.
+
 - **Total (never-fails) evaluation variants** (#256, spec §1.4.10 / §1.1.7). `booleanOrDefault`, `stringOrDefault`,
   `intOrDefault`, `longOrDefault`, `doubleOrDefault`, `objOrDefault`, and `valueOrDefault[A]` return `UIO[A]` — they never
   fail, absorbing any evaluation error into the supplied default, matching the spec's promise that evaluation "MUST NOT

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
@@ -8,7 +8,7 @@ import zio.bdd.core.step.{State, ZIOSteps}
 import zio.openfeature._
 // zio-bdd's Hooks trait defines `type FeatureHook = URIO[R, Unit]`, which shadows the OpenFeature hook trait; alias it.
 import zio.openfeature.FeatureHook as OFFeatureHook
-import zio.openfeature.testkit.TestFeatureProvider
+import zio.openfeature.testkit.{CachingReasonProvider, TestFeatureProvider}
 import zio.schema.{DeriveSchema, Schema}
 import dev.openfeature.sdk.{EvaluationContext => OFEvaluationContext, OpenFeatureAPIFactory}
 import dev.openfeature.sdk.providers.memory.InMemoryProvider
@@ -27,16 +27,18 @@ object HookRow { given Schema[HookRow] = DeriveSchema.gen[HookRow] }
   reporters = Array("pretty"),
   parallelism = 1,
   scenarioParallelism = 1,
+  // Canonical exclusion rationale for BOTH conformance runners (the Cucumber `RunConformance` references this).
   // The remaining excluded tags are out of scope for a ZIO SDK + in-memory testkit, not coverage gaps:
-  //   - async:               tautological — every evaluation already returns a non-blocking ZIO effect; there is no
-  //                          separate async API surface to assert against.
-  //   - reason-codes-cached: the in-memory testkit provider cannot emit a CACHED reason (it derives the reason from
-  //                          key presence only), so the scenario can't be satisfied without a contrived provider.
-  //   - deprecated:          superseded scenarios retained in the feature file for history, not meant to run.
-  //   - immutability:        the @immutability scenario asserts evaluation-*context* immutability (spec 1.4.15) and
-  //                          has no step definitions here; enabling it needs those steps implemented. It is unrelated
-  //                          to hook-*hints* immutability (spec 4.5.3), which #247 enforces at the type level.
-  excludeTags = Array("deprecated", "reason-codes-cached", "async", "immutability"),
+  //   - async:        tautological — every evaluation already returns a non-blocking ZIO effect; there is no separate
+  //                   async API surface to assert against.
+  //   - deprecated:   superseded scenarios retained in the feature file for history, not meant to run.
+  //   - immutability: the @immutability scenario asserts evaluation-*context* immutability (spec 1.4.15) and has no
+  //                   step definitions here; enabling it needs those steps implemented. It is unrelated to
+  //                   hook-*hints* immutability (spec 4.5.3), which #247 enforces at the type level.
+  // Both runners exclude exactly {deprecated, async, immutability}. @reason-codes-cached (spec 1.4.7) and
+  // @evaluation-options (spec 1.5.1) are now enabled: the former via the CachingReasonProvider decorator wrapping the
+  // in-memory provider, the latter via the evaluation-options step defs.
+  excludeTags = Array("deprecated", "async", "immutability"),
   logLevel = "warning"
 )
 object ConformanceSpec extends ZIOSteps[Any, World] {
@@ -52,7 +54,12 @@ object ConformanceSpec extends ZIOSteps[Any, World] {
       domain = s"bdd-${java.util.UUID.randomUUID()}"
       env <- sc.extend[Any](
         FeatureFlags
-          .fromProviderWithDomain(new InMemoryProvider(Fixtures.inMemoryFlags), domain, statusRef, api = Some(api))
+          .fromProviderWithDomain(
+            new CachingReasonProvider(new InMemoryProvider(Fixtures.inMemoryFlags)),
+            domain,
+            statusRef,
+            api = Some(api)
+          )
           .build
       )
     } yield env.get[FeatureFlags]

--- a/conformance/src/test/resources/zio/openfeature/conformance/README.md
+++ b/conformance/src/test/resources/zio/openfeature/conformance/README.md
@@ -10,11 +10,16 @@ Keep these byte-identical to upstream so a re-sync is a clean diff. To update: r
 from the pinned path at a newer commit and run `sbt conformance/test`; new or changed scenarios
 surface as failing/undefined steps rather than silently going unrun.
 
-## Excluded tags (mirrors the OpenFeature Java SDK's own e2e runner)
+## Excluded tags
 
-`RunConformance` filters out: `@deprecated` (superseded by `evaluation_v2`), `@reason-codes-cached`,
-`@async`, `@immutability`, `@evaluation-options`. The `evaluation.feature` file is not vendored (it
-is entirely `@deprecated`).
+`RunConformance` filters out exactly `@deprecated`, `@async`, and `@immutability`, matching the
+zio-bdd runner's `excludeTags`. The canonical rationale for each exclusion lives in `ConformanceSpec`
+in the `conformance-zio-bdd` module. The `evaluation.feature` file is not vendored (it is entirely
+`@deprecated`).
+
+`@reason-codes-cached` (spec 1.4.7) and `@evaluation-options` (spec 1.5.1) are executed: the CACHED
+reason is exercised by wrapping the in-memory provider with the testkit `CachingReasonProvider`, and
+the evaluation-options step definitions live in `ConformanceSteps`.
 
 ## Provider-status scenarios
 

--- a/conformance/src/test/scala/zio/openfeature/conformance/ConformanceSteps.scala
+++ b/conformance/src/test/scala/zio/openfeature/conformance/ConformanceSteps.scala
@@ -5,7 +5,7 @@ import io.cucumber.scala.{EN, ScalaDsl}
 import zio._
 import zio.stream.SubscriptionRef
 import zio.openfeature._
-import zio.openfeature.testkit.TestFeatureProvider
+import zio.openfeature.testkit.{CachingReasonProvider, TestFeatureProvider}
 import dev.openfeature.sdk.{EvaluationContext => OFEvaluationContext, OpenFeatureAPIFactory}
 import dev.openfeature.sdk.providers.memory.InMemoryProvider
 
@@ -70,7 +70,12 @@ class ConformanceSteps extends ScalaDsl with EN {
     val ff = run(
       sc.extend[Any](
         FeatureFlags
-          .fromProviderWithDomain(new InMemoryProvider(Fixtures.inMemoryFlags), domain, statusRef, api = Some(api))
+          .fromProviderWithDomain(
+            new CachingReasonProvider(new InMemoryProvider(Fixtures.inMemoryFlags)),
+            domain,
+            statusRef,
+            api = Some(api)
+          )
           .build
           .map(_.get)
       )
@@ -153,15 +158,18 @@ class ConformanceSteps extends ScalaDsl with EN {
   private def evalDetails[A](io: IO[FeatureFlagError, FlagResolution[A]], default: A): FlagResolution[A] =
     run(io.catchAll(e => ZIO.succeed(bridge(e, default))))
 
-  When("""^the flag was evaluated with details$""") { () =>
-    result = (flagType match {
-      case "boolean" => evalDetails(flags.booleanDetails(flagKey, defaultBoolean, evalCtx), defaultBoolean)
-      case "string"  => evalDetails(flags.stringDetails(flagKey, defaultRaw, evalCtx), defaultRaw)
-      case "integer" => evalDetails(flags.intDetails(flagKey, defaultInt, evalCtx), defaultInt)
-      case "float"   => evalDetails(flags.doubleDetails(flagKey, defaultDouble, evalCtx), defaultDouble)
-      case "object"  => evalDetails(flags.objDetails(flagKey, defaultObject, evalCtx), defaultObject)
+  private def evaluate(options: EvaluationOptions): FlagResolution[Any] =
+    (flagType match {
+      case "boolean" => evalDetails(flags.booleanDetails(flagKey, defaultBoolean, evalCtx, options), defaultBoolean)
+      case "string"  => evalDetails(flags.stringDetails(flagKey, defaultRaw, evalCtx, options), defaultRaw)
+      case "integer" => evalDetails(flags.intDetails(flagKey, defaultInt, evalCtx, options), defaultInt)
+      case "float"   => evalDetails(flags.doubleDetails(flagKey, defaultDouble, evalCtx, options), defaultDouble)
+      case "object"  => evalDetails(flags.objDetails(flagKey, defaultObject, evalCtx, options), defaultObject)
       case other     => throw new IllegalArgumentException(s"unknown flag type: $other")
     }).asInstanceOf[FlagResolution[Any]]
+
+  When("""^the flag was evaluated with details$""") { () =>
+    result = evaluate(EvaluationOptions.empty)
   }
 
   // Assertions on the resolved details
@@ -297,6 +305,48 @@ class ConformanceSteps extends ScalaDsl with EN {
       if (value == "null") check(actual.isEmpty, s"error_code $actual should be null")
       else check(actual.contains(value), s"error_code $actual != $value")
     case other => throw new IllegalArgumentException(s"unknown hook detail key: $other")
+  }
+
+  // Evaluation options (spec 1.5.1)
+
+  private val optionHookLog                  = new java.util.concurrent.ConcurrentLinkedQueue[String]()
+  private var evalOptions: EvaluationOptions = EvaluationOptions.empty
+
+  // Per-invocation hook that tags each stage with its name, so we can assert both execution and ordering.
+  private def orderedHook(name: String): FeatureHook = new FeatureHook {
+    override def before(c: HookContext, h: HookHints): UIO[Option[EvaluationContext]] =
+      ZIO.succeed(optionHookLog.add(s"$name:before")).as(None)
+    override def after[A](c: HookContext, d: FlagResolution[A], h: HookHints): UIO[Unit] =
+      ZIO.succeed(optionHookLog.add(s"$name:after")).unit
+    override def error(c: HookContext, e: FeatureFlagError, h: HookHints): UIO[Unit] =
+      ZIO.succeed(optionHookLog.add(s"$name:error")).unit
+    override def finallyAfter(c: HookContext, d: Option[FlagResolution[_]], h: HookHints): UIO[Unit] =
+      ZIO.succeed(optionHookLog.add(s"$name:finally")).unit
+  }
+
+  Given("""^evaluation options containing specific hooks$""") { () =>
+    evalOptions = EvaluationOptions(orderedHook("first"), orderedHook("second"))
+  }
+
+  When("""^the flag was evaluated with details using the evaluation options$""") { () =>
+    result = evaluate(evalOptions)
+  }
+
+  Then("""^the specified hooks should execute during evaluation$""") { () =>
+    val log = optionHookLog.asScala.toList
+    val allRan = Set("first", "second").forall(n =>
+      log.contains(s"$n:before") && log.contains(s"$n:after") && log.contains(s"$n:finally")
+    )
+    check(allRan, s"option hooks did not all execute: $log")
+  }
+
+  Then("""^the hook order should be maintained$""") { () =>
+    // Spec 4.4.2: before hooks run in registration order; after/finally in reverse.
+    val log       = optionHookLog.asScala.toList
+    val beforeOk  = log.indexOf("first:before") < log.indexOf("second:before")
+    val afterOk   = log.indexOf("second:after") < log.indexOf("first:after")
+    val finallyOk = log.indexOf("second:finally") < log.indexOf("first:finally")
+    check(beforeOk && afterOk && finallyOk, s"hook order not maintained: $log")
   }
 
   // Context merging

--- a/conformance/src/test/scala/zio/openfeature/conformance/RunConformance.scala
+++ b/conformance/src/test/scala/zio/openfeature/conformance/RunConformance.scala
@@ -4,13 +4,17 @@ import io.cucumber.junit.{Cucumber, CucumberOptions}
 import org.junit.runner.RunWith
 
 /** JUnit entry point: sbt's junit-interface discovers this `@RunWith(Cucumber)` class and Cucumber executes every
-  * `.feature` on the classpath under this package. Tag filters mirror the OpenFeature Java SDK's own e2e runner.
+  * `.feature` on the classpath under this package.
+  *
+  * The excluded tags must stay in sync with the zio-bdd runner's `excludeTags`; the canonical rationale for each
+  * intentional exclusion (`@deprecated`, `@async`, `@immutability`) lives in `ConformanceSpec` in the
+  * `conformance-zio-bdd` module. Both runners exclude exactly {deprecated, async, immutability}.
   */
 @RunWith(classOf[Cucumber])
 @CucumberOptions(
   features = Array("classpath:zio/openfeature/conformance"),
   glue = Array("zio.openfeature.conformance"),
   plugin = Array("pretty"),
-  tags = "not @deprecated and not @reason-codes-cached and not @async and not @evaluation-options and not @immutability"
+  tags = "not @deprecated and not @async and not @immutability"
 )
 class RunConformance

--- a/testkit/src/main/scala/zio/openfeature/testkit/CachingReasonProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/CachingReasonProvider.scala
@@ -1,0 +1,97 @@
+package zio.openfeature.testkit
+
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  FeatureProvider => OFFeatureProvider,
+  Metadata,
+  ProviderEvaluation,
+  ProviderState,
+  TrackingEventDetails,
+  Value
+}
+
+import java.util.concurrent.ConcurrentHashMap
+
+/** A [[dev.openfeature.sdk.FeatureProvider]] decorator that reports the OpenFeature `CACHED` reason (spec 1.4.7) on the
+  * second and subsequent evaluation of any given flag key, delegating everything else to the wrapped provider.
+  *
+  * The stock SDK `InMemoryProvider` derives its reason from flag presence only and never emits `CACHED`, so the
+  * conformance suite's `@reason-codes-cached` scenario — which evaluates one key twice and asserts `CACHED` — cannot
+  * pass against it directly. Wrapping the in-memory provider with this decorator makes that scenario exercise the real
+  * `ResolutionReason.Cached` mapping end to end.
+  *
+  * Applying it globally to the conformance in-memory setup is safe: that scenario is the only one in the suite that
+  * evaluates a key more than once, and each scenario gets a fresh provider instance, so no other scenario ever observes
+  * a `CACHED` reason. Key tracking is thread-safe.
+  *
+  * Not to be confused with `zio.openfeature.extras.CachingProvider`, which caches evaluation *results*; this decorator
+  * only rewrites the reason and always re-delegates the actual evaluation.
+  */
+final class CachingReasonProvider(delegate: OFFeatureProvider) extends EventProvider {
+
+  // Keys evaluated at least once. `add` returns false when the key was already present, marking a repeat evaluation.
+  private val evaluated: java.util.Set[String] = ConcurrentHashMap.newKeySet[String]()
+
+  private def cached[T](key: String, result: ProviderEvaluation[T]): ProviderEvaluation[T] =
+    if (evaluated.add(key)) result
+    else
+      // Repeat evaluation: preserve value/variant/error/metadata, override only the reason to CACHED (spec 1.4.7).
+      new ProviderEvaluation[T](
+        result.getValue,
+        result.getVariant,
+        "CACHED",
+        result.getErrorCode,
+        result.getErrorMessage,
+        result.getFlagMetadata
+      )
+
+  override def getBooleanEvaluation(
+    key: String,
+    defaultValue: java.lang.Boolean,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Boolean] =
+    cached(key, delegate.getBooleanEvaluation(key, defaultValue, context))
+
+  override def getStringEvaluation(
+    key: String,
+    defaultValue: String,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[String] =
+    cached(key, delegate.getStringEvaluation(key, defaultValue, context))
+
+  override def getIntegerEvaluation(
+    key: String,
+    defaultValue: java.lang.Integer,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Integer] =
+    cached(key, delegate.getIntegerEvaluation(key, defaultValue, context))
+
+  override def getDoubleEvaluation(
+    key: String,
+    defaultValue: java.lang.Double,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Double] =
+    cached(key, delegate.getDoubleEvaluation(key, defaultValue, context))
+
+  override def getObjectEvaluation(
+    key: String,
+    defaultValue: Value,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[Value] =
+    cached(key, delegate.getObjectEvaluation(key, defaultValue, context))
+
+  override def getMetadata: Metadata = delegate.getMetadata
+
+  override def getProviderHooks = delegate.getProviderHooks
+
+  @scala.annotation.nowarn("msg=deprecated")
+  override def getState: ProviderState = delegate.getState
+
+  override def initialize(context: OFEvaluationContext): Unit = delegate.initialize(context)
+
+  override def shutdown(): Unit = delegate.shutdown()
+
+  override def track(eventName: String, context: OFEvaluationContext, details: TrackingEventDetails): Unit =
+    delegate.track(eventName, context, details)
+}


### PR DESCRIPTION
The two conformance runners' tag-exclusion lists had drifted, and @reason-codes-cached (spec 1.4.7 CACHED reason) was excluded from both because the in-memory providers never emit CACHED. Adds a testkit CachingReasonProvider decorator that returns CACHED on the 2nd+ evaluation of a key (safe: only that scenario double-evaluates, and each scenario gets a fresh provider), wires it into both runners, and enables @reason-codes-cached in both. Adds the missing Cucumber step defs for @evaluation-options (spec 1.5.1, mirroring the ZIO-BDD runner incl. hook-order assertions) and enables it. Both runners now exclude exactly {deprecated, async, immutability}, with the rationale centralized. No official .feature files were modified.

Closes #257