### PR TITLE
Forward getProviderHooks and track in provider decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`CachingProvider` and `CircuitBreakerProvider` now forward the delegate's provider hooks and tracking** (#261).
+  Neither wrapper overrode `getProviderHooks` or `track`, so both inherited the Java SDK's no-op defaults: wrapping a
+  provider that ships provider hooks (telemetry/validation) silently dropped them, and `client.track(...)` was silently
+  discarded. Both wrappers now delegate `getProviderHooks` and `track` to the underlying provider (in
+  `CircuitBreakerProvider`, `track` passes through without consulting the circuit, since it is fire-and-forget).
+
 - **`HoconProvider.reload` now refreshes the original construction source** (#260). `reload` previously ignored how the
   provider was built — it always called `ConfigFactory.load()` against the classpath and read the `feature-flags`
   default path, so `HoconProvider("my-flags").reload()` silently swapped the flag set to the (usually empty)

--- a/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
@@ -9,6 +9,7 @@ import dev.openfeature.sdk.{
   ProviderEvaluation,
   ProviderEventDetails,
   ProviderState,
+  TrackingEventDetails,
   Value
 }
 import zio._
@@ -97,6 +98,13 @@ final class CachingProvider private (
 
   @scala.annotation.nowarn("msg=deprecated")
   override def getState: ProviderState = underlying.getState
+
+  // Forward the delegate's provider hooks and tracking so wrapping a provider in caching doesn't silently drop its
+  // telemetry/validation hooks or discard `track` events (spec: a decorator must not swallow these). See #261.
+  override def getProviderHooks = underlying.getProviderHooks
+
+  override def track(eventName: String, context: OFEvaluationContext, details: TrackingEventDetails): Unit =
+    underlying.track(eventName, context, details)
 
   private val delegateAttached = new AtomicBoolean(false)
 

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
@@ -9,6 +9,7 @@ import dev.openfeature.sdk.{
   ProviderEvaluation,
   ProviderEventDetails,
   ProviderState,
+  TrackingEventDetails,
   Value
 }
 import dev.openfeature.sdk.exceptions.GeneralError
@@ -140,6 +141,14 @@ final class CircuitBreakerProvider private (
       scala.util.Try(EventProviderBridge.detach(underlying))
     underlying.shutdown()
   }
+
+  // Forward the delegate's provider hooks and tracking so wrapping a provider in a circuit breaker doesn't silently
+  // drop its telemetry/validation hooks or discard `track` events. `track` is fire-and-forget, so it passes through
+  // without consulting the circuit. See #261.
+  override def getProviderHooks = underlying.getProviderHooks
+
+  override def track(eventName: String, context: OFEvaluationContext, details: TrackingEventDetails): Unit =
+    underlying.track(eventName, context, details)
 
   override def getBooleanEvaluation(
     key: String,

--- a/extras/src/test/scala/zio/openfeature/extras/ProviderDelegationSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/ProviderDelegationSpec.scala
@@ -1,0 +1,78 @@
+package zio.openfeature.extras
+
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Hook,
+  ImmutableContext,
+  Metadata,
+  MutableTrackingEventDetails,
+  ProviderEvaluation,
+  ProviderState,
+  TrackingEventDetails,
+  Value
+}
+import zio.openfeature.internal.ProviderEvaluations
+import zio._
+import zio.test._
+import java.util.concurrent.CopyOnWriteArrayList
+
+/** #261: the caching / circuit-breaker decorators must forward the delegate's `getProviderHooks` and `track` — the Java
+  * SDK's `FeatureProvider` defines both as no-op defaults, so a decorator that doesn't override them silently drops the
+  * delegate's provider hooks (telemetry/validation) and discards tracking events.
+  */
+object ProviderDelegationSpec extends ZIOSpecDefault {
+
+  private class HookedTrackingProvider extends EventProvider {
+    // Type the hook as `Hook[_]` so `singletonList` infers `List[Hook[_]]` (not `List[Hook[Object]]`, which the
+    // invariant `java.util.List` would reject against the annotated return type). This mirrors the cross-version-safe
+    // pattern in core's ProviderHookDuplicationSpec.
+    private val providerHook: Hook[_] = new Hook[java.lang.Object] {}
+    val tracked                       = new CopyOnWriteArrayList[String]()
+
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                       = new Metadata { override def getName: String = "Hooked" }
+    override def getState: ProviderState                     = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit  = ()
+    override def shutdown(): Unit                            = ()
+    override def getProviderHooks(): java.util.List[Hook[_]] = java.util.Collections.singletonList(providerHook)
+    override def track(eventName: String, context: OFEvaluationContext, details: TrackingEventDetails): Unit = {
+      tracked.add(eventName); ()
+    }
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](d, "STATIC")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "STATIC")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "STATIC")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "STATIC")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "STATIC")
+  }
+
+  private val ctx     = new ImmutableContext()
+  private val details = new MutableTrackingEventDetails()
+
+  def spec = suite("provider decorator delegation (#261)")(
+    test("CachingProvider forwards getProviderHooks and track to the delegate") {
+      val delegate = new HookedTrackingProvider
+      val cached   = CachingProvider(delegate)
+      cached.track("purchase", ctx, details)
+      assertTrue(
+        cached.getProviderHooks.size == 1,    // the delegate's hooks, not the SDK's empty default
+        delegate.tracked.contains("purchase") // track reached the delegate, not the no-op default
+      )
+    },
+    test("CircuitBreakerProvider forwards getProviderHooks and track to the delegate") {
+      val delegate = new HookedTrackingProvider
+      for {
+        cb <- CircuitBreakerProvider.make(delegate)
+        _  <- ZIO.succeed(cb.track("purchase", ctx, details))
+      } yield assertTrue(
+        cb.getProviderHooks.size == 1,
+        delegate.tracked.contains("purchase")
+      )
+    }
+  )
+}


### PR DESCRIPTION
Neither `CachingProvider` nor `CircuitBreakerProvider` overrode `getProviderHooks` or `track`, so both inherited the Java SDK's no-op `FeatureProvider` defaults: wrapping a provider that ships provider hooks (telemetry/validation) silently dropped them, and `client.track(...)` was silently discarded — both regressions appearing merely by adding caching/circuit-breaking.

Both wrappers now forward `getProviderHooks` and `track` to the underlying provider. In `CircuitBreakerProvider`, `track` passes through without consulting the circuit (it is fire-and-forget telemetry, not an evaluation). Adds `ProviderDelegationSpec` covering both wrappers.

Closes #261