### PR TITLE
Normalize Optimizely context attributes for audience matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Optimizely `ContextTransformer` produces attribute types the audience evaluator can actually match** (#266).
+  Instant, list, and structure attributes were passed through unchanged, but Optimizely's audience evaluator matches
+  only `String`/`Boolean`/`Number` — so a targeting rule against such an attribute evaluated to `UNKNOWN` on every
+  evaluation (silently dead targeting with one WARN log per call and no startup signal). Now an `Instant` is converted
+  to its ISO-8601 string (matchable by string conditions), integral numbers are preserved as `Integer` instead of being
+  coerced to `Double`, and lists/structures — which Optimizely cannot match — are dropped rather than poisoning every
+  condition. Additionally, `decide()` now extracts the targeting key and checks provider readiness **before** normalizing
+  attributes, so the not-ready / missing-key / invalid short-circuits no longer pay for a full attribute conversion whose
+  result is discarded.
+
 - **`OptimizelyFeatureProvider` lifecycle robustness** (#265). Three fixes to the provider's init/shutdown state machine:
   (1) a failed `initialize` (datafile timeout, invalid config, handler-registration failure) previously left the
   provider in a state where a retry silently no-op'd — the SDK treated the non-throwing retry as success and emitted

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/ContextTransformer.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/ContextTransformer.scala
@@ -18,39 +18,49 @@ private[optimizely] object ContextTransformer {
     */
   final case class Transformed(userId: String, attributes: java.util.Map[String, Object])
 
-  def transform(ctx: OFEvaluationContext): Transformed = {
-    val userId = Option(ctx).flatMap(c => Option(c.getTargetingKey)).getOrElse("")
-    val attrs  = Option(ctx).map(_.asObjectMap()).getOrElse(java.util.Collections.emptyMap[String, AnyRef]())
-    Transformed(userId, normalize(attrs))
-  }
+  def transform(ctx: OFEvaluationContext): Transformed =
+    Transformed(userId(ctx), attributes(ctx))
 
-  /** Normalize OpenFeature `Value`-wrapped attributes into the Java primitives Optimizely's targeting engine
-    * understands. Optimizely's `OptimizelyUserContext` accepts `String`, `Boolean`, `Number`, plus collections, but
-    * does NOT accept the `Value` wrapper.
+  /** The Optimizely user identifier (the OF `targetingKey`), or "" when absent. Cheap — no attribute normalization, so
+    * the caller can gate on provider state / targeting key before paying for the full attribute conversion.
+    */
+  def userId(ctx: OFEvaluationContext): String =
+    Option(ctx).flatMap(c => Option(c.getTargetingKey)).getOrElse("")
+
+  /** The normalized attribute map ready to hand to Optimizely. */
+  def attributes(ctx: OFEvaluationContext): java.util.Map[String, Object] =
+    normalize(Option(ctx).map(_.asObjectMap()).getOrElse(java.util.Collections.emptyMap[String, AnyRef]()))
+
+  /** Normalize OpenFeature `Value`-wrapped attributes into the Java types Optimizely's audience evaluator can actually
+    * match: `String`, `Boolean`, and `Number` (`Integer`/`Double`). Anything else evaluates every audience condition to
+    * UNKNOWN (silently dead targeting, one WARN log per evaluation), so:
+    *   - `Instant` is converted to its ISO-8601 string (matchable by string audience conditions);
+    *   - integral numbers are preserved as `Integer` (not coerced to `Double`);
+    *   - lists and structures are DROPPED — Optimizely has no way to match a collection attribute.
+    * A dropped/absent attribute simply doesn't participate in targeting, rather than poisoning every condition.
     */
   private def normalize(attrs: java.util.Map[String, AnyRef]): java.util.Map[String, Object] = {
     val out = new java.util.HashMap[String, Object](attrs.size)
     attrs.asScala.foreach { case (k, v) =>
-      val unwrapped: Object = v match {
-        case null     => null
-        case x: Value => unwrapValue(x)
-        case other    => other
-      }
-      out.put(k, unwrapped)
+      val converted = convert(v)
+      // null means either an unset attribute or an unmatchable type (list/structure) — omit it rather than pass an
+      // attribute Optimizely can only ever evaluate to UNKNOWN.
+      if (converted != null) out.put(k, converted)
     }
     out
   }
 
-  private def unwrapValue(v: Value): Object =
-    if (v == null) null
-    else if (v.isBoolean) java.lang.Boolean.valueOf(v.asBoolean())
-    else if (v.isString) v.asString()
-    else if (v.isNumber) java.lang.Double.valueOf(v.asDouble())
-    else if (v.isInstant) v.asInstant()
-    else if (v.isList) v.asList().asScala.map(unwrapValue).asJava
-    else if (v.isStructure) {
-      val javaMap = new java.util.HashMap[String, Object]()
-      v.asStructure().asMap().asScala.foreach { case (k, vv) => javaMap.put(k, unwrapValue(vv)) }
-      javaMap
-    } else null
+  // `EvaluationContext.asObjectMap()` yields the RAW wrapped objects (Boolean/String/Integer/Double/Instant, and
+  // List[Value]/Structure for collections), so we convert by concrete type. A `Value` wrapper is handled defensively.
+  private def convert(v: Object): Object = v match {
+    case null                    => null
+    case b: java.lang.Boolean    => b
+    case s: String               => s
+    case i: java.lang.Integer    => i             // preserve integral numbers rather than coercing to Double
+    case l: java.lang.Long       => l
+    case n: java.lang.Number     => java.lang.Double.valueOf(n.doubleValue)
+    case inst: java.time.Instant => inst.toString // ISO-8601; Optimizely can't match a raw Instant
+    case x: Value                => convert(x.asObject)
+    case _ => null // lists, structures, and anything else Optimizely's evaluator can't match
+  }
 }

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
@@ -324,12 +324,15 @@ final class OptimizelyFeatureProvider private[optimizely] (
   //   2. Targeting key — caller-supplied context error; only meaningful once the provider is actually usable.
   //   3. `optimizely.isValid` — defence-in-depth in case state says READY but the SDK silently went invalid.
   private def decide(key: String, ctx: OFEvaluationContext): Either[String, OptimizelyDecision] = {
-    val transformed = ContextTransformer.transform(ctx)
+    // Extract only the targeting key up front — cheap — and gate on it before normalizing attributes, so the
+    // NOT_READY / missing-key / invalid short-circuits don't pay for a full attribute conversion whose result is
+    // discarded (#266).
+    val userId = ContextTransformer.userId(ctx)
     if (stateRef.get() != ProviderState.READY) Left("PROVIDER_NOT_READY")
-    else if (transformed.userId.isEmpty) Left("TARGETING_KEY_MISSING")
+    else if (userId.isEmpty) Left("TARGETING_KEY_MISSING")
     else if (!Try(optimizely.isValid).getOrElse(false)) Left("PROVIDER_NOT_READY")
     else
-      Try(optimizely.createUserContext(transformed.userId, transformed.attributes).decide(key)).toEither.left
+      Try(optimizely.createUserContext(userId, ContextTransformer.attributes(ctx)).decide(key)).toEither.left
         .map(t => Option(t.getMessage).getOrElse(t.getClass.getSimpleName))
         .flatMap { decision =>
           if (isFlagNotFound(decision)) Left("FLAG_NOT_FOUND")

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/ContextTransformerSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/ContextTransformerSpec.scala
@@ -4,9 +4,11 @@ import dev.openfeature.sdk.{MutableContext, Structure, Value}
 import zio.test._
 import scala.jdk.CollectionConverters._
 
-/** Unit tests for `ContextTransformer.transform`. Optimizely's user-context attributes accept Java primitives, lists,
-  * and maps — `Value`-wrapped attributes from the OpenFeature SDK must be unwrapped before they cross the boundary,
-  * otherwise Optimizely's targeting engine sees opaque `Value` objects and silently mismatches.
+/** Unit tests for `ContextTransformer.transform`. Optimizely's audience evaluator matches only `String`, `Boolean`, and
+  * `Number` attributes, so the transformer normalizes an OpenFeature context accordingly: integral numbers stay
+  * `Integer` (not coerced to `Double`), an `Instant` becomes its ISO-8601 string, and lists/structures — which no
+  * Optimizely audience condition can match — are dropped rather than passed through to evaluate every condition
+  * UNKNOWN.
   */
 object ContextTransformerSpec extends ZIOSpecDefault {
 
@@ -24,7 +26,7 @@ object ContextTransformerSpec extends ZIOSpecDefault {
       val out = ContextTransformer.transform(new MutableContext())
       assertTrue(out.userId.isEmpty)
     },
-    test("scalar attributes unwrap to Java primitives") {
+    test("scalar attributes unwrap to Java primitives Optimizely can match") {
       val ctx = new MutableContext("u").add("isAdmin", true).add("plan", "premium").add("score", 42d)
       val out = ContextTransformer.transform(ctx)
       assertTrue(
@@ -33,25 +35,33 @@ object ContextTransformerSpec extends ZIOSpecDefault {
         out.attributes.get("score") == java.lang.Double.valueOf(42d)
       )
     },
-    test("list attribute unwraps to a Java List of primitives") {
-      val list    = java.util.Arrays.asList(new Value("a"), new Value("b"))
-      val ctx     = new MutableContext("u").add("tags", list)
-      val out     = ContextTransformer.transform(ctx)
-      val tags    = out.attributes.get("tags")
-      val isList  = tags.isInstanceOf[java.util.List[?]]
-      val asScala = tags.asInstanceOf[java.util.List[Object]].asScala.toList
-      assertTrue(isList, asScala == List("a", "b"))
+    test("integral numbers are preserved as Integer, not coerced to Double (#266)") {
+      val ctx = new MutableContext("u").add("age", java.lang.Integer.valueOf(30))
+      val out = ContextTransformer.transform(ctx)
+      val age = out.attributes.get("age")
+      assertTrue(age.isInstanceOf[java.lang.Integer], age == java.lang.Integer.valueOf(30))
     },
-    test("structure attribute unwraps to a Java Map of primitives") {
+    test("an Instant attribute becomes an ISO-8601 string Optimizely can match (#266)") {
+      val instant = java.time.Instant.parse("2024-01-15T00:00:00Z")
+      val ctx     = new MutableContext("u").add("signupDate", instant)
+      val out     = ContextTransformer.transform(ctx)
+      val v       = out.attributes.get("signupDate")
+      assertTrue(v.isInstanceOf[String], v == "2024-01-15T00:00:00Z")
+    },
+    test("a list attribute is dropped — Optimizely cannot match a collection (#266)") {
+      val list = java.util.Arrays.asList(new Value("a"), new Value("b"))
+      val ctx  = new MutableContext("u").add("tags", list)
+      val out  = ContextTransformer.transform(ctx)
+      // Previously this passed through a java.util.List that evaluated every audience condition to UNKNOWN.
+      assertTrue(!out.attributes.containsKey("tags"))
+    },
+    test("a structure attribute is dropped — Optimizely cannot match it (#266)") {
       val struct = Structure.mapToStructure(
         java.util.Map.of("city", "NYC".asInstanceOf[Object], "zip", "10001".asInstanceOf[Object])
       )
-      val ctx     = new MutableContext("u").add("address", struct)
-      val out     = ContextTransformer.transform(ctx)
-      val v       = out.attributes.get("address")
-      val isMap   = v.isInstanceOf[java.util.Map[?, ?]]
-      val cityVal = v.asInstanceOf[java.util.Map[String, AnyRef]].get("city")
-      assertTrue(isMap, cityVal == "NYC")
+      val ctx = new MutableContext("u").add("address", struct)
+      val out = ContextTransformer.transform(ctx)
+      assertTrue(!out.attributes.containsKey("address"))
     }
   )
 }


### PR DESCRIPTION
`ContextTransformer` passed attribute types Optimizely's audience evaluator cannot match — `Instant`, lists, and structures — so a targeting rule against such an attribute evaluated to `UNKNOWN` on every evaluation (silently dead targeting, one WARN log per call, no startup signal). It also coerced integers to `Double` and ran the full attribute normalization before the readiness short-circuit.

Now an `Instant` is converted to its ISO-8601 string (matchable by string audience conditions), integral numbers are preserved as `Integer`, and lists/structures — which Optimizely cannot match — are dropped rather than poisoning every condition. `decide()` extracts the targeting key and checks provider readiness before normalizing attributes, so the not-ready / missing-key / invalid short-circuits no longer pay for a conversion whose result is discarded. Updates the transformer tests (lists/structures now asserted dropped) and adds integral-preservation and Instant tests.

Closes #266