### PR TITLE
Harden CircuitBreaker timing, timeouts, and probe slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CircuitBreaker robustness: monotonic timing, interruptible timeouts, no half-open probe leak** (#263). Three fixes:
+  (1) elapsed-time decisions (open→half-open reset, delegate-state poll rate-limiting) now use a monotonic `Ticker`
+  (`System.nanoTime`, injectable for tests) instead of a wall clock, so an NTP/clock step can no longer delay recovery
+  or collapse the reset window against a still-down delegate. (2) The per-evaluation timeout now uses
+  `attemptBlockingInterrupt`, so a timed-out delegate call delivers `Thread.interrupt` to the blocking-pool thread
+  instead of leaking one pinned thread per timeout while the system is degraded. (3) A half-open probe slot can no longer
+  wedge the circuit forever: `tryAcquire` steals a probe slot older than `probeTimeout` (default `evaluationTimeout +
+  1s`), and a probe dying with a `VirtualMachineError` now records the failure (re-opening the circuit) before
+  rethrowing. `CircuitBreakerConfig` gains a `probeTimeout` parameter.
+
 - **`EnvVarProvider` surfaces parse failures instead of swallowing them** (#262). A set-but-unparsable environment
   variable was indistinguishable from an unset one: the integer/double paths collapsed a parse failure to the default
   with reason `DEFAULT`, and the boolean path was worse — it returned the default labeled `STATIC`, falsely claiming the

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreaker.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreaker.scala
@@ -3,6 +3,20 @@ package zio.openfeature.extras
 import zio._
 import java.util.concurrent.atomic.AtomicReference
 
+/** A monotonic time source for the circuit breaker's elapsed-time decisions.
+  *
+  * Uses `System.nanoTime()` rather than a wall clock so an NTP step or manual clock adjustment cannot corrupt open /
+  * half-open timing. Injectable so tests can drive transitions deterministically.
+  */
+trait Ticker {
+  def nanos(): Long
+}
+object Ticker {
+  val system: Ticker = new Ticker {
+    def nanos(): Long = java.lang.System.nanoTime()
+  }
+}
+
 /** Configuration for the circuit breaker state machine.
   *
   * @param failureThreshold
@@ -11,11 +25,15 @@ import java.util.concurrent.atomic.AtomicReference
   *   How long the circuit stays open before transitioning to half-open
   * @param halfOpenMaxCalls
   *   Number of successful probes in half-open state required to close the circuit
+  * @param probeTimeout
+  *   How long a single half-open probe may hold the probe slot before another caller may steal it. Guards against a
+  *   probe that dies without recording an outcome pinning the circuit half-open forever.
   */
 final case class CircuitBreakerConfig(
   failureThreshold: Int = 5,
   resetTimeout: Duration = 30.seconds,
-  halfOpenMaxCalls: Int = 1
+  halfOpenMaxCalls: Int = 1,
+  probeTimeout: Duration = 1.second
 )
 
 /** Why the circuit was opened — determines whether external recovery applies. */
@@ -27,9 +45,10 @@ private[extras] object OpenReason {
 
 sealed private[extras] trait CircuitState extends Product with Serializable
 private[extras] object CircuitState {
-  case object Closed                                           extends CircuitState
-  final case class Open(sinceMillis: Long, reason: OpenReason) extends CircuitState
-  final case class HalfOpen(successes: Int, probing: Boolean)  extends CircuitState
+  case object Closed                                          extends CircuitState
+  final case class Open(sinceNanos: Long, reason: OpenReason) extends CircuitState
+  // probeStartNanos records when the in-flight probe acquired the slot; it only matters when probing == true.
+  final case class HalfOpen(successes: Int, probing: Boolean, probeStartNanos: Long) extends CircuitState
 }
 
 final private[extras] case class CircuitBreakerState(
@@ -63,7 +82,7 @@ private[extras] object GateResult {
 final class CircuitBreaker private[extras] (
   val config: CircuitBreakerConfig,
   private[extras] val stateRef: AtomicReference[CircuitBreakerState],
-  private[extras] val clock: java.time.Clock
+  private[extras] val ticker: Ticker
 ) {
 
   import CircuitState._
@@ -79,9 +98,13 @@ final class CircuitBreaker private[extras] (
       case Closed => GateResult.Allowed
 
       case open: Open =>
-        val elapsed = clock.millis() - open.sinceMillis
-        if (elapsed >= config.resetTimeout.toMillis) {
-          val halfOpen = CircuitBreakerState(HalfOpen(successes = 0, probing = true), state.consecutiveFailures)
+        val elapsed = ticker.nanos() - open.sinceNanos
+        if (elapsed >= config.resetTimeout.toNanos) {
+          val halfOpen =
+            CircuitBreakerState(
+              HalfOpen(successes = 0, probing = true, probeStartNanos = ticker.nanos()),
+              state.consecutiveFailures
+            )
           if (stateRef.compareAndSet(state, halfOpen)) GateResult.Allowed
           else GateResult.Rejected
         } else {
@@ -90,8 +113,22 @@ final class CircuitBreaker private[extras] (
 
       case ho: HalfOpen =>
         if (!ho.probing) {
-          val probing = CircuitBreakerState(HalfOpen(ho.successes, probing = true), state.consecutiveFailures)
+          val probing =
+            CircuitBreakerState(
+              HalfOpen(ho.successes, probing = true, probeStartNanos = ticker.nanos()),
+              state.consecutiveFailures
+            )
           if (stateRef.compareAndSet(state, probing)) GateResult.Allowed
+          else GateResult.Rejected
+        } else if (ticker.nanos() - ho.probeStartNanos >= config.probeTimeout.toNanos) {
+          // Steal a wedged probe slot: a probe that won the CAS but died without recording an outcome would
+          // otherwise pin the circuit half-open forever. After probeTimeout, let a fresh caller take the slot.
+          val stolen =
+            CircuitBreakerState(
+              HalfOpen(ho.successes, probing = true, probeStartNanos = ticker.nanos()),
+              state.consecutiveFailures
+            )
+          if (stateRef.compareAndSet(state, stolen)) GateResult.Allowed
           else GateResult.Rejected
         } else {
           GateResult.Rejected
@@ -126,7 +163,7 @@ final class CircuitBreaker private[extras] (
             done = stateRef.compareAndSet(current, next)
             if (done) didClose = true
           } else {
-            val next = CircuitBreakerState(HalfOpen(newSuccesses, probing = false), 0)
+            val next = CircuitBreakerState(HalfOpen(newSuccesses, probing = false, probeStartNanos = 0L), 0)
             done = stateRef.compareAndSet(current, next)
           }
 
@@ -158,7 +195,11 @@ final class CircuitBreaker private[extras] (
           if (!ho.probing) {
             done = true
           } else {
-            val next = CircuitBreakerState(HalfOpen(ho.successes, probing = false), current.consecutiveFailures)
+            val next =
+              CircuitBreakerState(
+                HalfOpen(ho.successes, probing = false, probeStartNanos = 0L),
+                current.consecutiveFailures
+              )
             done = stateRef.compareAndSet(current, next)
           }
 
@@ -182,7 +223,7 @@ final class CircuitBreaker private[extras] (
       current.circuit match {
         case Closed =>
           if (newFailures >= config.failureThreshold) {
-            val next = CircuitBreakerState(Open(clock.millis(), OpenReason.Failures), newFailures)
+            val next = CircuitBreakerState(Open(ticker.nanos(), OpenReason.Failures), newFailures)
             done = stateRef.compareAndSet(current, next)
             if (done) didOpen = true
           } else {
@@ -191,7 +232,7 @@ final class CircuitBreaker private[extras] (
           }
 
         case _: HalfOpen =>
-          val next = CircuitBreakerState(Open(clock.millis(), OpenReason.Failures), newFailures)
+          val next = CircuitBreakerState(Open(ticker.nanos(), OpenReason.Failures), newFailures)
           done = stateRef.compareAndSet(current, next)
           if (done) didOpen = true
 
@@ -210,7 +251,7 @@ final class CircuitBreaker private[extras] (
       current.circuit match {
         case _: Open => done = true
         case _ =>
-          val next = CircuitBreakerState(Open(clock.millis(), OpenReason.External), current.consecutiveFailures)
+          val next = CircuitBreakerState(Open(ticker.nanos(), OpenReason.External), current.consecutiveFailures)
           done = stateRef.compareAndSet(current, next)
       }
     }
@@ -245,7 +286,11 @@ final class CircuitBreaker private[extras] (
         case _: HalfOpen => done = true
         case Closed      => done = true
         case _: Open =>
-          val next = CircuitBreakerState(HalfOpen(successes = 0, probing = false), current.consecutiveFailures)
+          val next =
+            CircuitBreakerState(
+              HalfOpen(successes = 0, probing = false, probeStartNanos = 0L),
+              current.consecutiveFailures
+            )
           done = stateRef.compareAndSet(current, next)
       }
     }
@@ -269,13 +314,13 @@ object CircuitBreaker {
   def apply(
     config: CircuitBreakerConfig = CircuitBreakerConfig()
   ): CircuitBreaker =
-    apply(config, java.time.Clock.systemUTC())
+    apply(config, Ticker.system)
 
   private[extras] def apply(
     config: CircuitBreakerConfig,
-    clock: java.time.Clock
+    ticker: Ticker
   ): CircuitBreaker = {
     val state = new AtomicReference(CircuitBreakerState(CircuitState.Closed, consecutiveFailures = 0))
-    new CircuitBreaker(config, state, clock)
+    new CircuitBreaker(config, state, ticker)
   }
 }

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
@@ -54,7 +54,10 @@ final case class CircuitBreakerProviderConfig(
     CircuitBreakerConfig(
       failureThreshold = failureThreshold,
       resetTimeout = resetTimeout,
-      halfOpenMaxCalls = halfOpenMaxCalls
+      halfOpenMaxCalls = halfOpenMaxCalls,
+      // A probe should never be considered wedged before the evaluation it runs could itself time out; add a
+      // margin so a legitimately slow probe is not stolen out from under itself.
+      probeTimeout = evaluationTimeout + 1.second
     )
 }
 
@@ -198,15 +201,15 @@ final class CircuitBreakerProvider private (
       case GateResult.Allowed => executeWithTimeout(evaluate)
       case GateResult.Rejected =>
         val detail = breaker.currentState match {
-          case CircuitState.Open(sinceMillis, reason) =>
-            val ago = breaker.clock.millis() - sinceMillis
+          case CircuitState.Open(sinceNanos, reason) =>
+            val ago = (breaker.ticker.nanos() - sinceNanos) / 1000000
             val cause = reason match {
               case OpenReason.Failures => "consecutive failures"
               case OpenReason.External => "delegate reported unhealthy state"
             }
             s"open for ${ago}ms due to $cause, resets after ${config.resetTimeout.toMillis}ms"
-          case CircuitState.HalfOpen(_, _) => "half-open, probe in progress"
-          case CircuitState.Closed         => "closed"
+          case CircuitState.HalfOpen(_, _, _) => "half-open, probe in progress"
+          case CircuitState.Closed            => "closed"
         }
         throw new GeneralError(s"Circuit breaker rejected: $detail")
     }
@@ -218,7 +221,9 @@ final class CircuitBreakerProvider private (
         runtime.unsafe
           .run(
             ZIO
-              .attemptBlocking(evaluate())
+              // attemptBlockingInterrupt (not attemptBlocking) so the timeout delivers Thread.interrupt to the
+              // blocking-pool thread instead of leaking it while the delegate call runs on unbounded.
+              .attemptBlockingInterrupt(evaluate())
               .disconnect // detach so timeout completes without waiting for the blocking call
               .timeoutFail(new java.util.concurrent.TimeoutException("Evaluation timed out"))(config.evaluationTimeout)
           )
@@ -233,7 +238,9 @@ final class CircuitBreakerProvider private (
         // frees the probe slot in Half-Open, without advancing toward closing the circuit on app errors alone.
         breaker.recordReachable()
         throw FiberFailures.unwrap(e)
-      case e: VirtualMachineError => throw e
+      // Record the failure before re-throwing: a probe dying with e.g. OOM after winning the half-open CAS must
+      // re-open the circuit, not leave it wedged "half-open, probe in progress".
+      case e: VirtualMachineError => breaker.recordFailure(); throw e
       case e: LinkageError =>
         breaker.recordFailure()
         throw e
@@ -283,11 +290,11 @@ final class CircuitBreakerProvider private (
   // Rate-limit delegate state polling on the evaluation hot path. Whichever caller wins the CAS
   // performs the poll; losers skip it — the next winner after the interval re-polls.
   private def checkDelegateState(): Unit = {
-    val interval = config.stateCheckInterval.toMillis
+    val interval = config.stateCheckInterval.toNanos
     if (interval <= 0L) doCheckDelegateState()
     else {
       val last = lastStateCheckAt.get()
-      val now  = breaker.clock.millis()
+      val now  = breaker.ticker.nanos()
       if ((last == NeverChecked || now - last >= interval) && lastStateCheckAt.compareAndSet(last, now))
         doCheckDelegateState()
     }
@@ -323,15 +330,15 @@ object CircuitBreakerProvider {
     underlying: EventProvider,
     config: CircuitBreakerProviderConfig = CircuitBreakerProviderConfig()
   ): UIO[CircuitBreakerProvider] =
-    make(underlying, config, java.time.Clock.systemUTC())
+    make(underlying, config, Ticker.system)
 
   private[extras] def make(
     underlying: EventProvider,
     config: CircuitBreakerProviderConfig,
-    clock: java.time.Clock
+    ticker: Ticker
   ): UIO[CircuitBreakerProvider] =
     ZIO.runtime[Any].map { rt =>
-      val breaker = CircuitBreaker(config.toCircuitBreakerConfig, clock)
+      val breaker = CircuitBreaker(config.toCircuitBreakerConfig, ticker)
       new CircuitBreakerProvider(underlying, config, breaker, rt)
     }
 
@@ -339,7 +346,7 @@ object CircuitBreakerProvider {
     underlying: EventProvider,
     config: CircuitBreakerProviderConfig = CircuitBreakerProviderConfig()
   ): CircuitBreakerProvider =
-    apply(underlying, config, java.time.Clock.systemUTC())
+    apply(underlying, config, Ticker.system)
 
   // Uses Runtime.default intentionally — this constructor exists for test helpers and Java-side
   // construction where a ZIO runtime is not available. Production code should use `make`, which
@@ -347,10 +354,10 @@ object CircuitBreakerProvider {
   private[extras] def apply(
     underlying: EventProvider,
     config: CircuitBreakerProviderConfig,
-    clock: java.time.Clock
+    ticker: Ticker
   ): CircuitBreakerProvider = {
     val rt      = Runtime.default
-    val breaker = CircuitBreaker(config.toCircuitBreakerConfig, clock)
+    val breaker = CircuitBreaker(config.toCircuitBreakerConfig, ticker)
     new CircuitBreakerProvider(underlying, config, breaker, rt)
   }
 }

--- a/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerProviderSpec.scala
@@ -98,17 +98,14 @@ object CircuitBreakerProviderSpec extends ZIOSpecDefault {
     }
   }
 
-  /** A controllable clock for testing time-based transitions. */
-  private class TestClock extends java.time.Clock {
-    private val currentMillis = new AtomicReference[Long](java.lang.System.currentTimeMillis())
+  /** A controllable monotonic ticker for testing time-based transitions. */
+  private class TestClock extends Ticker {
+    private val currentNanos = new AtomicReference[Long](java.lang.System.nanoTime())
 
     def advance(duration: Duration): Unit =
-      currentMillis.updateAndGet(_ + duration.toMillis)
+      currentNanos.updateAndGet(_ + duration.toNanos)
 
-    override def millis(): Long                                    = currentMillis.get()
-    override def getZone: java.time.ZoneId                         = java.time.ZoneId.of("UTC")
-    override def withZone(zone: java.time.ZoneId): java.time.Clock = this
-    override def instant(): java.time.Instant                      = java.time.Instant.ofEpochMilli(millis())
+    override def nanos(): Long = currentNanos.get()
   }
 
   private val ctx = new ImmutableContext()

--- a/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/CircuitBreakerSpec.scala
@@ -6,16 +6,14 @@ import java.util.concurrent.atomic.AtomicReference
 
 object CircuitBreakerSpec extends ZIOSpecDefault {
 
-  private class TestClock extends java.time.Clock {
-    private val currentMillis = new AtomicReference[Long](java.lang.System.currentTimeMillis())
+  /** A controllable monotonic ticker for deterministic time-based tests. */
+  private class TestTicker extends Ticker {
+    private val current = new AtomicReference[Long](0L)
 
     def advance(duration: Duration): Unit =
-      currentMillis.updateAndGet(_ + duration.toMillis)
+      current.updateAndGet(_ + duration.toNanos)
 
-    override def millis(): Long                                    = currentMillis.get()
-    override def getZone: java.time.ZoneId                         = java.time.ZoneId.of("UTC")
-    override def withZone(zone: java.time.ZoneId): java.time.Clock = this
-    override def instant(): java.time.Instant                      = java.time.Instant.ofEpochMilli(millis())
+    override def nanos(): Long = current.get()
   }
 
   def spec = suite("CircuitBreaker")(
@@ -63,28 +61,61 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
     ),
     suite("Open state")(
       test("rejects calls when open") {
-        val clock = new TestClock()
-        val cb    = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.minute), clock)
+        val ticker = new TestTicker()
+        val cb     = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.minute), ticker)
         cb.recordFailure()
         assertTrue(cb.tryAcquire == GateResult.Rejected)
       },
       test("transitions to half-open after resetTimeout") {
-        val clock = new TestClock()
-        val cb    = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.second), clock)
+        val ticker = new TestTicker()
+        val cb     = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.second), ticker)
         cb.recordFailure()
-        clock.advance(2.seconds)
+        ticker.advance(2.seconds)
         assertTrue(cb.tryAcquire == GateResult.Allowed)
+      }
+    ),
+    suite("Monotonic reset timing (#263.1)")(
+      test("stays rejected before resetTimeout, allowed at/after it — elapsed uses the injected ticker") {
+        val ticker = new TestTicker()
+        val cb =
+          CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 30.seconds), ticker)
+        cb.recordFailure() // opens
+        ticker.advance(29.seconds)
+        val beforeTimeout = cb.tryAcquire
+        // Reaching exactly resetTimeout is enough (>= comparison).
+        ticker.advance(1.second)
+        val atTimeout = cb.tryAcquire
+        assertTrue(beforeTimeout == GateResult.Rejected) &&
+        assertTrue(atTimeout == GateResult.Allowed) &&
+        assertTrue(cb.isHalfOpen)
+      },
+      test("elapsed is measured from the injected ticker, never a wall clock") {
+        // A monotonic nanoTime never runs backward, so open-timing derives solely from ticker deltas:
+        // small forward advances keep the circuit open until their sum reaches resetTimeout.
+        val ticker = new TestTicker()
+        val cb =
+          CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 10.seconds), ticker)
+        cb.recordFailure()
+        ticker.advance(3.seconds)
+        val a = cb.tryAcquire
+        ticker.advance(3.seconds)
+        val b = cb.tryAcquire
+        ticker.advance(5.seconds) // total 11s >= 10s
+        val c = cb.tryAcquire
+        assertTrue(a == GateResult.Rejected) &&
+        assertTrue(b == GateResult.Rejected) &&
+        assertTrue(c == GateResult.Allowed)
       }
     ),
     suite("Half-open state")(
       test("closes after halfOpenMaxCalls successes") {
-        val clock = new TestClock()
+        val ticker = new TestTicker()
         val cb = CircuitBreaker(
           CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.second, halfOpenMaxCalls = 2),
-          clock
+          ticker
         )
         cb.recordFailure()
-        clock.advance(2.seconds)
+        ticker.advance(2.seconds)
         cb.tryAcquire // transition to half-open, first probe
         cb.recordSuccess()
         cb.tryAcquire // second probe
@@ -93,24 +124,61 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
         assertTrue(cb.isClosed)
       },
       test("re-opens on failed probe") {
-        val clock = new TestClock()
-        val cb    = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.second), clock)
+        val ticker = new TestTicker()
+        val cb     = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.second), ticker)
         cb.recordFailure()
-        clock.advance(2.seconds)
+        ticker.advance(2.seconds)
         cb.tryAcquire // transition to half-open
         val didOpen = cb.recordFailure()
         assertTrue(didOpen) &&
         assertTrue(cb.isOpen)
       },
       test("only one probe at a time") {
-        val clock = new TestClock()
-        val cb    = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.second), clock)
+        val ticker = new TestTicker()
+        val cb     = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.second), ticker)
         cb.recordFailure()
-        clock.advance(2.seconds)
+        ticker.advance(2.seconds)
         val first  = cb.tryAcquire
         val second = cb.tryAcquire
         assertTrue(first == GateResult.Allowed) &&
         assertTrue(second == GateResult.Rejected)
+      }
+    ),
+    suite("Probe-slot steal (#263.3)")(
+      test("a wedged probe slot is stolen after probeTimeout") {
+        val ticker = new TestTicker()
+        val cb = CircuitBreaker(
+          CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.second, probeTimeout = 5.seconds),
+          ticker
+        )
+        cb.recordFailure()
+        ticker.advance(2.seconds)
+        // First caller wins the probe slot but never records an outcome (simulating a probe that died).
+        val probe = cb.tryAcquire
+        // Before probeTimeout, no other caller may probe.
+        val blocked = cb.tryAcquire
+        // After probeTimeout elapses, the slot is stolen by the next caller.
+        ticker.advance(5.seconds)
+        val stolen = cb.tryAcquire
+        assertTrue(probe == GateResult.Allowed) &&
+        assertTrue(blocked == GateResult.Rejected) &&
+        assertTrue(stolen == GateResult.Allowed) &&
+        assertTrue(cb.isHalfOpen)
+      },
+      test("stealing resets the probe window, so an immediately-following caller is rejected") {
+        val ticker = new TestTicker()
+        val cb = CircuitBreaker(
+          CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.second, probeTimeout = 5.seconds),
+          ticker
+        )
+        cb.recordFailure()
+        ticker.advance(2.seconds)
+        cb.tryAcquire // original probe acquires the slot
+        ticker.advance(5.seconds)
+        val stolen  = cb.tryAcquire // steals the slot, resets probeStartNanos
+        val blocked = cb.tryAcquire // window just reset, so this one is rejected again
+        assertTrue(stolen == GateResult.Allowed) &&
+        assertTrue(blocked == GateResult.Rejected)
       }
     ),
     suite("External trip/reset")(
@@ -127,8 +195,8 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
         assertTrue(cb.isClosed)
       },
       test("reset does not close failure-tripped circuit") {
-        val clock = new TestClock()
-        val cb    = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.minute), clock)
+        val ticker = new TestTicker()
+        val cb     = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.minute), ticker)
         cb.recordFailure() // trip via failures
         cb.reset()         // should NOT close
         assertTrue(cb.isOpen)
@@ -142,8 +210,8 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
     ),
     suite("recordReachable")(
       test("frees probe slot in half-open without closing the circuit") {
-        val clock = new TestClock()
-        val cb    = CircuitBreaker(CircuitBreakerConfig(halfOpenMaxCalls = 3), clock)
+        val ticker = new TestTicker()
+        val cb     = CircuitBreaker(CircuitBreakerConfig(halfOpenMaxCalls = 3), ticker)
         cb.trip()
         cb.transitionToHalfOpen()
         cb.tryAcquire // acquire probe slot
@@ -153,8 +221,8 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
         assertTrue(cb.isHalfOpen)
       },
       test("repeated reachability does not close the circuit") {
-        val clock = new TestClock()
-        val cb    = CircuitBreaker(CircuitBreakerConfig(halfOpenMaxCalls = 2), clock)
+        val ticker = new TestTicker()
+        val cb     = CircuitBreaker(CircuitBreakerConfig(halfOpenMaxCalls = 2), ticker)
         cb.trip()
         cb.transitionToHalfOpen()
         (1 to 10).foreach { _ =>
@@ -171,11 +239,26 @@ object CircuitBreakerSpec extends ZIOSpecDefault {
         assertTrue(cb.stateRef.get().consecutiveFailures == 0)
       },
       test("no-op in open state") {
-        val clock = new TestClock()
-        val cb    = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.minute), clock)
+        val ticker = new TestTicker()
+        val cb     = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.minute), ticker)
         cb.recordFailure() // trip
         cb.recordReachable()
         assertTrue(cb.isOpen)
+      }
+    ),
+    suite("Probe outcome after acquisition (#263.3b)")(
+      test("recordFailure on an acquired probe re-opens the circuit") {
+        // Mirrors the provider's VirtualMachineError catch, which calls breaker.recordFailure() before re-throwing:
+        // a probe that dies after winning the CAS must re-open the circuit rather than wedge it half-open.
+        val ticker = new TestTicker()
+        val cb     = CircuitBreaker(CircuitBreakerConfig(failureThreshold = 1, resetTimeout = 1.second), ticker)
+        cb.recordFailure()
+        ticker.advance(2.seconds)
+        val probe = cb.tryAcquire // enters half-open, acquires the probe slot
+        cb.recordFailure() // probe dies -> re-open
+        assertTrue(probe == GateResult.Allowed) &&
+        assertTrue(cb.isOpen) &&
+        assertTrue(cb.tryAcquire == GateResult.Rejected)
       }
     )
   )


### PR DESCRIPTION
Three robustness defects in the circuit breaker, fixed together:

1. **Monotonic timing.** Elapsed-time decisions (open→half-open reset, delegate-state poll rate-limiting) used a wall clock seeded from `java.time.Clock.systemUTC()`, so an NTP step backward delayed recovery and a forward step collapsed the reset window against a still-down delegate. They now use an injectable monotonic `Ticker` (`System.nanoTime`).
2. **Interruptible timeouts.** The per-evaluation timeout used `attemptBlocking`, which ignores interruption — a delegate hung on a black-holed connection leaked one pinned blocking-pool thread per timeout. It now uses `attemptBlockingInterrupt`, so the timeout delivers `Thread.interrupt`.
3. **Half-open probe slot leak.** A probe that won the CAS but died without recording an outcome pinned the circuit half-open forever. `HalfOpen` now records the probe start; `tryAcquire` steals a slot older than `probeTimeout` (default `evaluationTimeout + 1s`), and a probe dying with a `VirtualMachineError` records the failure (re-opening the circuit) before rethrowing.

`CircuitBreakerConfig` gains a `probeTimeout` parameter. Adds a state-machine spec (monotonic reset, probe-slot steal, probe outcome) driven by a deterministic injectable ticker; existing specs migrated from a wall clock to the ticker.

Closes #263