### PR TITLE
Fix CachingProvider DEFAULT-reason caching and racy hit detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`CachingProvider` cache-correctness fixes** (#259). Two related defects: (1) a `DEFAULT`-reason evaluation (flag
+  absent, delegate echoes the caller's default) was cached under a key that excludes the default value, so a second call
+  site passing a different default received the first caller's value — labeled `CACHED` — for the whole TTL.
+  `DEFAULT`-reason results are now invalidated after each lookup (like error results), so every call site gets its own
+  default. (2) Hit detection used `cache.contains` followed by `cache.get`, which is not atomic — an entry expiring
+  between the two calls made a fresh delegate evaluation report `CACHED` — and cost two cache operations per evaluation.
+  Detection now uses a flag set inside the lookup thunk (which zio-cache runs only on a miss): one cache operation, and
+  a re-evaluation after expiry is correctly reported with the delegate's reason instead of `CACHED`.
+
 - **`CachingProvider` no longer throws `FiberFailure` into application code** (#258). Its synchronous cache lookup used
   `getOrThrowFiberFailure()`, so a delegate failure surfaced as a `zio.FiberFailure` — which extends `Throwable`, not
   `Exception`, and therefore sailed past the Java SDK's `catch (Exception)` around evaluation and was thrown into the

--- a/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
@@ -74,7 +74,14 @@ final private[extras] class CacheKey(
   *
   * Failures are never served from cache: a delegate exception (and any evaluation that resolves with an error code)
   * invalidates its entry, so the next evaluation retries the delegate instead of replaying a transient error for the
-  * remainder of the TTL.
+  * remainder of the TTL. `DEFAULT`-reason results are likewise not retained — a `DEFAULT` resolution echoes the
+  * caller's own default value, which the cache key does not capture, so caching it would serve one call site's default
+  * to another.
+  *
+  * Caveat: because concurrent lookups deduplicate by cache key (which excludes the default value), N simultaneous
+  * callers evaluating the same absent flag with DIFFERENT defaults all await the single in-flight evaluation and so
+  * share whichever default won the race. The non-retention above eliminates the sequential leak (across the TTL); the
+  * concurrent-window sharing is inherent to dedup and cannot be prevented without keying on the default.
   */
 final class CachingProvider private (
   val underlying: EventProvider,
@@ -140,6 +147,9 @@ final class CachingProvider private (
       s"${lp(tk)}|$attrs"
     }
 
+  // The OpenFeature `DEFAULT` reason string, compared against `ProviderEvaluation.getReason` (a raw String).
+  private val DefaultReason: String = dev.openfeature.sdk.Reason.DEFAULT.toString
+
   private def withCachedReason[A](eval: ProviderEvaluation[A]): ProviderEvaluation[A] = {
     // Builder calls are split across statements (not chained) because the SDK's SuperBuilder-style
     // self-type confuses Scala 2.13's existential resolution past the second fluent call.
@@ -159,23 +169,32 @@ final class CachingProvider private (
     context: OFEvaluationContext,
     evaluate: => ProviderEvaluation[A]
   ): ProviderEvaluation[A] = {
-    val ck =
-      new CacheKey(key, flagType, contextFingerprint(context), () => evaluate.asInstanceOf[ProviderEvaluation[Any]])
+    // `ran` is flipped inside the lookup thunk, which zio-cache invokes ONLY on a miss (a hit returns the stored value
+    // without calling it). Reading it after `get` tells us hit-vs-miss atomically — no separate `cache.contains` that
+    // could disagree with `get` if the entry expires between the two, and one cache operation per evaluation instead of
+    // two (#259).
+    val ran = new AtomicBoolean(false)
+    val ck = new CacheKey(
+      key,
+      flagType,
+      contextFingerprint(context),
+      () => { ran.set(true); evaluate.asInstanceOf[ProviderEvaluation[Any]] }
+    )
     Unsafe.unsafe { implicit u =>
       runtime.unsafe
         .run(
-          cache.contains(ck).flatMap { hit =>
-            cache
-              .get(ck)
-              // zio-cache stores the completed lookup Exit, failures included. Without this invalidation a
-              // single transient delegate exception would be replayed for the rest of the TTL.
-              .onError(_ => cache.invalidate(ck))
-              // Error *results* (errorCode set, no exception) are returned to this caller but not kept either:
-              // serving an error from cache would delay recovery by up to the TTL.
-              .tap(r => ZIO.when(r.getErrorCode != null)(cache.invalidate(ck)))
-              .map(_.asInstanceOf[ProviderEvaluation[A]])
-              .map(r => if (hit) withCachedReason(r) else r)
-          }
+          cache
+            .get(ck)
+            // zio-cache stores the completed lookup Exit, failures included. Without this invalidation a
+            // single transient delegate exception would be replayed for the rest of the TTL.
+            .onError(_ => cache.invalidate(ck))
+            // Don't retain error results (errorCode set) OR DEFAULT-reason results: a DEFAULT resolution means the flag
+            // was absent and the delegate echoed THIS caller's default value, which the cache key does not include —
+            // keeping it would serve one call site's default to another (under a CACHED label) for the whole TTL. Both
+            // are still returned to this caller, but re-evaluated next time (#259).
+            .tap(r => ZIO.when(r.getErrorCode != null || r.getReason == DefaultReason)(cache.invalidate(ck)))
+            .map(_.asInstanceOf[ProviderEvaluation[A]])
+            .map(r => if (ran.get()) r else withCachedReason(r))
         ) match {
         // Rethrow the original error as an `OpenFeatureError` (an `Exception`) rather than letting
         // `getOrThrowFiberFailure` raise a `zio.FiberFailure` (a `Throwable`) that would escape the SDK's

--- a/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CachingProviderSpec.scala
@@ -125,6 +125,45 @@ object CachingProviderSpec extends ZIOSpecDefault {
       throw error
   }
 
+  /** A provider that always echoes the caller's default value with reason DEFAULT (as EnvVar/Hocon do for an absent
+    * flag), counting evaluations. Used to prove DEFAULT-reason results are not cached across differing defaults (#259).
+    */
+  private class DefaultingProvider extends EventProvider {
+    val evaluationCount = new AtomicInteger(0)
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata   = new Metadata { override def getName: String = "DefaultingProvider" }
+    override def getState: ProviderState = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getBooleanEvaluation(
+      k: String,
+      d: java.lang.Boolean,
+      c: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Boolean] = {
+      evaluationCount.incrementAndGet(); ProviderEvaluations.of[java.lang.Boolean](d, "DEFAULT")
+    }
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext): ProviderEvaluation[String] = {
+      evaluationCount.incrementAndGet(); ProviderEvaluations.of[String](d, "DEFAULT")
+    }
+    override def getIntegerEvaluation(
+      k: String,
+      d: java.lang.Integer,
+      c: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Integer] = {
+      evaluationCount.incrementAndGet(); ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    }
+    override def getDoubleEvaluation(
+      k: String,
+      d: java.lang.Double,
+      c: OFEvaluationContext
+    ): ProviderEvaluation[java.lang.Double] = {
+      evaluationCount.incrementAndGet(); ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    }
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext): ProviderEvaluation[Value] = {
+      evaluationCount.incrementAndGet(); ProviderEvaluations.of[Value](d, "DEFAULT")
+    }
+  }
+
   private val ctx = new ImmutableContext()
 
   def spec = suite("CachingProvider")(
@@ -501,6 +540,34 @@ object CachingProviderSpec extends ZIOSpecDefault {
             cached.getBooleanEvaluation("flag", false, ctx)
           }
         } yield assertTrue(underlying.evaluationCount.get() == 1)
+      }
+    ),
+    suite("cache correctness (#259)")(
+      test("a DEFAULT-reason result is not cached, so differing call-site defaults do not leak") {
+        val underlying = new DefaultingProvider
+        val cached     = CachingProvider(underlying)
+        val a          = cached.getBooleanEvaluation("absent", false, ctx) // call site A: default false
+        val b          = cached.getBooleanEvaluation("absent", true, ctx)  // call site B: default true
+        assertTrue(
+          !a.getValue,
+          b.getValue, // B gets its OWN default, not A's cached `false`
+          a.getReason == "DEFAULT",
+          b.getReason == "DEFAULT",             // not CACHED — DEFAULT results are not retained
+          underlying.evaluationCount.get() == 2 // both call sites reach the delegate
+        )
+      },
+      test("after TTL expiry a re-evaluation is a fresh miss, not mislabeled CACHED") {
+        val underlying = new CountingProvider(Map("flag" -> true))
+        val cached     = CachingProvider(underlying, CachingConfig(ttl = 100.millis))
+        for {
+          r1 <- ZIO.succeed(cached.getBooleanEvaluation("flag", false, ctx)) // miss
+          _  <- ZIO.sleep(250.millis)                                        // let the TTL lapse (live clock)
+          r2 <- ZIO.succeed(cached.getBooleanEvaluation("flag", false, ctx)) // expired → fresh miss
+        } yield assertTrue(
+          r1.getReason == "TARGETING_MATCH",
+          r2.getReason == "TARGETING_MATCH", // the racy contains→get gap would have mislabeled this CACHED
+          underlying.evaluationCount.get() == 2
+        )
       }
     ),
     suite("error surfacing (#258)")(


### PR DESCRIPTION
Two `CachingProvider` cache-correctness defects.

(1) A DEFAULT-reason evaluation (flag absent, delegate echoes the caller's default) was cached under a key that excludes the default value, so a second call site passing a different default received the first caller's value — labeled CACHED — for the whole TTL. DEFAULT-reason results are now invalidated after lookup (like error results), so every call site gets its own default.

(2) Hit detection used `cache.contains` then `cache.get` — not atomic (an entry expiring between them mislabeled a fresh evaluation CACHED) and two cache operations per call. Detection now uses a flag set inside the lookup thunk, which zio-cache runs only on a miss: one cache operation, race-free, and a re-evaluation after TTL expiry reports the delegate's reason instead of CACHED.

Adds two gate tests (DEFAULT-reason not leaked across differing defaults; TTL-expiry re-eval not mislabeled CACHED).

Closes #259