### PR TITLE
Surface EnvVarProvider parse failures as ParseError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`EnvVarProvider` surfaces parse failures instead of swallowing them** (#262). A set-but-unparsable environment
+  variable was indistinguishable from an unset one: the integer/double paths collapsed a parse failure to the default
+  with reason `DEFAULT`, and the boolean path was worse — it returned the default labeled `STATIC`, falsely claiming the
+  value came from the environment (so `FF_NEW_CHECKOUT=enabled` silently ran on the code default). A set-but-unparsable
+  boolean/integer/double value now throws `ParseError`, which the SDK surfaces as a `PARSE_ERROR` evaluation (the zio
+  layer maps it to a typed `ParseError`) instead of hiding the misconfiguration. An unset variable still returns the
+  default with reason `DEFAULT`.
+
 - **`CachingProvider` and `CircuitBreakerProvider` now forward the delegate's provider hooks and tracking** (#261).
   Neither wrapper overrode `getProviderHooks` or `track`, so both inherited the Java SDK's no-op defaults: wrapping a
   provider that ships provider hooks (telemetry/validation) silently dropped them, and `client.track(...)` was silently

--- a/extras/src/main/scala/zio/openfeature/extras/EnvVarProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/EnvVarProvider.scala
@@ -8,6 +8,7 @@ import dev.openfeature.sdk.{
   ProviderState,
   Value
 }
+import dev.openfeature.sdk.exceptions.ParseError
 import zio.openfeature.internal.ProviderEvaluations
 
 /** A feature flag provider that reads values from environment variables.
@@ -46,12 +47,13 @@ final class EnvVarProvider private (
   ): ProviderEvaluation[java.lang.Boolean] =
     lookup(key) match {
       case Some(v) =>
-        val parsed = v.toLowerCase match {
-          case "true" | "1" | "yes" | "on"  => true
-          case "false" | "0" | "no" | "off" => false
-          case _                            => defaultValue.booleanValue()
+        v.toLowerCase match {
+          case "true" | "1" | "yes" | "on"  => ProviderEvaluations.of(java.lang.Boolean.TRUE, "STATIC")
+          case "false" | "0" | "no" | "off" => ProviderEvaluations.of(java.lang.Boolean.FALSE, "STATIC")
+          // Set-but-unparsable: surface a spec PARSE_ERROR rather than silently returning the default (worse, the old
+          // code labeled that fallback STATIC, claiming it came from the environment). See #262.
+          case _ => throw new ParseError(s"Env var ${envKey(key)}='$v' is not a valid boolean for flag '$key'")
         }
-        ProviderEvaluations.of(java.lang.Boolean.valueOf(parsed), "STATIC")
       case None =>
         ProviderEvaluations.of(defaultValue, "DEFAULT")
     }
@@ -73,9 +75,13 @@ final class EnvVarProvider private (
     defaultValue: java.lang.Integer,
     context: OFEvaluationContext
   ): ProviderEvaluation[java.lang.Integer] =
-    lookup(key).flatMap(v => scala.util.Try(v.toInt).toOption) match {
+    lookup(key) match {
       case Some(v) =>
-        ProviderEvaluations.of(java.lang.Integer.valueOf(v), "STATIC")
+        scala.util.Try(v.toInt) match {
+          case scala.util.Success(n) => ProviderEvaluations.of(java.lang.Integer.valueOf(n), "STATIC")
+          case scala.util.Failure(_) =>
+            throw new ParseError(s"Env var ${envKey(key)}='$v' is not a valid int for flag '$key'")
+        }
       case None =>
         ProviderEvaluations.of(defaultValue, "DEFAULT")
     }
@@ -85,9 +91,13 @@ final class EnvVarProvider private (
     defaultValue: java.lang.Double,
     context: OFEvaluationContext
   ): ProviderEvaluation[java.lang.Double] =
-    lookup(key).flatMap(v => scala.util.Try(v.toDouble).toOption) match {
+    lookup(key) match {
       case Some(v) =>
-        ProviderEvaluations.of(java.lang.Double.valueOf(v), "STATIC")
+        scala.util.Try(v.toDouble) match {
+          case scala.util.Success(n) => ProviderEvaluations.of(java.lang.Double.valueOf(n), "STATIC")
+          case scala.util.Failure(_) =>
+            throw new ParseError(s"Env var ${envKey(key)}='$v' is not a valid double for flag '$key'")
+        }
       case None =>
         ProviderEvaluations.of(defaultValue, "DEFAULT")
     }

--- a/extras/src/test/scala/zio/openfeature/extras/EnvVarProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/EnvVarProviderSpec.scala
@@ -3,6 +3,7 @@ package zio.openfeature.extras
 import zio._
 import zio.test._
 import dev.openfeature.sdk.ImmutableContext
+import dev.openfeature.sdk.exceptions.ParseError
 
 object EnvVarProviderSpec extends ZIOSpecDefault {
 
@@ -12,7 +13,8 @@ object EnvVarProviderSpec extends ZIOSpecDefault {
     "FF_RATE_LIMIT"   -> "2.5",
     "FF_WELCOME_MSG"  -> "Hello!",
     "FF_DISABLED"     -> "false",
-    "FF_BAD_NUMBER"   -> "not-a-number"
+    "FF_BAD_NUMBER"   -> "not-a-number",
+    "FF_BAD_BOOL"     -> "enabled"
   )
 
   private val provider = EnvVarProvider.withLookup(testEnv.get)
@@ -33,6 +35,13 @@ object EnvVarProviderSpec extends ZIOSpecDefault {
         val result = provider.getBooleanEvaluation("missing", true, ctx)
         assertTrue(result.getValue == true) &&
         assertTrue(result.getReason == "DEFAULT")
+      },
+      test("throws ParseError for a set-but-unparseable value (#262)") {
+        // Previously this returned the default labeled STATIC, falsely claiming it came from the environment.
+        ZIO
+          .attempt(provider.getBooleanEvaluation("bad-bool", false, ctx))
+          .flip
+          .map(e => assertTrue(e.isInstanceOf[ParseError]))
       }
     ),
     suite("string evaluation")(
@@ -50,15 +59,25 @@ object EnvVarProviderSpec extends ZIOSpecDefault {
         val result = provider.getIntegerEvaluation("max-items", 10, ctx)
         assertTrue(result.getValue == 50)
       },
-      test("returns default for unparseable value") {
-        val result = provider.getIntegerEvaluation("bad-number", 10, ctx)
-        assertTrue(result.getValue == 10)
+      test("throws ParseError for a set-but-unparseable value (#262)") {
+        // Set-but-unparsable must surface as PARSE_ERROR, not silently collapse to the default (which is
+        // indistinguishable from the variable being unset).
+        ZIO
+          .attempt(provider.getIntegerEvaluation("bad-number", 10, ctx))
+          .flip
+          .map(e => assertTrue(e.isInstanceOf[ParseError]))
       }
     ),
     suite("double evaluation")(
       test("returns parsed double") {
         val result = provider.getDoubleEvaluation("rate-limit", 1.0, ctx)
         assertTrue(result.getValue == 2.5)
+      },
+      test("throws ParseError for a set-but-unparseable value (#262)") {
+        ZIO
+          .attempt(provider.getDoubleEvaluation("bad-number", 1.0, ctx))
+          .flip
+          .map(e => assertTrue(e.isInstanceOf[ParseError]))
       }
     ),
     suite("key transformation")(


### PR DESCRIPTION
`EnvVarProvider` swallowed parse failures: a set-but-unparsable environment variable was indistinguishable from an unset one. The integer/double paths collapsed a parse failure to the default with reason `DEFAULT`, and the boolean path was worse — it returned the default labeled `STATIC`, falsely claiming the value came from the environment (so `FF_NEW_CHECKOUT=enabled` silently ran on the code default).

A set-but-unparsable boolean/integer/double value now throws `ParseError`, which the SDK surfaces as a `PARSE_ERROR` evaluation (the zio layer maps it to a typed `ParseError`) instead of hiding the misconfiguration. An unset variable still returns the default with reason `DEFAULT`. String/object paths are unchanged. Updates the int test that encoded the old behavior and adds boolean + double parse-error tests.

Closes #262