### PR TITLE
Reload HoconProvider from its construction source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`HoconProvider.reload` now refreshes the original construction source** (#260). `reload` previously ignored how the
+  provider was built — it always called `ConfigFactory.load()` against the classpath and read the `feature-flags`
+  default path, so `HoconProvider("my-flags").reload()` silently swapped the flag set to the (usually empty)
+  `feature-flags` subtree, and `HoconProvider.fromConfig(customConfig).reload()` discarded the injected config for
+  whatever was on the classpath. The provider now stores its source: `apply(path)` re-reads that same path (after
+  invalidating the config cache), and `fromConfig` keeps the injected config (which has no external source) instead of
+  discarding it. `reload` no longer takes a `path` argument (it reloads the constructed source).
+
 - **`CachingProvider` cache-correctness fixes** (#259). Two related defects: (1) a `DEFAULT`-reason evaluation (flag
   absent, delegate echoes the caller's default) was cached under a key that excludes the default value, so a second call
   site passing a different default received the first caller's value — labeled `CACHED` — for the whole TTL.

--- a/docs/extras.md
+++ b/docs/extras.md
@@ -77,9 +77,10 @@ All evaluations return `STATIC` as the resolution reason since values are loaded
 ### Manual reload
 
 ```scala
-// Re-read config from disk without restarting
-val provider = HoconProvider()
-provider.reload() // or provider.reload("custom-path")
+// Re-read config without restarting. `reload()` refreshes the source the provider was built from:
+// the classpath path for `HoconProvider(path)`, or the injected config for `HoconProvider.fromConfig(...)`.
+val provider = HoconProvider("custom-path")
+provider.reload()
 ```
 
 ---

--- a/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
@@ -25,7 +25,10 @@ import scala.jdk.CollectionConverters._
   *   The Typesafe Config object scoped to the feature flags path
   */
 final class HoconProvider private (
-  private val configRef: AtomicReference[Config]
+  private val configRef: AtomicReference[Config],
+  // Re-reads the config from the ORIGINAL construction source, so `reload()` refreshes what the provider was built
+  // from — the classpath path for `apply`, or the injected `Config` (which has no external source) for `fromConfig`.
+  private val reloadSource: () => Config
 ) extends FeatureProvider {
 
   private val state = new AtomicReference[ProviderState](ProviderState.READY)
@@ -129,18 +132,16 @@ final class HoconProvider private (
       case ConfigValueType.NULL => new Value()
     }
 
-  /** Reload the config by re-parsing from the original source.
+  /** Reload the config by re-parsing from the original construction source (the classpath path passed to `apply`, or
+    * the injected `Config` from `fromConfig` — which has no external source, so `reload` keeps it rather than
+    * discarding it to the classpath).
     *
     * On failure, the existing config is preserved and provider state transitions to `ERROR`. The state remains `ERROR`
     * until a subsequent `reload` succeeds — callers must re-invoke to recover.
     */
-  def reload(path: String = "feature-flags"): Task[Unit] =
+  def reload(): Task[Unit] =
     ZIO
-      .attempt {
-        ConfigFactory.invalidateCaches()
-        val root = ConfigFactory.load()
-        if (root.hasPath(path)) root.getConfig(path) else ConfigFactory.empty()
-      }
+      .attempt(reloadSource())
       .tapBoth(
         _ => ZIO.succeed(state.set(ProviderState.ERROR)),
         newCfg => ZIO.succeed { configRef.set(newCfg); state.set(ProviderState.READY) }
@@ -150,14 +151,20 @@ final class HoconProvider private (
 
 object HoconProvider {
 
-  /** Create from the default `application.conf` at the given path. */
+  /** Create from the default `application.conf` at the given path. `reload()` re-reads this same path (after
+    * invalidating the config cache, so on-disk/classpath changes are picked up).
+    */
   def apply(path: String = "feature-flags"): HoconProvider = {
-    val root   = ConfigFactory.load()
-    val config = if (root.hasPath(path)) root.getConfig(path) else ConfigFactory.empty()
-    new HoconProvider(new AtomicReference(config))
+    def extract(root: Config): Config = if (root.hasPath(path)) root.getConfig(path) else ConfigFactory.empty()
+    new HoconProvider(
+      new AtomicReference(extract(ConfigFactory.load())),
+      () => { ConfigFactory.invalidateCaches(); extract(ConfigFactory.load()) }
+    )
   }
 
-  /** Create from a specific Config object. */
+  /** Create from a specific `Config` object. An injected config has no external source, so `reload()` keeps it as-is
+    * rather than discarding it — use `apply(path)` for a reloadable classpath-backed provider.
+    */
   def fromConfig(config: Config): HoconProvider =
-    new HoconProvider(new AtomicReference(config))
+    new HoconProvider(new AtomicReference(config), () => config)
 }

--- a/extras/src/test/scala/zio/openfeature/extras/HoconProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/HoconProviderSpec.scala
@@ -124,6 +124,35 @@ object HoconProviderSpec extends ZIOSpecDefault {
         val r   = p.getBooleanEvaluation("flag", false, ctx)
         assertTrue(r.getValue == true)
       }
-    )
+    ),
+    suite("reload (#260)")(
+      test("fromConfig reload preserves the injected config instead of discarding it to the classpath") {
+        val cfg = ConfigFactory.parseString("only-here = true")
+        val p   = HoconProvider.fromConfig(cfg)
+        for {
+          before <- ZIO.succeed(p.getBooleanEvaluation("only-here", false, ctx))
+          _      <- p.reload()
+          after  <- ZIO.succeed(p.getBooleanEvaluation("only-here", false, ctx))
+        } yield assertTrue(
+          before.getValue == true,
+          after.getValue == true, // pre-fix: reload discarded cfg → classpath has no "only-here" → false/DEFAULT
+          after.getReason == "STATIC"
+        )
+      },
+      test("apply(path) reload re-reads the constructed path, not the hardcoded 'feature-flags'") {
+        java.lang.System.setProperty("issue260-flags.limit", "10")
+        ConfigFactory.invalidateCaches()
+        val p = HoconProvider("issue260-flags")
+        (for {
+          before <- ZIO.succeed(p.getIntegerEvaluation("limit", 0, ctx))
+          _      <- ZIO.succeed(java.lang.System.setProperty("issue260-flags.limit", "20"))
+          _      <- p.reload()
+          after  <- ZIO.succeed(p.getIntegerEvaluation("limit", 0, ctx))
+        } yield assertTrue(
+          before.getValue == 10,
+          after.getValue == 20 // proves reload re-read "issue260-flags"; the hardcoded "feature-flags" would give 0
+        )).ensuring(ZIO.succeed(java.lang.System.clearProperty("issue260-flags.limit")))
+      }
+    ) @@ TestAspect.sequential
   )
 }


### PR DESCRIPTION
`HoconProvider.reload` ignored how the provider was constructed — it always called `ConfigFactory.load()` on the classpath and read the hardcoded `feature-flags` path, so `HoconProvider("my-flags").reload()` silently swapped the flag set to the (usually empty) `feature-flags` subtree, and `HoconProvider.fromConfig(customConfig).reload()` discarded the injected config for whatever was on the classpath.

The provider now stores its construction source: `apply(path)` re-reads that same path (invalidating the config cache first so on-disk/classpath changes are picked up), and `fromConfig` keeps the injected config (which has no external source) instead of discarding it. `reload()` no longer takes a `path` argument — it reloads the constructed source.

Adds reload gate tests (fromConfig preserves the injected config; apply re-reads the constructed path) and updates docs/extras.md.

Closes #260