### PR TITLE
Read variableKey in Optimizely object evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`OptimizelyFeatureProvider.getObjectEvaluation` reads the configured variable and falls back to the default** (#264).
+  Object evaluation returned the entire `decision.getVariables` map and never reached `defaultValue`, contradicting the
+  provider's own documentation and diverging from every other typed path (a flag with zero variables handed callers an
+  empty structure instead of their default). It now reads the single variable named by `variableKey` (default `"value"`,
+  overridable via the `openfeature.variableKey` context attribute) as a JSON object and falls back to `defaultValue`
+  with `Reason.DEFAULT` when that variable is absent or not a readable object — mirroring the string/integer/double
+  paths.
+
 - **CircuitBreaker robustness: monotonic timing, interruptible timeouts, no half-open probe leak** (#263). Three fixes:
   (1) elapsed-time decisions (open→half-open reset, delegate-state poll rate-limiting) now use a monotonic `Ticker`
   (`System.nanoTime`, injectable for tests) instead of a wall clock, so an NTP/clock step can no longer delay recovery

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
@@ -250,12 +250,19 @@ final class OptimizelyFeatureProvider private[optimizely] (
   ): ProviderEvaluation[Value] =
     decide(key, ctx) match {
       case Right(d) =>
-        val map     = Option(d.getVariables).map(_.toMap).getOrElse(java.util.Collections.emptyMap[String, Object]())
-        val value   = new Value(Structure.mapToStructure(map))
+        // Mirror the other typed paths: read the single variable named by `variableKey` (a JSON object) rather than
+        // returning the whole variables map, and fall back to the OF default with reason DEFAULT when it is absent.
+        // Previously object evaluation ignored `variableKey` and never reached `defaultValue` (#264).
+        val variableKey = OptimizelyFeatureProvider.variableKey(ctx)
+        val variable    = readVariable[java.util.Map[_, _]](d, variableKey, classOf[java.util.Map[_, _]])
+        val (value, usedDefault) = variable match {
+          case Some(m) => (new Value(Structure.mapToStructure(m.asInstanceOf[java.util.Map[String, Object]])), false)
+          case None    => (defaultValue, true)
+        }
         val builder = ProviderEvaluation.builder[Value]()
         builder.value(value)
         builder.variant(d.getVariationKey)
-        builder.reason(deriveReason(d))
+        builder.reason(if (usedDefault) Reason.DEFAULT.name() else deriveReason(d))
         builder.flagMetadata(metadataFrom(d))
         builder.build().asInstanceOf[ProviderEvaluation[Value]]
       case Left(err) => failingEvaluation(defaultValue, err)

--- a/optimizely/src/test/resources/datafiles/object-flag.json
+++ b/optimizely/src/test/resources/datafiles/object-flag.json
@@ -1,0 +1,51 @@
+{
+  "version": "4",
+  "accountId": "1",
+  "projectId": "1",
+  "revision": "1",
+  "anonymizeIP": false,
+  "botFiltering": false,
+  "sendFlagDecisions": true,
+  "experiments": [],
+  "featureFlags": [
+    {
+      "id": "100",
+      "key": "object_flag",
+      "rolloutId": "200",
+      "experimentIds": [],
+      "variables": [
+        { "id": "500", "key": "value", "type": "json", "defaultValue": "{\"theme\":\"light\",\"limit\":0}" }
+      ]
+    }
+  ],
+  "rollouts": [
+    {
+      "id": "200",
+      "experiments": [
+        {
+          "id": "300",
+          "key": "rollout-200",
+          "status": "Running",
+          "layerId": "200",
+          "audienceIds": [],
+          "forcedVariations": {},
+          "trafficAllocation": [{ "entityId": "400", "endOfRange": 10000 }],
+          "variations": [
+            {
+              "id": "400",
+              "key": "on",
+              "featureEnabled": true,
+              "variables": [{ "id": "500", "value": "{\"theme\":\"dark\",\"limit\":10}" }]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "audiences": [],
+  "typedAudiences": [],
+  "groups": [],
+  "attributes": [],
+  "variables": [],
+  "events": []
+}

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyObjectEvaluationSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyObjectEvaluationSpec.scala
@@ -1,0 +1,114 @@
+package zio.openfeature.optimizely
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.optimizely.ab.Optimizely
+import com.optimizely.ab.config.HttpProjectConfigManager
+import dev.openfeature.sdk.{ImmutableContext, MutableStructure, Reason, Value}
+import zio._
+import zio.test._
+
+import java.util.concurrent.TimeUnit
+
+/** Object-evaluation tests for `OptimizelyFeatureProvider`, guarding the fix for #264.
+  *
+  * Before the fix, `getObjectEvaluation` returned the ENTIRE `decision.getVariables` map as a `Structure` and never
+  * fell back to the OpenFeature default. It now mirrors the other typed paths: it reads the single variable named by
+  * `variableKey` (default `"value"`) as a JSON object and falls back to `defaultValue` with reason `DEFAULT` when that
+  * variable is absent or not a JSON object.
+  *
+  * WireMock-backed (no Docker) so this runs on every PR, using the same fail-fast HTTP + shutdown-in-finally hygiene as
+  * the lifecycle/concurrency specs.
+  */
+object OptimizelyObjectEvaluationSpec extends ZIOSpecDefault {
+
+  private val DatafilePath = "/datafiles/object-eval-key.json"
+  // `decide` needs a userId; a bare targeting key is enough for these rollout-only flags.
+  private val targetedContext = new ImmutableContext("user-object")
+
+  private def readResource(path: String): String =
+    scala.io.Source.fromInputStream(getClass.getResourceAsStream(path)).mkString
+
+  private def withMockServer[A](body: WireMockServer => A): A = {
+    val server = new WireMockServer(WireMockConfiguration.options().dynamicPort())
+    server.start()
+    try body(server)
+    finally server.stop()
+  }
+
+  private def datafileUrl(server: WireMockServer): String =
+    s"http://localhost:${server.port()}$DatafilePath"
+
+  /** Same fail-fast client build as the lifecycle spec: aggressive timeouts and a fail-fast HTTP client so a poll in
+    * flight when WireMock stops fails immediately instead of retrying forever on a non-daemon thread.
+    */
+  private def buildClient(
+    server: WireMockServer,
+    blockingTimeout: java.time.Duration = java.time.Duration.ofSeconds(2),
+    pollingInterval: java.time.Duration = java.time.Duration.ofSeconds(3600)
+  ): Optimizely = {
+    val mgr = HttpProjectConfigManager
+      .builder()
+      .withSdkKey("object-eval-key")
+      .withUrl(datafileUrl(server))
+      .withBlockingTimeout(blockingTimeout.toMillis, TimeUnit.MILLISECONDS)
+      .withPollingInterval(pollingInterval.toSeconds, TimeUnit.SECONDS)
+      .withOptimizelyHttpClient(TestHttpClient.failFast())
+      .build()
+    Optimizely.builder().withConfigManager(mgr).build()
+  }
+
+  private def readyProvider(server: WireMockServer, datafile: String): OptimizelyFeatureProvider = {
+    server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(datafile)))
+    val client   = buildClient(server)
+    val provider = new OptimizelyFeatureProvider(client, java.time.Duration.ofSeconds(3), closeOnShutdown = true)
+    provider.initialize(new ImmutableContext())
+    provider
+  }
+
+  // Optimizely parses JSON numbers into either Integer or Double depending on the JSON library on the classpath, so
+  // accept both representations of `10`.
+  private def numericEquals(v: Value, expected: Int): Boolean =
+    Option(v.asInteger).exists(_.intValue == expected) ||
+      Option(v.asDouble).exists(_.doubleValue == expected.toDouble)
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("OptimizelyFeatureProvider object evaluation")(
+    test("falls back to the OF default (reason DEFAULT) when the variable is not a JSON object (#264)") {
+      withMockServer { server =>
+        // `lifecycle_flag`'s `value` variable is a STRING, so reading it as a Map fails -> the fix must return the
+        // supplied default, NOT a Structure wrapping the whole variables map (the old bug).
+        val provider = readyProvider(server, readResource("/test-datafile-with-flag.json"))
+        try {
+          val sentinel = new Value(new MutableStructure().add("sentinel", "dflt"))
+          val result   = provider.getObjectEvaluation("lifecycle_flag", sentinel, targetedContext)
+          val struct   = result.getValue.asStructure
+          assertTrue(
+            // Fell back to the caller's default...
+            result.getReason == Reason.DEFAULT.name(),
+            struct.getValue("sentinel").asString == "dflt",
+            // ...and did NOT smuggle the flag's `value` string back as a whole-map Structure (old #264 behaviour).
+            struct.getValue("value") == null
+          )
+        } finally provider.shutdown()
+      }
+    },
+    test("reads the JSON variable named by variableKey into a Structure") {
+      withMockServer { server =>
+        val provider = readyProvider(server, readResource("/datafiles/object-flag.json"))
+        try {
+          val default = new Value(new MutableStructure().add("sentinel", "dflt"))
+          val result  = provider.getObjectEvaluation("object_flag", default, targetedContext)
+          val struct  = result.getValue.asStructure
+          assertTrue(
+            result.getReason != Reason.DEFAULT.name(),
+            struct.getValue("theme").asString == "dark",
+            numericEquals(struct.getValue("limit"), 10),
+            // Not the fallback default.
+            struct.getValue("sentinel") == null
+          )
+        } finally provider.shutdown()
+      }
+    }
+  ) @@ TestAspect.sequential @@ TestAspect.timeout(60.seconds) @@ TestAspect.withLiveClock
+}


### PR DESCRIPTION
`OptimizelyFeatureProvider.getObjectEvaluation` returned the entire `decision.getVariables` map and never reached `defaultValue`, contradicting the provider's own documentation and diverging from every other typed evaluation path — a flag with zero variables handed callers an empty structure instead of their default.

It now reads the single variable named by `variableKey` (default `"value"`, overridable via the `openfeature.variableKey` context attribute) as a JSON object and falls back to `defaultValue` with `Reason.DEFAULT` when that variable is absent or not a readable object — mirroring the string/integer/double paths. Adds an object-evaluation spec (fallback-to-default and positive JSON-object cases) with a JSON-variable test datafile.

Closes #264