### PR TITLE
Fix CachingProvider throwing FiberFailure into app code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`CachingProvider` no longer throws `FiberFailure` into application code** (#258). Its synchronous cache lookup used
+  `getOrThrowFiberFailure()`, so a delegate failure surfaced as a `zio.FiberFailure` — which extends `Throwable`, not
+  `Exception`, and therefore sailed past the Java SDK's `catch (Exception)` around evaluation and was thrown into the
+  caller, breaking the spec's never-throw contract and bypassing the error hooks. The lookup now unwraps the failure
+  and rethrows the original `OpenFeatureError` as-is (so the SDK maps the right error code and reason), wrapping any
+  other throwable in `GeneralError`. The `FiberFailure`-unwrapping logic that `CircuitBreakerProvider` already used is
+  extracted into a shared `FiberFailures` helper reused by both.
+
 ### Added
 
 - **`zio.openfeature.testkit.CachingReasonProvider`** (#257). A `FeatureProvider` decorator that reports the OpenFeature

--- a/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
@@ -176,8 +176,13 @@ final class CachingProvider private (
               .map(_.asInstanceOf[ProviderEvaluation[A]])
               .map(r => if (hit) withCachedReason(r) else r)
           }
-        )
-        .getOrThrowFiberFailure()
+        ) match {
+        // Rethrow the original error as an `OpenFeatureError` (an `Exception`) rather than letting
+        // `getOrThrowFiberFailure` raise a `zio.FiberFailure` (a `Throwable`) that would escape the SDK's
+        // `catch (Exception)` and be thrown into application code (spec: evaluation must never throw). See #258.
+        case Exit.Success(value) => value
+        case Exit.Failure(cause) => throw FiberFailures.toOpenFeatureError(cause)
+      }
     }
   }
 

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
@@ -223,7 +223,7 @@ final class CircuitBreakerProvider private (
         // but are not real successes. `recordReachable` resets the failure counter in Closed state and
         // frees the probe slot in Half-Open, without advancing toward closing the circuit on app errors alone.
         breaker.recordReachable()
-        throw unwrapFiberFailure(e)
+        throw FiberFailures.unwrap(e)
       case e: VirtualMachineError => throw e
       case e: LinkageError =>
         breaker.recordFailure()
@@ -231,7 +231,7 @@ final class CircuitBreakerProvider private (
       case e: Throwable =>
         val didOpen = breaker.recordFailure()
         if (didOpen) safeEmitStale("Circuit breaker opened")
-        val unwrapped = unwrapFiberFailure(e)
+        val unwrapped = FiberFailures.unwrap(e)
         val error     = new GeneralError(s"Circuit breaker: delegate failed: ${unwrapped.getMessage}")
         error.initCause(unwrapped)
         throw error
@@ -247,24 +247,8 @@ final class CircuitBreakerProvider private (
     dev.openfeature.sdk.ErrorCode.INVALID_CONTEXT
   )
 
-  private def unwrapFiberFailure(e: Throwable): Throwable = e match {
-    case ff: zio.FiberFailure =>
-      ff.cause.failureOption match {
-        case Some(t: Throwable) => t
-        case _ =>
-          ff.cause.dieOption match {
-            case Some(t) => t
-            case None =>
-              if (ff.cause.isInterrupted)
-                new java.util.concurrent.TimeoutException("Evaluation was interrupted")
-              else ff
-          }
-      }
-    case other => other
-  }
-
   private def isApplicationError(e: Throwable): Boolean =
-    unwrapFiberFailure(e) match {
+    FiberFailures.unwrap(e) match {
       case ofe: dev.openfeature.sdk.exceptions.OpenFeatureError =>
         applicationErrorCodes.contains(ofe.getErrorCode)
       case _ => false

--- a/extras/src/main/scala/zio/openfeature/extras/FiberFailures.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/FiberFailures.scala
@@ -1,0 +1,41 @@
+package zio.openfeature.extras
+
+import dev.openfeature.sdk.exceptions.{GeneralError, OpenFeatureError}
+import java.util.concurrent.TimeoutException
+
+/** Shared handling for the `zio.FiberFailure` that `Runtime.unsafe.run(...).getOrThrow*` produces.
+  *
+  * A `FiberFailure` extends `Throwable`, NOT `Exception`, so it escapes the Java SDK's `catch (Exception)` around
+  * provider evaluation and throws straight into application code — breaking the spec's never-throw evaluation contract
+  * and bypassing the error hooks. Providers that run a ZIO effect synchronously (behind the blocking Java
+  * `FeatureProvider` API) must therefore unwrap the `FiberFailure` back to the original error before rethrowing.
+  */
+private[extras] object FiberFailures {
+
+  /** Unwrap a `FiberFailure` to the throwable the fiber actually failed with; pass any other throwable through. */
+  def unwrap(e: Throwable): Throwable = e match {
+    case ff: zio.FiberFailure =>
+      ff.cause.failureOption match {
+        case Some(t: Throwable) => t
+        case _ =>
+          ff.cause.dieOption match {
+            case Some(t) => t
+            case None =>
+              if (ff.cause.isInterrupted) new TimeoutException("Evaluation was interrupted")
+              else ff
+          }
+      }
+    case other => other
+  }
+
+  /** Convert a failed effect's `Cause` into the `OpenFeatureError` to rethrow: an original `OpenFeatureError` is
+    * preserved as-is (so the SDK maps it to the right error code and reason), and anything else is wrapped in
+    * `GeneralError`. Both extend `Exception`, so the SDK's `catch (Exception)` catches them and returns the default
+    * value with error details instead of letting the throwable escape.
+    */
+  def toOpenFeatureError(cause: zio.Cause[Throwable]): OpenFeatureError =
+    unwrap(new zio.FiberFailure(cause)) match {
+      case ofe: OpenFeatureError => ofe
+      case other                 => new GeneralError(Option(other.getMessage).getOrElse("evaluation failed"))
+    }
+}

--- a/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
@@ -10,6 +10,7 @@ import dev.openfeature.sdk.{
   ProviderState,
   Value
 }
+import dev.openfeature.sdk.exceptions.{FlagNotFoundError, GeneralError, OpenFeatureError}
 import zio.openfeature.internal.ProviderEvaluations
 import zio._
 import zio.test._
@@ -94,6 +95,34 @@ object CachingProviderSpec extends ZIOSpecDefault {
       builder.flagMetadata(ImmutableMetadata.builder().addString("source", "test").build())
       builder.build().asInstanceOf[ProviderEvaluation[Value]]
     }
+  }
+
+  /** A provider whose every evaluation throws the given exception, to test error-surfacing (#258). */
+  private class ThrowingProvider(error: RuntimeException) extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata   = new Metadata { override def getName: String = "ThrowingProvider" }
+    override def getState: ProviderState = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(
+      k: String,
+      d: java.lang.Boolean,
+      c: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Boolean] = throw error
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext): ProviderEvaluation[String] =
+      throw error
+    override def getIntegerEvaluation(
+      k: String,
+      d: java.lang.Integer,
+      c: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Integer] = throw error
+    override def getDoubleEvaluation(
+      k: String,
+      d: java.lang.Double,
+      c: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Double] = throw error
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext): ProviderEvaluation[Value] =
+      throw error
   }
 
   private val ctx = new ImmutableContext()
@@ -472,6 +501,28 @@ object CachingProviderSpec extends ZIOSpecDefault {
             cached.getBooleanEvaluation("flag", false, ctx)
           }
         } yield assertTrue(underlying.evaluationCount.get() == 1)
+      }
+    ),
+    suite("error surfacing (#258)")(
+      test("a delegate OpenFeatureError surfaces as-is (an Exception), not a zio.FiberFailure") {
+        val cached = CachingProvider(new ThrowingProvider(new FlagNotFoundError("flag")))
+        for {
+          err <- ZIO.attempt(cached.getBooleanEvaluation("flag", false, ctx)).flip
+        } yield assertTrue(
+          err.isInstanceOf[FlagNotFoundError], // original error preserved so the SDK maps FLAG_NOT_FOUND
+          err.isInstanceOf[Exception],         // caught by the SDK's `catch (Exception)` → default returned, hooks run
+          !err.isInstanceOf[zio.FiberFailure]  // the bug: a FiberFailure (a Throwable) would escape that catch
+        )
+      },
+      test("a non-OpenFeature delegate failure is wrapped in GeneralError, not a zio.FiberFailure") {
+        val cached = CachingProvider(new ThrowingProvider(new RuntimeException("boom")))
+        for {
+          err <- ZIO.attempt(cached.getStringEvaluation("flag", "d", ctx)).flip
+        } yield assertTrue(
+          err.isInstanceOf[GeneralError],
+          err.isInstanceOf[OpenFeatureError],
+          !err.isInstanceOf[zio.FiberFailure]
+        )
       }
     )
   ) @@ TestAspect.withLiveClock

--- a/extras/src/test/scala/zio/openfeature/extras/FiberFailuresSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/FiberFailuresSpec.scala
@@ -1,0 +1,37 @@
+package zio.openfeature.extras
+
+import dev.openfeature.sdk.exceptions.{FlagNotFoundError, GeneralError, OpenFeatureError}
+import zio._
+import zio.test._
+
+/** #258: `FiberFailures.toOpenFeatureError` is the contract that keeps a synchronously-run provider effect from ever
+  * throwing a non-`Exception` into the SDK. `CachingProvider` only ever feeds it a `Fail(throwable)` cause, so these
+  * same-package unit tests exercise the die / interrupt / empty-cause branches directly to prove the helper ALWAYS
+  * yields an `OpenFeatureError` (⊂ `Exception`).
+  */
+object FiberFailuresSpec extends ZIOSpecDefault {
+
+  def spec = suite("FiberFailures.toOpenFeatureError")(
+    test("Fail(OpenFeatureError) is preserved as-is") {
+      val ofe = new FlagNotFoundError("flag")
+      assertTrue(FiberFailures.toOpenFeatureError(Cause.fail(ofe: Throwable)) eq ofe)
+    },
+    test("Fail(other throwable) is wrapped in GeneralError") {
+      val result = FiberFailures.toOpenFeatureError(Cause.fail(new RuntimeException("boom")))
+      assertTrue(result.isInstanceOf[GeneralError], result.getMessage == "boom")
+    },
+    test("Die(OpenFeatureError) is recovered and preserved") {
+      val ofe = new FlagNotFoundError("flag")
+      assertTrue(FiberFailures.toOpenFeatureError(Cause.die(ofe)) eq ofe)
+    },
+    test("Die(other throwable) is wrapped in GeneralError") {
+      val result = FiberFailures.toOpenFeatureError(Cause.die(new IllegalStateException("bad")))
+      assertTrue(result.isInstanceOf[GeneralError], result.getMessage == "bad")
+    },
+    test("an interruption is wrapped in GeneralError, never a non-Exception") {
+      val result = FiberFailures.toOpenFeatureError(Cause.interrupt(FiberId.None))
+      // The interrupt branch yields a TimeoutException, which is not an OpenFeatureError → wrapped in GeneralError.
+      assertTrue(result.isInstanceOf[GeneralError], result.isInstanceOf[OpenFeatureError])
+    }
+  )
+}


### PR DESCRIPTION
Closes #258

CachingProvider ran its synchronous cache lookup with getOrThrowFiberFailure(), so a delegate failure surfaced as a zio.FiberFailure — which extends Throwable, not Exception, so it escaped the Java SDK's catch(Exception) around evaluation and was thrown into application code, breaking the spec's never-throw contract and bypassing error hooks. The lookup now unwraps the failure and rethrows the original OpenFeatureError as-is (wrapping other throwables in GeneralError) — both extend Exception, so the SDK catches them and returns the default with error details. The FiberFailure-unwrapping logic already in CircuitBreakerProvider is extracted into a shared FiberFailures helper used by both. Adds surfacing tests plus FiberFailures unit tests.