### PR TITLE
Restore SDK client routing on failed hot-swap rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A failed hot-swap now rolls back SDK client routing, not just the internal provider ref** (#282). `setProvider`'s
+  failure path restored the internal `providerRef`/status but not the OpenFeature Java SDK's provider binding — the SDK
+  binds a new provider into its domain/default slot *before* calling `initialize()` and does not revert that binding
+  when init throws. So after a failed swap, evaluations (which route through the SDK client) kept returning values from
+  the *failed* provider while `providerMetadata`/`providerStatus` claimed the previous provider was active. The rollback
+  now re-registers the previous provider with the SDK (via a compile-time package shim `dev.openfeature.sdk.EventProviderAccess`
+  that resets an `EventProvider`'s attach state so re-registration doesn't hit the SDK's "already attached" guard), so a
+  failed swap reverts routing **and** status to the previous, still-serving provider. **Behavior change:** after a failed
+  swap whose rollback succeeds, `providerStatus` is now `Ready` (the previous provider is serving) and evaluations return
+  the previous provider's values; if the rollback itself fails (the previous provider's re-`initialize()` throws), status
+  remains `Error` and the failure is logged. **Caveat:** re-registration starts a fresh SDK state manager for the
+  previous provider, so its `initialize()` runs again (e.g. an Optimizely poller restarts) — unless it is still bound to
+  another domain of a shared API, whose ready state manager is reused. `setProvider` still fails with
+  `ProviderInitializationFailed` carrying the original error.
+
 - **`providerNameRef` is refreshed for lazy-metadata providers on `PROVIDER_READY`** (#297). A provider whose metadata
   name only materializes inside `initialize()` — notably the SDK's `MultiProvider` — had its name captured as the
   `"unknown"` fallback at build time and never corrected, so a fully-ready `MultiProvider` reported

--- a/core/src/main/scala/dev/openfeature/sdk/EventProviderAccess.scala
+++ b/core/src/main/scala/dev/openfeature/sdk/EventProviderAccess.scala
@@ -1,0 +1,30 @@
+package dev.openfeature.sdk
+
+/** Access to package-private SDK members needed for hot-swap rollback (#282).
+  *
+  * When `setProvider`'s `setProviderAndWait(new)` fails because the new provider's `initialize()` throws, the SDK has
+  * already evicted the old provider's state manager from the domain/default slot but left the old `EventProvider`
+  * `attach`ed. Re-registering the old provider then throws `IllegalStateException: already attached` unless its attach
+  * state is first reset via the package-private `detach()`. This shim exposes that member.
+  *
+  * Compile-time checked rather than reflective: an SDK upgrade that changes these signatures fails compilation here
+  * instead of surfacing as a runtime reflection error. Same precedent as `OpenFeatureAPIFactory` sitting next to it
+  * (which accesses the package-private `OpenFeatureAPI` constructor).
+  */
+object EventProviderAccess {
+
+  /** Reset an `EventProvider`'s attach state so it can be re-registered with an API instance. No-op for providers that
+    * don't extend `EventProvider` (they never attach). The SDK's `detach()` is idempotent (a plain
+    * `AtomicReference.set(null)`).
+    */
+  def detach(provider: FeatureProvider): Unit = provider match {
+    case ep: EventProvider => ep.detach()
+    case _                 => ()
+  }
+
+  /** Release a provider from the SDK's global provider registry (spec 1.8.4) — used only in the rollback-failure
+    * cleanup path, mirroring what `ProviderRepository.shutDownOld` would have done on a successful rollback.
+    */
+  def deregisterGlobalProvider(api: OpenFeatureAPI, provider: FeatureProvider): Unit =
+    api.deregisterGlobalProvider(provider)
+}

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -1176,9 +1176,8 @@ object FeatureFlags {
           freshFallback <- fallback
           _ <- ff
             .setProvider(compose(real, freshFallback))
-            // `setProvider`'s rollback restored the live fallback to the provider ref but left status `Error`; the
-            // fallback is still serving, so force status back to Ready before reporting the failure.
-            .tapError(_ => ff.forceReady)
+            // `setProvider`'s rollback now restores both routing AND status (#282): a failed swap re-registers the
+            // still-live fallback with the SDK and sets Ready, so no local force-ready workaround is needed here.
             .mapError(e => new RuntimeException(s"Provider swap failed: $e"))
         } yield ()
         _ <- construct.catchAll(onConstructionError).forkScoped

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -15,6 +15,7 @@ import dev.openfeature.sdk.{
   FeatureProvider => OFFeatureProvider,
   ProviderEvent => JavaProviderEvent,
   EventDetails,
+  EventProviderAccess,
   FlagEvaluationDetails,
   MutableTrackingEventDetails,
   OpenFeatureAPI
@@ -794,12 +795,67 @@ final private[openfeature] class FeatureFlagsLive(
   override def providerStatus: UIO[ProviderStatus] =
     state.statusRef.get
 
-  // Force status back to Ready. Used by `fromAcquireAsync` when a hot-swap to the real provider fails: `setProvider`'s
-  // rollback restores the still-live fallback to `providerRef` but leaves status `Error`. Evaluations still proceed in
-  // `Error` (spec 1.7.6/1.7.7), but restoring `Ready` keeps `providerStatus` / `awaitReady` accurate for the usable
-  // fallback (`Error` is not `canEvaluate`). Package-private — not part of the public API.
-  private[openfeature] def forceReady: UIO[Unit] =
-    applySignal(Signal.ForceReady).unit
+  /** Re-register `oldProvider` with the SDK iff the failed swap left the SDK routing to `newProvider` (#282). Returns
+    * true iff the SDK is verified to route to `oldProvider` afterwards.
+    *
+    * The Java SDK binds the new provider's state manager into the domain/default slot before calling its `initialize()`
+    * and does not revert that binding when init throws, so after a failed swap the SDK client still routes evaluations
+    * to the failed provider while our refs have already rolled back to the old one. Re-registering the old provider
+    * reconciles the two — and, on success, triggers the SDK's own `shutDownOld` of the failed provider.
+    *
+    * Caveat: re-registration starts a fresh state manager for the old provider, so the SDK calls its `initialize()`
+    * again (an Optimizely poller restarts, an OFREP client re-fetches, ...) — unless the old provider is still bound to
+    * another domain of a shared API, whose READY manager is reused and skips re-init.
+    */
+  private def restoreSdkRegistration(
+    oldProvider: OFFeatureProvider,
+    newProvider: OFFeatureProvider
+  ): Task[Boolean] =
+    ZIO.attemptBlocking {
+      val bound = domain.fold(api.getProvider())(d => api.getProvider(d))
+      if (bound eq oldProvider) true // swap failed before binding (e.g. attach threw); already routing to old
+      // A concurrent sibling swap (shared-api topology) won the slot: leave it alone and report no restore, so status
+      // stays Error rather than us fighting the winner. The refs stay rolled back to oldProvider — a benign skew in
+      // this rare topology, deliberately not reconciled here.
+      else if (bound ne newProvider) false
+      else {
+        def register(): Unit = domain match {
+          case Some(d) => api.setProviderAndWait(d, oldProvider)
+          case None    => api.setProviderAndWait(oldProvider)
+        }
+        try register()
+        catch {
+          case _: IllegalStateException =>
+            // The "already attached" state a failed swap leaves an EventProvider in: its state manager was evicted from
+            // the slot but its `attach` CAS was never reset, so re-registration throws. Detach and retry once; any
+            // further failure propagates. This is precise for the case that matters — the ISE fires here only for an
+            // old provider still bound to ANOTHER domain when its reused READY manager skips attach entirely (so the
+            // detach is never called on a still-attached shared provider). The SDK's other ISE ("cannot set provider
+            // while repository is shutting down") also lands here, but it throws before any rebind, and the detach is
+            // moot then because the whole API is being torn down; the retry rethrows it and it propagates to cleanup.
+            EventProviderAccess.detach(oldProvider)
+            register()
+        }
+        true
+      }
+    }
+
+  /** Best-effort teardown of the failed new provider when rollback itself failed and left it unbound (#282). On a
+    * successful rollback the SDK's `shutDownOld` already does this; this covers only the rollback-failure path. If the
+    * failed provider is somehow still bound, do nothing.
+    */
+  private def cleanupUnboundFailedProvider(newProvider: OFFeatureProvider): UIO[Unit] =
+    (for {
+      bound <- ZIO.attemptBlocking(domain.fold(api.getProvider())(d => api.getProvider(d)))
+      _ <- ZIO.when(bound ne newProvider)(
+        ZIO.attemptBlocking(newProvider.shutdown()).ignore *>
+          ZIO.attemptBlocking(EventProviderAccess.deregisterGlobalProvider(api, newProvider)).ignore
+      )
+    } yield ())
+      // Log if even the best-effort teardown's own precondition read fails, so a leaked provider/thread from this
+      // doubly-rare path leaves a breadcrumb instead of vanishing silently.
+      .tapErrorCause(c => ZIO.logWarningCause("cleanupUnboundFailedProvider: best-effort teardown failed", c))
+      .ignore
 
   /** Async-init watchdog escalation (#244). Only when the machine actually transitions (the provider never became
     * usable — the `everReady` gate) does it shut the provider down, publish a terminal Error event with code
@@ -1030,11 +1086,31 @@ final private[openfeature] class FeatureFlagsLive(
           case None    => ZIO.attemptBlocking(api.setProviderAndWait(newProvider))
         }).mapError(e => FeatureFlagError.ProviderInitializationFailed(e))
           .tapError(_ =>
-            // Roll back refs FIRST so the identity guard again reflects the (still registered) old provider, then
-            // record the failure via the machine.
+            // Roll back refs FIRST so the identity guard again reflects the previous provider and record the failure
+            // via the machine, THEN reconcile the SDK client routing (#282): the SDK binds the new provider before
+            // init and does not revert on a failed init, so evaluations would keep hitting the failed provider while
+            // our refs point back at the old one. Re-registering the old provider restores routing; on success we
+            // restore Ready (the previous provider is serving again), on failure we log loudly and leave status Error.
             providerRef.set(oldProvider) *>
               ZIO.succeed(providerNameRef.set(oldName)) *>
-              applySignal(Signal.SwapFailed)
+              applySignal(Signal.SwapFailed) *>
+              restoreSdkRegistration(oldProvider, newProvider).foldZIO(
+                e =>
+                  ZIO.logErrorCause(
+                    s"setProvider rollback: failed to re-register previous provider '$oldName'; status remains Error " +
+                      "and evaluations may still route to the failed provider until a later setProvider succeeds",
+                    Cause.fail(e)
+                  ) *> cleanupUnboundFailedProvider(newProvider),
+                restored =>
+                  // restored == false only when a concurrent sibling swap already won the slot (see
+                  // restoreSdkRegistration): leave status Error and log a breadcrumb, don't fight the winner.
+                  if (restored) applySignal(Signal.RollbackSucceeded).unit
+                  else
+                    ZIO.logInfo(
+                      s"setProvider rollback: slot no longer bound to the failed provider (concurrent swap?); " +
+                        s"leaving status Error for '$oldName'"
+                    )
+              )
           )
         // 4. Mark ready via the machine — the Java SDK bridge also fires PROVIDER_READY, but we set it explicitly for
         //    immediate visibility.

--- a/core/src/main/scala/zio/openfeature/internal/ProviderStatusMachine.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ProviderStatusMachine.scala
@@ -27,8 +27,11 @@ private[openfeature] object ProviderStatusMachine {
     case object ShutdownStarted                 extends Signal
     case object ShutdownCompleted               extends Signal
 
-    /** fromAcquireAsync: a failed hot-swap rolled back to a still-live fallback. */
-    case object ForceReady extends Signal
+    /** setProvider: a failed hot-swap was rolled back and the previous provider re-registered with the SDK, verified to
+      * be routing again (#282). Same transition as a successful swap outcome, applied by `setProvider` itself once the
+      * rollback re-registration confirms the old provider is bound.
+      */
+    case object RollbackSucceeded extends Signal
   }
 
   /** Cross-thread context the table needs but the public ProviderStatus cannot represent. */
@@ -52,7 +55,7 @@ private[openfeature] object ProviderStatusMachine {
       case Signal.SwapStarted       => Some(NotReady)
       case Signal.SwapSucceeded     => Some(Ready)
       case Signal.SwapFailed        => Some(Error)
-      case Signal.ForceReady        => Some(Ready)
+      case Signal.RollbackSucceeded => Some(Ready)
 
       // Non-lifecycle signals (the init watchdog and every bridge event) never take effect during a swap (the swap
       // sets its own outcome) nor after an explicit shutdown has completed (post-shutdown NotReady is terminal; a

--- a/core/src/test/scala/zio/openfeature/FeatureFlagRegistrySpec.scala
+++ b/core/src/test/scala/zio/openfeature/FeatureFlagRegistrySpec.scala
@@ -196,15 +196,19 @@ object FeatureFlagRegistrySpec extends ZIOSpecDefault {
           client   <- registry.getClient("domain1")
           v1       <- client.string("flag", default = "none")
           result   <- registry.setProvider("domain1", failingProvider).either
-          // After failed swap, client is in Error state (old provider was shut down by Java SDK)
+          // #282: after a failed swap the rollback re-registers the previous provider with the SDK, so the client
+          // routes back to it (status Ready, evaluations return the old provider's values) rather than being stranded
+          // on the failed provider.
           status <- client.providerStatus
+          v2     <- client.string("flag", default = "none")
           // Recover with a working provider
           _  <- registry.setProvider("domain1", recoveryProvider)
           v3 <- client.string("flag", default = "none")
         } yield assertTrue(
           v1 == "default",
           result.is(_.left).isInstanceOf[FeatureFlagError],
-          status == ProviderStatus.Error,
+          status == ProviderStatus.Ready,
+          v2 == "default",
           v3 == "recovered"
         )
       }

--- a/core/src/test/scala/zio/openfeature/NonBlockingInitSpec.scala
+++ b/core/src/test/scala/zio/openfeature/NonBlockingInitSpec.scala
@@ -142,13 +142,12 @@ object NonBlockingInitSpec extends ZIOSpecDefault {
             .flatMap { ff =>
               for {
                 _ <- errP.await
-                // The real guarantee is that the instance stays *usable* on the fallback: the evaluation succeeds
-                // rather than hard-failing. Since #245 lets evaluations proceed in Error, this holds regardless of
-                // whether `forceReady` won the race or a late async PROVIDER_ERROR (from the failing provider's init)
-                // re-set the status to Error. (Asserting via `awaitReady` under this spec's frozen TestClock would
-                // block forever on that Error race, so assert on the evaluation itself.)
+                // #282: setProvider's rollback now re-registers the fallback with the SDK, so evaluations route back to
+                // the FALLBACK — not the failed provider. The fallback ("fb") returns false, so the evaluation must be
+                // Right(false), not the failed provider's true. (Pre-#282 this could return the failed provider's
+                // value; asserting the value, not just evaluability, is the original evidence case for this bug.)
                 v <- ff.boolean("x", true).either
-              } yield assertTrue(v.isRight)
+              } yield assertTrue(v == Right(false))
             }
         }
       } yield result

--- a/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderHotSwapSpec.scala
@@ -87,6 +87,38 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
     } yield ff
   }
 
+  private def buildNoDomain(provider: SimpleProvider): ZIO[Scope, Throwable, FeatureFlags] = {
+    val api = OpenFeatureAPIFactory.create()
+    for {
+      ff <- FeatureFlags.build(
+        provider,
+        domain = None,
+        version = None,
+        initialHooks = Nil,
+        statusRef = None,
+        addShutdownFinalizer = false,
+        apiOverride = Some(api)
+      )
+      _ <- ZIO.attemptBlocking(Thread.sleep(50)).ignore
+    } yield ff
+  }
+
+  // Build a client on a caller-provided API + domain so several clients can share one API instance (registry topology).
+  private def buildOn(
+    api: dev.openfeature.sdk.OpenFeatureAPI,
+    domain: String,
+    provider: SimpleProvider
+  ): ZIO[Scope, Throwable, FeatureFlags] =
+    FeatureFlags.build(
+      provider,
+      domain = Some(domain),
+      version = None,
+      initialHooks = Nil,
+      statusRef = None,
+      addShutdownFinalizer = false,
+      apiOverride = Some(api)
+    )
+
   def spec = suite("Provider Hot-Swap")(
     test("setProvider swaps to a new provider") {
       ZIO.scoped {
@@ -203,20 +235,27 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
           assertTrue(vi == 42) && assertTrue(vd == 3.14)
       }
     },
-    test("failed swap sets status to Error") {
+    test("failed swap rolls back routing and status to the previous provider (#282)") {
+      // The core regression: after a failed swap, evaluations must route back to provider A (not the failed
+      // provider), status must be Ready, and metadata must name A — the SDK client routing is reconciled, not just
+      // the internal providerRef.
       ZIO.scoped {
         val providerA = new SimpleProvider("A", Map("flag" -> true))
-        val failingProvider = new SimpleProvider("Failing", Map.empty) {
+        val failingProvider = new SimpleProvider("Failing", Map("flag" -> false)) {
           override def initialize(ctx: OFEvaluationContext): Unit =
             throw new RuntimeException("Initialization failed")
         }
         for {
           ff     <- buildWithDomain(providerA)
           result <- ff.setProvider(failingProvider).either
+          v      <- ff.boolean("flag", default = false)
           status <- ff.providerStatus
+          m      <- ff.providerMetadata
         } yield assertTrue(result.isLeft) &&
           assertTrue(result.left.toOption.get.isInstanceOf[FeatureFlagError.ProviderInitializationFailed]) &&
-          assertTrue(status == ProviderStatus.Error)
+          assertTrue(v == true) &&
+          assertTrue(status == ProviderStatus.Ready) &&
+          assertTrue(m.name == "A")
       }
     },
     test("stale PROVIDER_READY from the old provider does not mark status Ready mid-swap (#181)") {
@@ -264,10 +303,165 @@ object ProviderHotSwapSpec extends ZIOSpecDefault {
           v      <- ff.boolean("flag", default = true)
           s2     <- ff.providerStatus
           m      <- ff.providerMetadata
-        } yield assertTrue(status == ProviderStatus.Error) &&
+        } yield assertTrue(status == ProviderStatus.Ready) &&
           assertTrue(v == false) &&
           assertTrue(s2 == ProviderStatus.Ready) &&
           assertTrue(m.name == "C")
+      }
+    },
+    test("no-domain failed swap rolls back routing and status (#282)") {
+      // The rollback branches on `domain`; exercise the default-slot (no-domain) path.
+      ZIO.scoped {
+        val providerA = new SimpleProvider("A", Map("flag" -> true))
+        val failingProvider = new SimpleProvider("Failing", Map("flag" -> false)) {
+          override def initialize(ctx: OFEvaluationContext): Unit =
+            throw new RuntimeException("Initialization failed")
+        }
+        for {
+          ff     <- buildNoDomain(providerA)
+          result <- ff.setProvider(failingProvider).either
+          v      <- ff.boolean("flag", default = false)
+          status <- ff.providerStatus
+          m      <- ff.providerMetadata
+        } yield assertTrue(result.isLeft) &&
+          assertTrue(v == true) &&
+          assertTrue(status == ProviderStatus.Ready) &&
+          assertTrue(m.name == "A")
+      }
+    },
+    test("failed swap re-initializes the previous provider exactly once more (#282)") {
+      // Pins the documented re-init caveat: rollback re-registers the old provider, so its initialize() runs a second
+      // time (once at build, once at rollback).
+      ZIO.scoped {
+        val initCount = new java.util.concurrent.atomic.AtomicInteger(0)
+        val providerA = new SimpleProvider("A", Map("flag" -> true)) {
+          override def initialize(ctx: OFEvaluationContext): Unit = { initCount.incrementAndGet(); () }
+        }
+        val failingProvider = new SimpleProvider("Failing", Map.empty) {
+          override def initialize(ctx: OFEvaluationContext): Unit =
+            throw new RuntimeException("Initialization failed")
+        }
+        for {
+          ff <- buildWithDomain(providerA)
+          _  <- ff.setProvider(failingProvider).either
+          n  <- ZIO.succeed(initCount.get())
+        } yield assertTrue(n == 2)
+      }
+    },
+    test("failed swap re-attaches the previous EventProvider so its events still flow (#282)") {
+      // The detach->re-register round-trip must not sever event propagation: after rollback, A can still emit a
+      // configuration-changed event that reaches subscribers.
+      ZIO.scoped {
+        class EmittingProvider extends SimpleProvider("A", Map("flag" -> true)) {
+          def fireConfigChanged(): Unit =
+            emitProviderConfigurationChanged(dev.openfeature.sdk.ProviderEventDetails.builder().build())
+        }
+        val providerA = new EmittingProvider
+        val failingProvider = new SimpleProvider("Failing", Map.empty) {
+          override def initialize(ctx: OFEvaluationContext): Unit =
+            throw new RuntimeException("Initialization failed")
+        }
+        for {
+          ff       <- buildWithDomain(providerA)
+          received <- Queue.unbounded[ProviderEvent]
+          _        <- ff.on(ProviderEventType.ConfigurationChanged, e => received.offer(e).unit)
+          _        <- ff.setProvider(failingProvider).either
+          _        <- ZIO.attemptBlocking(providerA.fireConfigChanged()).orDie
+          ev <- received.take.timeoutFail(new RuntimeException("no config-changed event after rollback"))(5.seconds)
+        } yield assertTrue(ev.eventType == ProviderEventType.ConfigurationChanged)
+      }
+    },
+    test("failed swap eventually shuts the failed provider down (#282)") {
+      // On a successful rollback the SDK's shutDownOld tears down the failed provider (async).
+      ZIO.scoped {
+        val failShutdowns = new java.util.concurrent.atomic.AtomicInteger(0)
+        val providerA     = new SimpleProvider("A", Map("flag" -> true))
+        val failingProvider = new SimpleProvider("Failing", Map.empty) {
+          override def initialize(ctx: OFEvaluationContext): Unit =
+            throw new RuntimeException("Initialization failed")
+          override def shutdown(): Unit = { failShutdowns.incrementAndGet(); () }
+        }
+        for {
+          ff <- buildWithDomain(providerA)
+          _  <- ff.setProvider(failingProvider).either
+          _ <- ZIO
+            .succeed(failShutdowns.get())
+            .repeatUntil(_ >= 1)
+            .timeoutFail(new RuntimeException("failed provider never shut down"))(5.seconds)
+        } yield assertTrue(failShutdowns.get() >= 1)
+      }
+    },
+    test("rollback failure: old provider re-init throws leaves status Error, surfaces original error, no hang (#282)") {
+      // When the old provider's re-initialize() throws, rollback fails: setProvider still reports the ORIGINAL swap
+      // failure, status stays Error, and the call completes (no hang). The SDK slot was rebound to the old provider
+      // before its failing init ran, so evaluations still route to it.
+      ZIO.scoped {
+        val initCount = new java.util.concurrent.atomic.AtomicInteger(0)
+        // A succeeds on the first init (at build), throws on the second (rollback re-register).
+        val providerA = new SimpleProvider("A", Map("flag" -> true)) {
+          override def initialize(ctx: OFEvaluationContext): Unit =
+            if (initCount.incrementAndGet() >= 2) throw new RuntimeException("re-init boom") else ()
+        }
+        val failingProvider = new SimpleProvider("Failing", Map.empty) {
+          override def initialize(ctx: OFEvaluationContext): Unit =
+            throw new RuntimeException("original swap failure")
+        }
+        for {
+          ff <- buildWithDomain(providerA)
+          result <- ff
+            .setProvider(failingProvider)
+            .either
+            .timeoutFail(new RuntimeException("setProvider hung on rollback failure"))(10.seconds)
+          status <- ff.providerStatus
+          m      <- ff.providerMetadata
+        } yield assertTrue(result.isLeft) &&
+          assertTrue(result.left.toOption.get.isInstanceOf[FeatureFlagError.ProviderInitializationFailed]) &&
+          assertTrue(
+            result.left.toOption.get
+              .asInstanceOf[FeatureFlagError.ProviderInitializationFailed]
+              .underlying
+              .getMessage
+              .contains("original swap failure")
+          ) &&
+          assertTrue(status == ProviderStatus.Error) &&
+          assertTrue(m.name == "A")
+      }
+    },
+    test("shared provider bound to two domains: failed swap on one leaves the shared provider intact (#282)") {
+      // Decision-2 guard: one provider instance bound to two domains of the same API. A failed swap on domain 1 must
+      // NOT detach or re-initialize the shared provider (its READY manager on domain 2 is reused), so its events on
+      // domain 2 keep flowing and its init count does not grow.
+      ZIO.scoped {
+        val sharedInit = new java.util.concurrent.atomic.AtomicInteger(0)
+        class SharedProvider extends SimpleProvider("Shared", Map("flag" -> true)) {
+          override def initialize(ctx: OFEvaluationContext): Unit = { sharedInit.incrementAndGet(); () }
+          def fireConfigChanged(): Unit =
+            emitProviderConfigurationChanged(dev.openfeature.sdk.ProviderEventDetails.builder().build())
+        }
+        val shared = new SharedProvider
+        val failingProvider = new SimpleProvider("Failing", Map.empty) {
+          override def initialize(ctx: OFEvaluationContext): Unit =
+            throw new RuntimeException("Initialization failed")
+        }
+        val api = OpenFeatureAPIFactory.create()
+        val d1  = s"d1-${java.util.UUID.randomUUID()}"
+        val d2  = s"d2-${java.util.UUID.randomUUID()}"
+        for {
+          ff1 <- buildOn(api, d1, shared)
+          ff2 <- buildOn(api, d2, shared)
+          _   <- ZIO.attemptBlocking(Thread.sleep(50)).ignore
+          initBefore = sharedInit.get()
+          // Failed swap on domain 1; shared stays bound to domain 2, so rollback reuses its manager (no detach/re-init).
+          _        <- ff1.setProvider(failingProvider).either
+          received <- Queue.unbounded[ProviderEvent]
+          _        <- ff2.on(ProviderEventType.ConfigurationChanged, e => received.offer(e).unit)
+          _        <- ZIO.attemptBlocking(shared.fireConfigChanged()).orDie
+          ev <- received.take.timeoutFail(new RuntimeException("domain-2 events severed by domain-1 rollback"))(
+            5.seconds
+          )
+          initAfter = sharedInit.get()
+        } yield assertTrue(ev.eventType == ProviderEventType.ConfigurationChanged) &&
+          assertTrue(initAfter == initBefore)
       }
     }
   ) @@ TestAspect.sequential

--- a/core/src/test/scala/zio/openfeature/ProviderStatusMachineSpec.scala
+++ b/core/src/test/scala/zio/openfeature/ProviderStatusMachineSpec.scala
@@ -29,7 +29,7 @@ object ProviderStatusMachineSpec extends ZIOSpecDefault {
     Signal.SwapStarted       -> NotReady,
     Signal.SwapSucceeded     -> Ready,
     Signal.SwapFailed        -> Error,
-    Signal.ForceReady        -> Ready
+    Signal.RollbackSucceeded -> Ready
   )
 
   def spec = suite("ProviderStatusMachineSpec")(


### PR DESCRIPTION
Closes #282.

A failed provider hot-swap rolled back the internal `providerRef`/status but not the OpenFeature Java SDK's provider binding. The SDK (1.21.0) binds a new provider into its domain/default slot before calling `initialize()` and does not revert on a failed init, so after a failed swap, evaluations (routed via the SDK `Client`) kept returning the failed provider's values while `providerMetadata`/`providerStatus` claimed the previous provider was active.

## Fix
- New compile-time package shim `dev.openfeature.sdk.EventProviderAccess` (no reflection; same pattern as `OpenFeatureAPIFactory`) exposing `detach` + `deregisterGlobalProvider`.
- `restoreSdkRegistration` in `setProvider`'s rollback re-registers the previous provider with the SDK (catch-detach-retry-once for the `EventProvider` "already attached" case), reconciling routing.
- `cleanupUnboundFailedProvider` best-effort tears down the still-unbound failed provider on the rollback-failure path.
- `Signal.ForceReady` renamed to `Signal.RollbackSucceeded`, applied by `setProvider` itself; removes #281's `forceReady` workaround.

## Behavior change
After a failed swap whose rollback succeeds, `providerStatus` is now `Ready` (previous provider serving) and evaluations return the previous provider's values. If rollback itself fails, status stays `Error` and it is logged. `setProvider` still fails with `ProviderInitializationFailed` carrying the original error.

## Tests
8 new/updated hot-swap tests (domain + no-domain, re-init count, `EventProvider` re-attach, failed-provider shutdown, rollback-failure, shared-provider topology); `NonBlockingInitSpec` AC2b strengthened; `FeatureFlagRegistrySpec` updated for the new Ready-after-rollback behavior. Full suite green (928 tests, 0 failed).
