### PR TITLE
Add OFREP shutdown finalizer and config case class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`OFREPProviderConfig` and scope-managed OFREP factories** (#268). `OFREPProvider.layer(...)` now uses
+  `ZLayer.scoped` with a bounded shutdown finalizer (mirroring the Optimizely module), so the provider's executor and
+  HttpClient are torn down on scope close instead of being orphaned — closing the JVM-exit-hang class (#217/#229) for a
+  caller-supplied non-daemon executor. Added `scoped(...)` overloads and an `OFREPProviderConfig` case class
+  (`baseUrl`, `requestTimeout`, `connectTimeout`, `headers`, `proxy`) with `make`/`scoped`/`layer` factories that build
+  the provider options internally with a daemon executor and validate the base URL **before** creating any thread pool
+  — so configuring timeouts/headers/a proxy no longer requires the raw Guava builder or risks re-arming the non-daemon
+  pool footgun.
+
 - **Optimizely provider staleness watchdog** (#267). After a successful init, datafile-poll failures never surfaced at
   the OpenFeature level — the provider served an aging datafile indefinitely with no operator signal. The provider now
   observes datafile fetches (via an HTTP-client wrapper that records the last successful fetch — distinguishing "polling

--- a/ofrep/src/main/scala/zio/openfeature/ofrep/OFREPProvider.scala
+++ b/ofrep/src/main/scala/zio/openfeature/ofrep/OFREPProvider.scala
@@ -1,11 +1,39 @@
 package zio.openfeature.ofrep
 
+import com.google.common.collect.{ImmutableList, ImmutableMap}
 import dev.openfeature.contrib.providers.ofrep.{OfrepProvider, OfrepProviderOptions}
 import zio._
 import zio.openfeature.FeatureFlagError
 
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{Executors, ExecutorService, ThreadFactory}
+import scala.jdk.CollectionConverters._
+
+/** Scala-friendly configuration for an OFREP provider, mapped internally to the contrib provider's
+  * `OfrepProviderOptions`. Prefer this over hand-building `OfrepProviderOptions`: it exposes only the safe knobs, takes
+  * plain Scala types (no Guava `ImmutableMap`/`ImmutableList`), and — critically — the factories that consume it always
+  * wire in a daemon executor via [[OFREPProvider.daemonOptionsBuilder]] and validate before building, so the contrib
+  * default non-daemon 5-thread pool (a JVM-exit-blocking footgun, see issue #229) is never spawned by this path.
+  *
+  * @param baseUrl
+  *   OFREP endpoint base URL (validated — see
+  *   [[OFREPProvider.make(config:zio\.openfeature\.ofrep\.OFREPProviderConfig)*]])
+  * @param requestTimeout
+  *   Per-request timeout; `None` uses the contrib default
+  * @param connectTimeout
+  *   Connection-establishment timeout; `None` uses the contrib default
+  * @param headers
+  *   Static headers sent on every OFREP request (e.g. `"Authorization" -> List("Bearer …")`); empty means none
+  * @param proxy
+  *   Optional `java.net.ProxySelector` routing OFREP HTTP traffic through a proxy; `None` uses the JVM default
+  */
+final case class OFREPProviderConfig(
+  baseUrl: String,
+  requestTimeout: Option[java.time.Duration] = None,
+  connectTimeout: Option[java.time.Duration] = None,
+  headers: Map[String, List[String]] = Map.empty,
+  proxy: Option[java.net.ProxySelector] = None
+)
 
 /** Scala-friendly factories for the OpenFeature Java SDK's OFREP contrib provider
   * ([[dev.openfeature.contrib.providers.ofrep.OfrepProvider]]).
@@ -98,16 +126,69 @@ object OFREPProvider {
         .mapError(t => FeatureFlagError.InvalidConfiguration(s"OFREP provider construction failed: ${t.getMessage}"))
     } yield provider
 
+  /** Validate an [[OFREPProviderConfig]] and construct a provider. The `baseUrl` is validated FIRST — before any
+    * executor or options are built — so an invalid configuration fails without ever spawning a thread pool. Only on
+    * success are the options assembled internally, starting from [[daemonOptionsBuilder]] (daemon executor) and
+    * applying the configured request/connect timeouts, headers, and proxy.
+    *
+    * This is the ergonomic path for configuring timeouts/headers/proxy: it takes plain Scala types and keeps the
+    * daemon-executor and validate-before-pool guarantees, so callers never need to touch the raw Guava builder.
+    */
+  def make(config: OFREPProviderConfig): IO[FeatureFlagError.InvalidConfiguration, OfrepProvider] =
+    validateBaseUrl(config.baseUrl).flatMap { validated =>
+      ZIO
+        .attempt(OfrepProvider.constructProvider(buildOptions(config, validated)))
+        .mapError(t => FeatureFlagError.InvalidConfiguration(s"OFREP provider construction failed: ${t.getMessage}"))
+    }
+
+  /** Upper bound on provider teardown. `OfrepProvider.shutdown()` terminates the options executor and closes the
+    * HttpClient; the bound exists so a pathological close cannot hang scope teardown. When the executor is the daemon
+    * pool this wrapper installs, the JVM can exit regardless — but a caller-supplied non-daemon executor (via
+    * [[make(options:dev\.openfeature\.contrib\.providers\.ofrep\.OfrepProviderOptions)*]]) is only released by this
+    * shutdown, so the finalizer matters.
+    */
+  private val ShutdownTimeout: zio.Duration = 5.seconds
+
+  private def releaseOfrep(provider: OfrepProvider): UIO[Unit] =
+    // `.disconnect` because finalizers run uninterruptibly and the timeout must still fire.
+    ZIO.attemptBlocking(provider.shutdown()).disconnect.timeout(ShutdownTimeout).ignore
+
+  /** [[make(String)]] with scope-managed shutdown: when the surrounding `Scope` closes, the provider is shut down
+    * (bounded), terminating its executor and closing the HttpClient — even if it was never registered with a
+    * `FeatureFlags` layer.
+    */
+  def scoped(baseUrl: String): ZIO[Scope, FeatureFlagError.InvalidConfiguration, OfrepProvider] =
+    ZIO.acquireRelease(make(baseUrl))(releaseOfrep)
+
+  /** [[make(OfrepProviderOptions)]] with scope-managed shutdown — see [[scoped(baseUrl:String)*]]. Especially important
+    * here: caller-supplied options may hold a non-daemon executor, and this finalizer is what releases it.
+    */
+  def scoped(options: OfrepProviderOptions): ZIO[Scope, FeatureFlagError.InvalidConfiguration, OfrepProvider] =
+    ZIO.acquireRelease(make(options))(releaseOfrep)
+
+  /** [[make(config:zio\.openfeature\.ofrep\.OFREPProviderConfig)*]] with scope-managed shutdown — see
+    * [[scoped(baseUrl:String)*]].
+    */
+  def scoped(config: OFREPProviderConfig): ZIO[Scope, FeatureFlagError.InvalidConfiguration, OfrepProvider] =
+    ZIO.acquireRelease(make(config))(releaseOfrep)
+
   /** ZLayer convenience that wraps [[make(String)]]. Use as `OFREPProvider.layer("https://flags.example.com")` to wire
     * an OFREP provider into a ZIO application; failures arrive as typed `FeatureFlagError.InvalidConfiguration` at
-    * layer build time.
+    * layer build time. The layer owns the provider lifecycle: its finalizer shuts the provider down when the layer's
+    * scope closes.
     */
   def layer(baseUrl: String): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OfrepProvider] =
-    ZLayer.fromZIO(make(baseUrl))
+    ZLayer.scoped(scoped(baseUrl))
 
-  /** ZLayer convenience that wraps [[make(OfrepProviderOptions)]]. */
+  /** ZLayer convenience that wraps [[make(OfrepProviderOptions)]]. Owns the provider lifecycle — see
+    * [[layer(baseUrl:String)*]].
+    */
   def layer(options: OfrepProviderOptions): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OfrepProvider] =
-    ZLayer.fromZIO(make(options))
+    ZLayer.scoped(scoped(options))
+
+  /** ZLayer from an [[OFREPProviderConfig]]. Owns the provider lifecycle — see [[layer(baseUrl:String)*]]. */
+  def layer(config: OFREPProviderConfig): ZLayer[Any, FeatureFlagError.InvalidConfiguration, OfrepProvider] =
+    ZLayer.scoped(scoped(config))
 
   /** Create an OFREP provider with the contrib provider's built-in default options (baseUrl defaults to whatever the
     * contrib library declares — currently `http://localhost:8016`).
@@ -136,6 +217,27 @@ object OFREPProvider {
   @deprecated("Use OFREPProvider.make(options) or OFREPProvider.layer(options) for validated construction", "0.2.0")
   def fromOptions(options: OfrepProviderOptions): OfrepProvider =
     OfrepProvider.constructProvider(options)
+
+  // Options assembly
+
+  /** Assemble `OfrepProviderOptions` from a validated config. Always starts from [[daemonOptionsBuilder]] so the daemon
+    * executor is installed; the caller must have validated `validatedBaseUrl` already.
+    */
+  private def buildOptions(config: OFREPProviderConfig, validatedBaseUrl: String): OfrepProviderOptions = {
+    // The Guava-style builder returns itself from each setter, so this fold threads a single builder instance.
+    val base       = daemonOptionsBuilder().baseUrl(validatedBaseUrl)
+    val withReq    = config.requestTimeout.fold(base)(base.requestTimeout)
+    val withConn   = config.connectTimeout.fold(withReq)(withReq.connectTimeout)
+    val withProxy  = config.proxy.fold(withConn)(withConn.proxySelector)
+    val configured = if (config.headers.isEmpty) withProxy else withProxy.headers(toGuavaHeaders(config.headers))
+    configured.build()
+  }
+
+  private def toGuavaHeaders(headers: Map[String, List[String]]): ImmutableMap[String, ImmutableList[String]] = {
+    val builder = ImmutableMap.builder[String, ImmutableList[String]]()
+    headers.foreach { case (name, values) => builder.put(name, ImmutableList.copyOf(values.asJava)) }
+    builder.build()
+  }
 
   // Validation
 

--- a/ofrep/src/test/scala/zio/openfeature/ofrep/OFREPLifecycleSpec.scala
+++ b/ofrep/src/test/scala/zio/openfeature/ofrep/OFREPLifecycleSpec.scala
@@ -1,0 +1,110 @@
+package zio.openfeature.ofrep
+
+import dev.openfeature.contrib.providers.ofrep.OfrepProvider
+import zio._
+import zio.openfeature.FeatureFlagError
+import zio.test._
+
+import java.time.Duration
+import java.util.concurrent.{ExecutorService, Executors, ThreadFactory, TimeUnit}
+
+/** Covers the two #268 gaps: the `layer`/`scoped` shutdown finalizer (Fix 1) and the `OFREPProviderConfig` factory (Fix
+  * 2). The load-bearing property throughout is that no construction path leaks a non-daemon pool: if any test here
+  * hangs at suite teardown, a pool was orphaned.
+  */
+object OFREPLifecycleSpec extends ZIOSpecDefault {
+
+  private val ValidUrl = "http://localhost:9999"
+
+  // A daemon executor we can hand to the provider via options and then observe: after the scope closes, the layer's
+  // finalizer must have called shutdown() on the provider, which terminates this executor. Daemon so a regression
+  // (finalizer not firing) surfaces as a failed assertion rather than a hung JVM.
+  private def daemonExecutor(): ExecutorService = {
+    val tf: ThreadFactory = (r: Runnable) => {
+      val t = new Thread(r, "ofrep-lifecycle-test")
+      t.setDaemon(true)
+      t
+    }
+    Executors.newCachedThreadPool(tf)
+  }
+
+  def spec = suite("OFREPProvider lifecycle & config")(
+    suite("Fix 1 — layer/scoped own the provider lifecycle")(
+      test("scoped(baseUrl) builds and releases without hanging") {
+        for {
+          _ <- ZIO.scoped(OFREPProvider.scoped(ValidUrl).unit)
+        } yield assertCompletes
+      },
+      test("layer(baseUrl) builds and releases without hanging") {
+        for {
+          _ <- ZIO.scoped(OFREPProvider.layer(ValidUrl).build.unit)
+        } yield assertCompletes
+      },
+      test("layer(options) shuts the provider down on scope close (executor terminated)") {
+        val exec = daemonExecutor()
+        val opts = OFREPProvider.daemonOptionsBuilder().baseUrl(ValidUrl).executor(exec).build()
+        for {
+          // While the scope is open the executor is live; after it closes the finalizer's shutdown() terminates it.
+          _          <- ZIO.scoped(OFREPProvider.layer(opts).build.unit)
+          shutdown   <- ZIO.succeed(exec.isShutdown)
+          terminated <- ZIO.attemptBlocking(exec.awaitTermination(5, TimeUnit.SECONDS)).orDie
+        } yield assertTrue(shutdown, terminated)
+      },
+      test("layer(config) builds and releases without hanging") {
+        val config = OFREPProviderConfig(ValidUrl, requestTimeout = Some(Duration.ofSeconds(3)))
+        for {
+          _ <- ZIO.scoped(OFREPProvider.layer(config).build.unit)
+        } yield assertCompletes
+      }
+    ),
+    suite("Fix 2 — OFREPProviderConfig factory")(
+      test("make(config) with timeouts + a header builds an OFREP provider") {
+        val config = OFREPProviderConfig(
+          baseUrl = ValidUrl,
+          requestTimeout = Some(Duration.ofSeconds(5)),
+          connectTimeout = Some(Duration.ofSeconds(2)),
+          headers = Map("Authorization" -> List("Bearer test-token"))
+        )
+        for {
+          provider <- OFREPProvider.make(config)
+        } yield try assertTrue(provider.getMetadata.getName.toLowerCase.contains("ofrep"))
+        finally provider.shutdown()
+      },
+      test("make(config) with a proxy selector builds an OFREP provider") {
+        val proxy  = java.net.ProxySelector.getDefault
+        val config = OFREPProviderConfig(baseUrl = ValidUrl, proxy = Some(proxy))
+        for {
+          provider <- OFREPProvider.make(config)
+        } yield try assertCompletes
+        finally provider.shutdown()
+      },
+      test("make(config) with an invalid baseUrl fails fast with InvalidConfiguration (no pool leak)") {
+        // Validation runs before any executor/options are built, so the rejection cannot orphan a pool.
+        val config =
+          OFREPProviderConfig(baseUrl = "ftp://flags.example.com", requestTimeout = Some(Duration.ofSeconds(5)))
+        for {
+          result <- OFREPProvider.make(config).either
+        } yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.isInstanceOf[FeatureFlagError.InvalidConfiguration]),
+          result.left.exists(_.message.toLowerCase.contains("unsupported scheme"))
+        )
+      },
+      test("make(config) with a null baseUrl fails fast with InvalidConfiguration") {
+        val config = OFREPProviderConfig(baseUrl = null)
+        for {
+          result <- OFREPProvider.make(config).either
+        } yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.message.toLowerCase.contains("null"))
+        )
+      },
+      test("scoped(config) builds and releases without hanging") {
+        val config = OFREPProviderConfig(ValidUrl, headers = Map("X-Env" -> List("test")))
+        for {
+          _ <- ZIO.scoped(OFREPProvider.scoped(config).unit)
+        } yield assertCompletes
+      }
+    )
+  )
+}


### PR DESCRIPTION
Two OFREP-module gaps:

1. **`layer(...)` now owns the provider lifecycle.** It used `ZLayer.fromZIO(make(...))` with no shutdown finalizer, orphaning the provider's executor and HttpClient on scope close — and a caller-supplied non-daemon executor then blocked JVM exit (the #217/#229 hang). It now uses `ZLayer.scoped` with a bounded shutdown finalizer (`shutdown().disconnect.timeout(5s).ignore`, mirroring the Optimizely module), plus `scoped(...)` overloads.

2. **`OFREPProviderConfig` case class.** Configuring timeouts/headers/a proxy previously required the raw Guava builder and knowing to avoid the contrib provider's default non-daemon 5-thread pool. The new `OFREPProviderConfig(baseUrl, requestTimeout, connectTimeout, headers, proxy)` with `make`/`scoped`/`layer` factories builds the options internally with a daemon executor and validates the base URL **before** creating any thread pool — so misconfiguration no longer risks re-arming the pool footgun.

Adds `OFREPLifecycleSpec` (finalizer teardown observed via the executor's `isShutdown`; config valid-build and invalid-baseUrl fast-fail; build-and-release without hang).

Closes #268