### PR TITLE
Refresh providerNameRef for lazy-metadata providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`providerNameRef` is refreshed for lazy-metadata providers on `PROVIDER_READY`** (#297). A provider whose metadata
+  name only materializes inside `initialize()` — notably the SDK's `MultiProvider` — had its name captured as the
+  `"unknown"` fallback at build time and never corrected, so a fully-ready `MultiProvider` reported
+  `ProviderMetadata("unknown")` and the event-identity guard stayed permanently failed-open for it. When a
+  `PROVIDER_READY` from the current provider arrives carrying a real stamped name, `providerNameRef` is now
+  refreshed from `"unknown"` to that name (via a race-safe `compareAndSet` that never clobbers a name set by a
+  concurrent swap), restoring accurate `providerMetadata` and re-enabling event-identity discrimination.
+
 - **Optimizely initial datafile-load event suppression is now deterministic** (#308). The provider suppressed the
   initial datafile load's spurious `PROVIDER_CONFIGURATION_CHANGED` by gating emission on `state == READY` read at
   notification time, which raced the `optimizely.isValid` fast-path: if init reached READY before the handler processed

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -128,7 +128,19 @@ final private[openfeature] class FeatureFlagsLive(
   private[openfeature] def onReadyEvent(details: EventDetails): UIO[Unit] = {
     val em      = extractEventMetadata(details)
     val current = fromCurrentProvider(details)
-    (if (current) applySignal(Signal.EventReady) else ZIO.none) *>
+    // Refresh a still-"unknown" provider name from the event's stamped name when the READY is from the current
+    // provider. A lazy-metadata provider (notably the SDK's MultiProvider) only builds its metadata name inside
+    // initialize(), so the async build captured the "unknown" fallback; the provider's own READY carries the real
+    // name. Refreshing restores accurate providerMetadata and re-enables the event-identity guard for such providers
+    // (#297). `compareAndSet` from the fallback only: it never clobbers a real name set by a concurrent swap.
+    val refreshName = ZIO.succeed {
+      val eventName = details.getProviderName
+      if (current && eventName != null)
+        providerNameRef.compareAndSet(FeatureFlags.UnknownProviderName, eventName)
+      ()
+    }
+    refreshName *>
+      (if (current) applySignal(Signal.EventReady) else ZIO.none) *>
       state.eventHub.publish(ProviderEvent.Ready(eventProviderMetadata(details), em)).unit *>
       ZIO.succeed(if (current) onReady.foreach(_.countDown()))
   }

--- a/core/src/test/scala/zio/openfeature/ProviderStatusBridgeSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderStatusBridgeSpec.scala
@@ -124,6 +124,26 @@ object ProviderStatusBridgeSpec extends ZIOSpecDefault {
         }
       } yield out
     },
+    test("lazy-metadata provider: a READY event refreshes providerNameRef from unknown to the real name (#297)") {
+      // buildAsync captured "unknown" for a LateMetadataProvider (metadata name only materializes after init). When
+      // the provider's own READY arrives stamped with the real name, providerNameRef must be refreshed so
+      // providerMetadata reports the real name AND the identity guard regains discrimination.
+      for {
+        ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)
+        out <- ZIO.scoped {
+          buildProvider(ref, new LateMetadataProvider).flatMap { ff =>
+            for {
+              beforeName <- ff.providerMetadata.map(_.name)
+              _          <- ff.onReadyEvent(details("multiprovider"))
+              afterName  <- ff.providerMetadata.map(_.name)
+            } yield assertTrue(
+              beforeName == FeatureFlags.UnknownProviderName,
+              afterName == "multiprovider"
+            )
+          }
+        }
+      } yield out
+    },
     test("null provider name fails open: transition applies") {
       for {
         ref <- SubscriptionRef.make[ProviderStatus](ProviderStatus.NotReady)


### PR DESCRIPTION
## Summary
A provider whose metadata name only materializes inside `initialize()` — notably the SDK's `MultiProvider` — had its name captured as the `"unknown"` fallback at build time and never corrected. As a result a fully-ready `MultiProvider` reported `ProviderMetadata("unknown")`, and the event-identity guard (`fromCurrentProvider`) stayed permanently failed-open for it (so a stale event from a replaced provider could not be discriminated).

## Change
When a `PROVIDER_READY` from the current provider arrives carrying a real stamped provider name, `onReadyEvent` now refreshes `providerNameRef` from the `"unknown"` fallback to that name, via a race-safe `compareAndSet` that never clobbers a name set by a concurrent swap. This restores accurate `providerMetadata` and re-enables event-identity discrimination for lazy-metadata providers. Additive; no public API change.

Adds a regression test to `ProviderStatusBridgeSpec` and a CHANGELOG entry.

Closes #297