### PR TITLE
Fix Optimizely provider init retry, shutdown race, config event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`OptimizelyFeatureProvider` lifecycle robustness** (#265). Three fixes to the provider's init/shutdown state machine:
+  (1) a failed `initialize` (datafile timeout, invalid config, handler-registration failure) previously left the
+  provider in a state where a retry silently no-op'd — the SDK treated the non-throwing retry as success and emitted
+  `PROVIDER_READY` while every evaluation kept failing `PROVIDER_NOT_READY`; a new `Failed` lifecycle state now cleans up
+  the registered handler on failure and lets a subsequent `initialize` cleanly re-attempt. (2) `shutdown()` racing an
+  in-flight `initialize()` could leak the update handler or leave the provider reporting `READY` after shutdown;
+  `initialize` now re-checks the lifecycle after registering its handler (removing it and aborting if a shutdown
+  interleaved) and makes the final `READY` transition conditional on not having been shut down. (3) the initial datafile
+  load no longer emits a spurious `PROVIDER_CONFIGURATION_CHANGED` ahead of `PROVIDER_READY` — the config-changed event
+  is emitted only once the provider is ready (genuine revisions), not for the initial load.
+
 - **`OptimizelyFeatureProvider.getObjectEvaluation` reads the configured variable and falls back to the default** (#264).
   Object evaluation returned the entire `decision.getVariables` map and never reached `defaultValue`, contradicting the
   provider's own documentation and diverging from every other typed path (a flag with zero variables handed callers an

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
@@ -26,11 +26,17 @@ import scala.util.Try
   * event dispatch; this class translates between the two worlds.
   *
   * '''Lifecycle notes:'''
-  *   - On `initialize()` we register an Optimizely `UpdateConfigNotification` handler. The first time it fires
-  *     (datafile loaded), we count down an internal latch so the OpenFeature `setProviderAndWait` returns cleanly.
-  *     Subsequent fires emit OpenFeature `PROVIDER_CONFIGURATION_CHANGED` events.
-  *   - If the datafile never arrives within `initWait`, `initialize()` throws — propagated by the OpenFeature SDK as a
-  *     failed init.
+  *   - On `initialize()` we register an Optimizely `UpdateConfigNotification` handler. It counts down an internal latch
+  *     so the OpenFeature `setProviderAndWait` returns cleanly once the datafile has loaded. Fires that occur before
+  *     the provider announces READY (the initial datafile load) suppress the `PROVIDER_CONFIGURATION_CHANGED` event —
+  *     it isn't a change and must not precede PROVIDER_READY. Only fires once the provider is READY (genuine datafile
+  *     revisions) emit `PROVIDER_CONFIGURATION_CHANGED`.
+  *   - If the datafile never arrives within `initWait`, or the config is invalid, or the handler can't be registered,
+  *     `initialize()` throws (propagated by the OpenFeature SDK as a failed init) and leaves the provider in a `Failed`
+  *     state with its handler removed. A subsequent `initialize()` on the same instance cleanly re-attempts (`Failed ->
+  *     Initialized`) instead of silently no-op'ing and leaving every evaluation `PROVIDER_NOT_READY`.
+  *   - A `shutdown()` racing an in-flight `initialize()` aborts the init cleanly: the handler it registered is removed
+  *     and the provider is left NOT_READY (it never reports READY after a shutdown).
   *   - `shutdown()` removes the notification handler and closes the underlying client (which stops datafile polling and
   *     the HTTP client for factory-built providers).
   *   - Factory-built providers (via `OptimizelyProvider.make`/`scoped`/`layer`) perform no network activity and run no
@@ -78,10 +84,11 @@ final class OptimizelyFeatureProvider private[optimizely] (
 
   override def initialize(ctx: OFEvaluationContext): Unit = {
     // Lifecycle transitions: Fresh -> Initialized (first init), Initialized -> no-op (idempotent),
-    // ShutDown -> Initialized only for caller-managed clients (closeOnShutdown = false). A provider whose
-    // client was closed on shutdown cannot be revived — fail loudly instead of silently never becoming
-    // READY (the Java SDK treats a non-throwing initialize as success, so a silent no-op here would leave
-    // every subsequent evaluation failing with PROVIDER_NOT_READY far from the cause).
+    // ShutDown -> Initialized only for caller-managed clients (closeOnShutdown = false), and
+    // Failed -> Initialized for a clean retry after a throwing init. A provider whose client was closed on
+    // shutdown cannot be revived — fail loudly instead of silently never becoming READY (the Java SDK treats a
+    // non-throwing initialize as success, so a silent no-op here would leave every subsequent evaluation failing
+    // with PROVIDER_NOT_READY far from the cause).
     val transitioned =
       lifecycle.compareAndSet(Lifecycle.Fresh, Lifecycle.Initialized) || {
         if (lifecycle.get() == Lifecycle.ShutDown) {
@@ -93,6 +100,11 @@ final class OptimizelyFeatureProvider private[optimizely] (
             initLatchRef.set(new CountDownLatch(1)) // fresh single-use latch for this init cycle
             true
           } else false
+        } else if (lifecycle.compareAndSet(Lifecycle.Failed, Lifecycle.Initialized)) {
+          // Clean retry after a failed init (mirrors the ShutDown caller-managed retry): a fresh latch and a
+          // re-registered handler. `failInitialize` already removed the previous handler and set state ERROR.
+          initLatchRef.set(new CountDownLatch(1))
+          true
         } else false
       }
     if (!transitioned) return
@@ -100,20 +112,39 @@ final class OptimizelyFeatureProvider private[optimizely] (
     val initLatch = initLatchRef.get()
 
     val handlerId = optimizely.addUpdateConfigNotificationHandler { _ =>
-      // The latch is single-use; subsequent updates are CONFIGURATION_CHANGED only.
+      // Suppress the CONFIGURATION_CHANGED event for any fire before the provider is READY — the initial datafile
+      // load isn't a "change" and would otherwise be delivered ahead of PROVIDER_READY. Only fires once the provider
+      // has announced READY (genuine datafile revisions) emit. Reading the state BEFORE counting the latch down is
+      // deliberate: the initial-load fire that opens the latch is, at that instant, still pre-READY (init is blocked
+      // on `initLatch.await` below and only sets READY after it returns), so it is reliably suppressed. A first fire
+      // that is instead observed via the `optimizely.isValid` fast-path below (handler never sees the initial load,
+      // e.g. the datafile loaded before registration) simply never reaches this handler, so nothing is emitted.
+      val alreadyReady = stateRef.get() == ProviderState.READY
       initLatch.countDown()
-      emitProviderConfigurationChanged(ProviderEventDetails.builder().build())
+      if (alreadyReady) emitProviderConfigurationChanged(ProviderEventDetails.builder().build())
     }
     // Optimizely's NotificationManager returns a non-positive id when registration fails (e.g. a duplicate handler
     // is already present). Without the handler we'd silently never count down the latch via the datafile-update
-    // path and would always wait the full `initWait` window. Fail fast instead.
-    if (handlerId <= 0) {
-      stateRef.set(ProviderState.ERROR)
-      throw new RuntimeException(
+    // path and would always wait the full `initWait` window. Fail fast instead (no handler to remove — id <= 0).
+    if (handlerId <= 0)
+      failInitialize(
         s"Optimizely datafile update handler registration failed (returned id=$handlerId); cannot drive init"
       )
-    }
     notificationHandle.set(handlerId)
+
+    // A shutdown() may have interleaved between registering the handler and recording its id above; its
+    // getAndSet(-1) would then have observed the stale -1 and never removed our handler (a leak + duplicate
+    // CONFIGURATION_CHANGED on any re-init). Re-check now: if shut down, remove the handler we just registered and
+    // abort — do not start polling, await, or announce READY.
+    if (lifecycle.get() == Lifecycle.ShutDown) {
+      val handle = notificationHandle.getAndSet(-1)
+      if (handle > 0) {
+        Try(optimizely.getNotificationCenter.removeNotificationListener(handle))
+        ()
+      }
+      stateRef.set(ProviderState.NOT_READY)
+      return
+    }
 
     // The handler is registered before this call so a notification firing from here on can't be missed. The SDK
     // may already have a fetch in flight or completed from construction time (see OptimizelyProvider#buildClient),
@@ -123,20 +154,36 @@ final class OptimizelyFeatureProvider private[optimizely] (
 
     if (optimizely.isValid) initLatch.countDown()
 
-    if (!initLatch.await(initWait.toMillis, TimeUnit.MILLISECONDS)) {
-      stateRef.set(ProviderState.ERROR)
-      throw new RuntimeException(
+    if (!initLatch.await(initWait.toMillis, TimeUnit.MILLISECONDS))
+      failInitialize(
         s"Optimizely datafile did not load within $initWait; check the SDK key and network reachability"
       )
-    }
 
-    if (optimizely.isValid) stateRef.set(ProviderState.READY)
-    else {
-      stateRef.set(ProviderState.ERROR)
-      throw new RuntimeException(
+    if (optimizely.isValid) {
+      stateRef.set(ProviderState.READY)
+      // Guard against a shutdown() that interleaved after the abort re-check above: shutdown sets
+      // lifecycle = ShutDown first thing, so if it did, revert to NOT_READY rather than report READY on a
+      // shut-down provider.
+      if (lifecycle.get() != Lifecycle.Initialized) stateRef.set(ProviderState.NOT_READY)
+    } else
+      failInitialize(
         "Optimizely client reported invalid configuration after datafile load (possible auth or parse failure)"
       )
+  }
+
+  /** Common failure path for `initialize()`: remove the handler registered this cycle (best-effort, as `shutdown` does)
+    * so a retry doesn't leak it or fire duplicate CONFIGURATION_CHANGED events, mark the provider `Failed` (state
+    * ERROR) so a subsequent `initialize()` cleanly re-attempts instead of silently no-op'ing, then throw.
+    */
+  private def failInitialize(msg: String): Nothing = {
+    val handle = notificationHandle.getAndSet(-1)
+    if (handle > 0) {
+      Try(optimizely.getNotificationCenter.removeNotificationListener(handle))
+      ()
     }
+    stateRef.set(ProviderState.ERROR)
+    lifecycle.set(Lifecycle.Failed)
+    throw new RuntimeException(msg)
   }
 
   override def shutdown(): Unit = {
@@ -337,15 +384,18 @@ final class OptimizelyFeatureProvider private[optimizely] (
 object OptimizelyFeatureProvider {
   val Name: String = "Optimizely"
 
-  /** Provider lifecycle: `Fresh -> Initialized -> ShutDown`, plus `ShutDown -> Initialized` for caller-managed clients.
-    * Tracked explicitly (instead of a boolean) so initialize-after-shutdown can fail loudly when the underlying client
-    * was closed.
+  /** Provider lifecycle: `Fresh -> Initialized -> ShutDown`, plus `ShutDown -> Initialized` for caller-managed clients
+    * and `Failed -> Initialized` for a clean retry after a failed init. Tracked explicitly (instead of a boolean) so
+    * initialize-after-shutdown can fail loudly when the underlying client was closed, and so a failed init does not
+    * leave the provider stuck as a silent no-op on retry.
     */
   sealed private[optimizely] trait Lifecycle
   private[optimizely] object Lifecycle {
     case object Fresh       extends Lifecycle
     case object Initialized extends Lifecycle
     case object ShutDown    extends Lifecycle
+    // A throwing initialize() lands here (state ERROR, handler removed). A subsequent initialize() cleanly re-attempts.
+    case object Failed extends Lifecycle
   }
 
   /** Context attribute key callers can set to override which Optimizely variable is read for typed evaluations. */

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyLifecycleRaceSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyLifecycleRaceSpec.scala
@@ -1,0 +1,199 @@
+package zio.openfeature.optimizely
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.optimizely.ab.Optimizely
+import com.optimizely.ab.config.HttpProjectConfigManager
+import com.optimizely.ab.notification.NotificationCenter
+import dev.openfeature.sdk.{ImmutableContext, OpenFeatureAPI, ProviderState}
+import zio._
+import zio.test._
+
+import java.util.UUID
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Race and retry tests for `OptimizelyFeatureProvider` covering the three lifecycle defects fixed in #265:
+  *   1. A failed `initialize()` leaves the provider retryable (`Failed -> Initialized`) instead of a silent no-op.
+  *   1. `shutdown()` racing an in-flight `initialize()` never leaves the provider reporting READY.
+  *   1. A handler fire before the provider is READY (the initial datafile load) does not emit a spurious
+  *      `PROVIDER_CONFIGURATION_CHANGED`; only fires after READY (genuine revisions) do.
+  *
+  * WireMock-backed so the suite runs on every PR without Docker.
+  */
+object OptimizelyLifecycleRaceSpec extends ZIOSpecDefault {
+
+  private val DatafilePath    = "/datafiles/race-key.json"
+  private val ValidDatafileV1 = readResource("/test-datafile-with-flag.json")
+  private val targetedContext = new ImmutableContext("user-race")
+
+  private def readResource(path: String): String =
+    scala.io.Source.fromInputStream(getClass.getResourceAsStream(path)).mkString
+
+  private def withMockServer[A](body: WireMockServer => A): A = {
+    val server = new WireMockServer(WireMockConfiguration.options().dynamicPort())
+    server.start()
+    try body(server)
+    finally server.stop()
+  }
+
+  private def datafileUrl(server: WireMockServer): String =
+    s"http://localhost:${server.port()}$DatafilePath"
+
+  @scala.annotation.nowarn("msg=deprecated")
+  private def stateOf(p: OptimizelyFeatureProvider): ProviderState = p.getState
+
+  private def tryInit(provider: OptimizelyFeatureProvider): Either[Throwable, Unit] =
+    try { provider.initialize(new ImmutableContext()); Right(()) }
+    catch { case t: Throwable => Left(t) }
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("OptimizelyFeatureProvider lifecycle races (#265)")(
+    test("failed init is retryable — a second initialize after the datafile recovers succeeds (#265.1)") {
+      withMockServer { server =>
+        // The datafile source is broken (500) to start; the SDK's continuous poller survives fetch failures (the
+        // fetch task catches and logs), so a later re-stub is picked up on a subsequent tick.
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(aResponse().withStatus(500).withBody("boom")))
+        // Share one NotificationCenter between the manager and the client (as production `buildClient` does) so the
+        // handler our `initialize` registers actually sees the poller's datafile-update notification on recovery.
+        val sharedCenter = new NotificationCenter()
+        // `.build()` runs a continuous poller (not paused); a short interval means recovery is observed quickly.
+        val mgr = HttpProjectConfigManager
+          .builder()
+          .withSdkKey("race-key")
+          .withUrl(datafileUrl(server))
+          .withBlockingTimeout(1000L, TimeUnit.MILLISECONDS)
+          .withPollingInterval(1L, TimeUnit.SECONDS)
+          .withNotificationCenter(sharedCenter)
+          .withOptimizelyHttpClient(TestHttpClient.failFast())
+          .build()
+        val client   = Optimizely.builder().withConfigManager(mgr).withNotificationCenter(sharedCenter).build()
+        val provider = new OptimizelyFeatureProvider(client, java.time.Duration.ofSeconds(5), closeOnShutdown = true)
+        try {
+          val first          = tryInit(provider) // throws: datafile never loads within initWait
+          val stateAfterFail = stateOf(provider)
+          // Recover the datafile source; the still-running poller fetches a valid file on its next tick. A newest-wins
+          // re-stub (not resetAll) avoids dropping the poller's keep-alive connections.
+          server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafileV1)))
+          val second          = tryInit(provider) // clean retry from Failed
+          val stateAfterRetry = stateOf(provider)
+          val eval = provider.getBooleanEvaluation("lifecycle_flag", java.lang.Boolean.FALSE, targetedContext)
+          assertTrue(
+            first.isLeft,
+            stateAfterFail == ProviderState.ERROR,
+            // Against the pre-#265 code the retry silently no-ops (matches neither Fresh nor ShutDown) and the
+            // provider stays not-ready forever. The fix re-attempts cleanly from the Failed state.
+            second.isRight,
+            stateAfterRetry == ProviderState.READY,
+            eval.getValue == java.lang.Boolean.TRUE
+          )
+        } finally provider.shutdown()
+      }
+    },
+    test("handler fire for the initial datafile load emits no CONFIGURATION_CHANGED event (#265.3)") {
+      withMockServer { server =>
+        // Serve v1 with a fixed delay so `initialize` registers its handler BEFORE the initial datafile load arrives —
+        // the handler therefore genuinely catches the initial-load notification (the case the old code emitted a
+        // spurious event on). Only v1 is ever served: its revision never changes, so the SDK notifies exactly once (the
+        // initial load) and no legitimate revision event can occur. Post-fix that single fire is suppressed (pre-READY);
+        // pre-fix it emitted a spurious CONFIGURATION_CHANGED. This makes the assertion deterministic — the only
+        // possible event is the very one under test.
+        server.stubFor(
+          get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafileV1).withFixedDelay(800))
+        )
+
+        val sharedCenter = new NotificationCenter()
+        // `build()` here would block on the delayed first fetch; `build(true)` starts the continuous poller without
+        // blocking, so the provider can register its handler before the (delayed) initial load arrives.
+        val configManager = HttpProjectConfigManager
+          .builder()
+          .withSdkKey("race-event-key")
+          .withUrl(datafileUrl(server))
+          .withBlockingTimeout(2000L, TimeUnit.MILLISECONDS)
+          .withPollingInterval(1L, TimeUnit.SECONDS)
+          .withNotificationCenter(sharedCenter)
+          // Timeout comfortably above the 800ms datafile delay so the initial fetch reliably completes (a socket
+          // timeout racing the delay would otherwise fail the initial load nondeterministically).
+          .withOptimizelyHttpClient(TestHttpClient.failFast(2000))
+          .build(true)
+        val optimizely =
+          Optimizely.builder().withConfigManager(configManager).withNotificationCenter(sharedCenter).build()
+        val provider =
+          new OptimizelyFeatureProvider(optimizely, java.time.Duration.ofSeconds(5), closeOnShutdown = true)
+        val api      = OpenFeatureAPI.getInstance()
+        val domain   = s"optimizely-firstfire-${UUID.randomUUID()}"
+        val received = new AtomicInteger(0)
+        val bumped   = new CountDownLatch(1)
+        try {
+          val client = api.getClient(domain)
+          client.onProviderConfigurationChanged { _ =>
+            received.incrementAndGet()
+            bumped.countDown()
+          }
+          // Blocks until the provider transitions to READY against the (delayed) initial v1 load, which the handler
+          // catches while init is still parked pre-READY. Since only v1 is ever served, the initial load is the ONLY
+          // notification the SDK can raise — so if any CONFIGURATION_CHANGED is delivered, it is the spurious initial
+          // one. Wait up to 2s for such a delivery: post-fix none arrives (suppressed); pre-fix the initial-load emit
+          // does.
+          api.setProviderAndWait(domain, provider)
+          val anyEvent = bumped.await(2, TimeUnit.SECONDS)
+          assertTrue(!anyEvent, received.get() == 0)
+        } finally {
+          scala.util.Try(api.shutdown())
+          ()
+        }
+      }
+    },
+    test("shutdown racing initialize never leaves the provider READY (#265.2)") {
+      withMockServer { server =>
+        // A delayed datafile keeps initialize in-flight so a concurrent shutdown genuinely interleaves.
+        server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(ValidDatafileV1).withFixedDelay(300)))
+        val mgr = HttpProjectConfigManager
+          .builder()
+          .withSdkKey("race-key")
+          .withUrl(datafileUrl(server))
+          .withBlockingTimeout(2000L, TimeUnit.MILLISECONDS)
+          .withPollingInterval(3600L, TimeUnit.SECONDS)
+          .withOptimizelyHttpClient(TestHttpClient.failFast())
+          .build(true)
+        mgr.stop()
+        val client = Optimizely.builder().withConfigManager(mgr).build()
+        val provider =
+          new OptimizelyFeatureProvider(
+            client,
+            java.time.Duration.ofSeconds(2),
+            closeOnShutdown = true,
+            configManager = Some(mgr)
+          )
+        try {
+          val release  = new CountDownLatch(1)
+          val initDone = new AtomicInteger(0)
+          val initThread = new Thread(() => {
+            release.await()
+            try provider.initialize(new ImmutableContext())
+            catch { case _: Throwable => () } // failInitialize against the closing client is an acceptable outcome
+            initDone.incrementAndGet()
+            ()
+          })
+          val shutdownThread = new Thread(() => {
+            release.await()
+            provider.shutdown()
+          })
+          initThread.start()
+          shutdownThread.start()
+          release.countDown()
+          initThread.join(10000)
+          shutdownThread.join(10000)
+          val finalState = stateOf(provider)
+          // Invariant across every interleaving: a provider that saw a shutdown must never end up READY. It is
+          // NOT_READY (abort or post-success revert) or ERROR (failed load against the closing client).
+          assertTrue(
+            initDone.get() == 1,
+            finalState != ProviderState.READY,
+            finalState == ProviderState.NOT_READY || finalState == ProviderState.ERROR
+          )
+        } finally provider.shutdown()
+      }
+    }
+  ) @@ TestAspect.sequential @@ TestAspect.timeout(60.seconds) @@ TestAspect.withLiveClock
+}


### PR DESCRIPTION
Three lifecycle defects in `OptimizelyFeatureProvider`'s init/shutdown state machine:

1. **Failed init is now retryable.** A failed `initialize` (datafile timeout, invalid config, handler-registration failure) previously left the provider so a retry silently no-op'd — the SDK treated the non-throwing retry as success and emitted `PROVIDER_READY` while every evaluation kept failing `PROVIDER_NOT_READY` far from the cause. A new `Failed` lifecycle state cleans up the registered handler on failure and lets a subsequent `initialize` cleanly re-attempt.
2. **shutdown racing initialize.** `initialize` now re-checks the lifecycle after registering its handler (removing it and aborting if a shutdown interleaved — closing a handler leak), and makes the final `READY` transition conditional on not having been shut down, so a shut-down provider never reports `READY`.
3. **No spurious initial config event.** The initial datafile load no longer emits `PROVIDER_CONFIGURATION_CHANGED` ahead of `PROVIDER_READY`; the event fires only once the provider is ready (genuine revisions).

Adds `OptimizelyLifecycleRaceSpec` (failed-init retry, initial-load suppression, shutdown-during-init never-READY invariant).

Closes #265