### PR TITLE
Add config-based FeatureFlags factory and deprecate overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`FeatureFlagsConfig` and the config-driven `FeatureFlags.fromProvider(provider, config)` factory** (#253). The 17
+  public factory overloads (`fromProvider*` / `fromProviderWithDomain*` / `fromProviderWithHooks*` /
+  `fromMultiProvider*`, sync and async) collapse to one config-driven entry point plus two kept shorthands
+  (`fromProvider(provider)`, `fromProviderAsync(provider)`). `FeatureFlagsConfig` composes `domain`, `version`,
+  `initialHooks`, `evaluationTimeout` (the #251 `EvaluationTimeout` ADT), `initTimeout`, and the new `InitMode`
+  (`Sync`/`Async`, replacing the sync/async factory-pair doubling) and `ApiOwnership` (`Auto`/`Owned`/`Shared`, making
+  the previously-implicit `WithDomain` shutdown-finalizer behavior an explicit, documented value — see #243) fields —
+  so combinations the old surface couldn't express (domain + hooks, domain + a per-instance evaluation timeout,
+  domain + version + a custom init timeout, hooks + init timeout on async init) are now one config value away. Added
+  `FeatureFlags.multiProvider(providers, strategy)` as the replacement for `fromMultiProvider*`, composable with every
+  other config field (e.g. multi-provider + domain).
+
 - **`OFREPProviderConfig` and scope-managed OFREP factories** (#268). `OFREPProvider.layer(...)` now uses
   `ZLayer.scoped` with a bounded shutdown finalizer (mirroring the Optimizely module), so the provider's executor and
   HttpClient are torn down on scope close instead of being orphaned — closing the JVM-exit-hang class (#217/#229) for a
@@ -26,6 +38,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   serving the last-known datafile, per OpenFeature STALE semantics), recovering to `PROVIDER_READY` on the next
   successful fetch. Configurable via `OptimizelyProviderConfig.staleAfter` (default `3 × pollingInterval`; disabled when
   polling is off). The watchdog thread is a daemon and is cancelled on shutdown.
+
+### Deprecated
+
+- **14 `FeatureFlags` factory overloads, superseded by `fromProvider(provider, config)`** (#253):
+  `fromProvider(p, evaluationTimeout)`, `fromProvider(p, evaluationTimeout, initTimeout)`,
+  `fromProviderWithDomain(p, domain[, version])`, `fromProviderWithHooks(p, hooks)`, `fromMultiProvider(ps[, strategy])`,
+  and their `*Async` twins `fromProviderAsync(p, evaluationTimeout[, initTimeout])`,
+  `fromProviderWithDomainAsync(p, domain[, version])`, `fromProviderWithHooksAsync(p, hooks)`, and
+  `fromMultiProviderAsync(ps[, strategy])`. Each forwards to an equivalent `fromProvider(p, FeatureFlagsConfig()...)`
+  call — see the `@deprecated` message on each overload for its exact one-line replacement. `fromProvider(provider)`
+  and `fromProviderAsync(provider)` are unaffected and remain the recommended shorthands for the common case.
 
 ### Fixed
 

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/MatrixHarness.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/MatrixHarness.scala
@@ -35,7 +35,7 @@ object MatrixHarness {
 
   /** A scoped ZLayer that owns one Rift mock space + one Optimizely provider for the named datafile.
     *
-    * Bound to a freshly-generated domain (`FeatureFlags.fromProviderWithDomain`) rather than the plain
+    * Bound to a freshly-generated domain (`FeatureFlagsConfig().withDomain(...)`) rather than the plain
     * `fromProvider` factory. `fromProvider` registers its provider as the *unnamed default* client on
     * the process-wide `OpenFeatureAPI` singleton — concurrent calls from different scenarios would race
     * to overwrite that single default slot, and since the OpenFeature SDK looks up the active provider
@@ -68,7 +68,7 @@ object MatrixHarness {
                   )
         provider <- OptimizelyProvider.scoped(config).mapError(e => new RuntimeException(e.message))
         domain    = s"flag-matrix-${java.util.UUID.randomUUID()}"
-        env      <- FeatureFlags.fromProviderWithDomain(provider, domain).build
+        env      <- FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain(domain)).build
         ff        = env.get[FeatureFlags]
         _ <- ZIO.foreachDiscard(plan)(p =>
                ff.setGlobalContext(EvaluationContext.empty.withAttribute("plan", AttributeValue.StringValue(p)))

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/ProxyMatrixHarness.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/ProxyMatrixHarness.scala
@@ -79,7 +79,7 @@ object ProxyMatrixHarness {
                  )
         provider <- OptimizelyProvider.scoped(config).mapError(e => new RuntimeException(e.message))
         domain = s"proxy-flag-matrix-${java.util.UUID.randomUUID()}"
-        env <- FeatureFlags.fromProviderWithDomain(provider, domain).build
+        env <- FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain(domain)).build
         ff = env.get[FeatureFlags]
         ctx = contextAttributes.foldLeft(EvaluationContext.empty) { case (acc, (k, v)) =>
                 acc.withAttribute(k, AttributeValue.StringValue(v))

--- a/core/src/main/scala/zio/openfeature/FeatureFlags.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlags.scala
@@ -726,37 +726,101 @@ object FeatureFlags {
       _ <- ff.startEventBridge
     } yield ff
 
+  /** The config-driven factory: every retired overload forwards here. See [[FeatureFlagsConfig]] for field semantics
+    * (`domain`, `version`, `initialHooks`, `evaluationTimeout`, `initTimeout`, `initMode`, `apiOwnership`).
+    *
+    * `FeatureFlagsConfig()` reproduces `fromProvider(provider)` exactly (sync init, no domain, `Owned` API — the `Auto`
+    * truth table's `domain.isEmpty` branch).
+    */
+  def fromProvider(provider: OFFeatureProvider, config: FeatureFlagsConfig): ZLayer[Scope, Throwable, FeatureFlags] =
+    fromProvider(provider, config, statusRef = None)
+
+  /** `private[openfeature]` variant of [[fromProvider(OFFeatureProvider, FeatureFlagsConfig)]] that additionally
+    * accepts a shared `statusRef`, an `apiOverride` (a private `OpenFeatureAPI` instead of the process-global
+    * singleton), and an `onReady` latch — the same knobs the legacy `private[openfeature]` statusRef overloads exposed,
+    * now available alongside the full `FeatureFlagsConfig` surface (e.g. `apiOwnership` overrides). Used by the testkit
+    * and by tests that need to observe `ApiOwnership` semantics against an isolated API.
+    */
+  private[openfeature] def fromProvider(
+    provider: OFFeatureProvider,
+    config: FeatureFlagsConfig,
+    statusRef: Option[SubscriptionRef[ProviderStatus]],
+    apiOverride: Option[OpenFeatureAPI] = None,
+    onReady: Option[java.util.concurrent.CountDownLatch] = None
+  ): ZLayer[Scope, Throwable, FeatureFlags] =
+    ZLayer.scoped {
+      val evalTimeout = config.evaluationTimeout match {
+        case EvaluationTimeout.Default  => Some(DefaultEvaluationTimeout)
+        case EvaluationTimeout.Disabled => None
+        case EvaluationTimeout.After(d) => Some(d)
+      }
+      val ownsApi = config.apiOwnership match {
+        case ApiOwnership.Auto   => config.domain.isEmpty
+        case ApiOwnership.Owned  => true
+        case ApiOwnership.Shared => false
+      }
+      config.initMode match {
+        case InitMode.Sync =>
+          build(
+            provider,
+            config.domain,
+            config.version,
+            config.initialHooks,
+            statusRef = statusRef,
+            addShutdownFinalizer = ownsApi,
+            apiOverride = apiOverride,
+            evaluationTimeout = evalTimeout,
+            initTimeout = config.initTimeout,
+            onReady = onReady
+          )
+        case InitMode.Async =>
+          buildAsync(
+            provider,
+            config.domain,
+            config.version,
+            config.initialHooks,
+            statusRef = statusRef,
+            addShutdownFinalizer = ownsApi,
+            apiOverride = apiOverride,
+            onReady = onReady,
+            evaluationTimeout = evalTimeout,
+            initTimeout = config.initTimeout
+          )
+      }
+    }
+
+  /** Combine multiple providers into one via the SDK's `MultiProvider`, defaulting to a first-match strategy. Pairs
+    * with [[fromProvider(OFFeatureProvider, FeatureFlagsConfig)]] to express combinations `fromMultiProvider` could
+    * not, e.g. multi-provider + domain: `fromProvider(multiProvider(ps), FeatureFlagsConfig(domain =
+    * Some("checkout")))`.
+    */
+  def multiProvider(
+    providers: List[OFFeatureProvider],
+    strategy: Strategy = new FirstMatchStrategy()
+  ): OFFeatureProvider = {
+    import scala.jdk.CollectionConverters._
+    new MultiProvider(providers.asJava, strategy)
+  }
+
   /** Create a FeatureFlags layer from any OpenFeature provider.
     *
     * Initialization is bounded by the default 30s init timeout: if `setProviderAndWait` takes longer, or the provider
     * reports `ERROR`/`FATAL`/`NOT_READY` afterwards, the layer build fails with a `TimeoutException` or
-    * `IllegalStateException` wrapped at the layer boundary. Use the overload that accepts an explicit `initTimeout` to
-    * raise/lower this bound; pass a very large duration (e.g. `365.days`) to effectively disable it.
+    * `IllegalStateException` wrapped at the layer boundary. Use `fromProvider(provider, FeatureFlagsConfig())` with
+    * `.withInitTimeout(...)` to override.
     */
   def fromProvider(provider: OFFeatureProvider): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      build(provider, domain = None, version = None, initialHooks = Nil, statusRef = None, addShutdownFinalizer = true)
-    )
+    fromProvider(provider, FeatureFlagsConfig())
 
   /** Create a FeatureFlags layer with a global evaluation timeout.
     *
     * If a provider evaluation takes longer than `evaluationTimeout`, it fails with `ProviderError` containing a
     * `TimeoutException`. This prevents hung providers from blocking fibers indefinitely. Per-call timeouts set via
-    * `EvaluationOptions.timeout` override this global default. Initialization uses the default 30s init timeout — see
-    * [[fromProvider(OFFeatureProvider, Duration, Duration)]] to override.
+    * `EvaluationOptions.timeout` override this global default. Initialization uses the default 30s init timeout.
     */
+  @deprecated("Use fromProvider(p, FeatureFlagsConfig().withEvaluationTimeout(evalTimeout))", "0.2.0")
   def fromProvider(provider: OFFeatureProvider, evaluationTimeout: Duration): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      build(
-        provider,
-        domain = None,
-        version = None,
-        initialHooks = Nil,
-        statusRef = None,
-        addShutdownFinalizer = true,
-        evaluationTimeout = Some(evaluationTimeout)
-      )
-    )
+    fromProvider(provider, FeatureFlagsConfig().withEvaluationTimeout(evaluationTimeout))
 
   /** Create a FeatureFlags layer with explicit evaluation and initialization timeouts.
     *
@@ -765,53 +829,30 @@ object FeatureFlags {
     * misconfiguration surfaces at startup rather than at first evaluation. Pass a very large duration to effectively
     * disable the init timeout.
     */
+  @deprecated(
+    "Use fromProvider(p, FeatureFlagsConfig().withEvaluationTimeout(evalT).withInitTimeout(initT))",
+    "0.2.0"
+  )
   def fromProvider(
     provider: OFFeatureProvider,
     evaluationTimeout: Duration,
     initTimeout: Duration
   ): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      build(
-        provider,
-        domain = None,
-        version = None,
-        initialHooks = Nil,
-        statusRef = None,
-        addShutdownFinalizer = true,
-        evaluationTimeout = Some(evaluationTimeout),
-        initTimeout = initTimeout
-      )
-    )
+    fromProvider(provider, FeatureFlagsConfig().withEvaluationTimeout(evaluationTimeout).withInitTimeout(initTimeout))
 
   /** Create a FeatureFlags layer with a named domain/client. */
+  @deprecated("Use fromProvider(p, FeatureFlagsConfig().withDomain(d))", "0.2.0")
   def fromProviderWithDomain(provider: OFFeatureProvider, domain: String): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      build(
-        provider,
-        domain = Some(domain),
-        version = None,
-        initialHooks = Nil,
-        statusRef = None,
-        addShutdownFinalizer = false
-      )
-    )
+    fromProvider(provider, FeatureFlagsConfig().withDomain(domain))
 
   /** Create a FeatureFlags layer with a named domain/client and version. */
+  @deprecated("Use fromProvider(p, FeatureFlagsConfig().withDomain(d).withVersion(v))", "0.2.0")
   def fromProviderWithDomain(
     provider: OFFeatureProvider,
     domain: String,
     version: String
   ): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      build(
-        provider,
-        domain = Some(domain),
-        version = Some(version),
-        initialHooks = Nil,
-        statusRef = None,
-        addShutdownFinalizer = false
-      )
-    )
+    fromProvider(provider, FeatureFlagsConfig().withDomain(domain).withVersion(version))
 
   /** Create a FeatureFlags layer with a named domain/client and a shared status ref. */
   private[openfeature] def fromProviderWithDomain(
@@ -835,35 +876,25 @@ object FeatureFlags {
     )
 
   /** Create a FeatureFlags layer from multiple providers using the first-match strategy. */
-  def fromMultiProvider(providers: List[OFFeatureProvider]): ZLayer[Scope, Throwable, FeatureFlags] = {
-    import scala.jdk.CollectionConverters._
-    fromProvider(new MultiProvider(providers.asJava))
-  }
+  @deprecated("Use fromProvider(FeatureFlags.multiProvider(ps), FeatureFlagsConfig())", "0.2.0")
+  def fromMultiProvider(providers: List[OFFeatureProvider]): ZLayer[Scope, Throwable, FeatureFlags] =
+    fromProvider(multiProvider(providers), FeatureFlagsConfig())
 
   /** Create a FeatureFlags layer from multiple providers with a custom strategy. */
+  @deprecated("Use fromProvider(FeatureFlags.multiProvider(ps, strategy), FeatureFlagsConfig())", "0.2.0")
   def fromMultiProvider(
     providers: List[OFFeatureProvider],
     strategy: Strategy
-  ): ZLayer[Scope, Throwable, FeatureFlags] = {
-    import scala.jdk.CollectionConverters._
-    fromProvider(new MultiProvider(providers.asJava, strategy))
-  }
+  ): ZLayer[Scope, Throwable, FeatureFlags] =
+    fromProvider(multiProvider(providers, strategy), FeatureFlagsConfig())
 
   /** Create a FeatureFlags layer with initial hooks. */
+  @deprecated("Use fromProvider(p, FeatureFlagsConfig().withHooks(hooks))", "0.2.0")
   def fromProviderWithHooks(
     provider: OFFeatureProvider,
     initialHooks: List[FeatureHook]
   ): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      build(
-        provider,
-        domain = None,
-        version = None,
-        initialHooks = initialHooks,
-        statusRef = None,
-        addShutdownFinalizer = true
-      )
-    )
+    fromProvider(provider, FeatureFlagsConfig().withHooks(initialHooks))
 
   // Async Factory Methods (non-blocking provider initialization)
 
@@ -947,98 +978,68 @@ object FeatureFlags {
     * The provider initializes in the background. Evaluations fail with `ProviderNotReady` until the provider is ready.
     * Use `onProviderReady` or `providerStatus` to detect when the provider becomes available. If the provider has not
     * become ready within the default 30s init timeout, status atomically transitions to `Fatal` so callers polling
-    * `providerStatus` stop waiting. See [[fromProviderAsync(OFFeatureProvider, Duration, Duration)]] to override.
+    * `providerStatus` stop waiting. Use `fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async))` with
+    * `.withInitTimeout(...)` to override.
     */
   def fromProviderAsync(provider: OFFeatureProvider): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      buildAsync(
-        provider,
-        domain = None,
-        version = None,
-        initialHooks = Nil,
-        statusRef = None,
-        addShutdownFinalizer = true
-      )
-    )
+    fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async))
 
   /** Create a FeatureFlags layer with a global evaluation timeout (non-blocking).
     *
     * Combines async initialization with evaluation timeout protection. The provider initializes in the background;
     * evaluations fail with `ProviderNotReady` until ready. Once ready, evaluations that exceed `evaluationTimeout` fail
-    * with `ProviderError` containing a `TimeoutException`. The init-side default 30s watchdog still applies — see
-    * [[fromProviderAsync(OFFeatureProvider, Duration, Duration)]] to override.
+    * with `ProviderError` containing a `TimeoutException`. The init-side default 30s watchdog still applies.
     */
+  @deprecated(
+    "Use fromProvider(p, FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(evalT))",
+    "0.2.0"
+  )
   def fromProviderAsync(
     provider: OFFeatureProvider,
     evaluationTimeout: Duration
   ): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      buildAsync(
-        provider,
-        domain = None,
-        version = None,
-        initialHooks = Nil,
-        statusRef = None,
-        addShutdownFinalizer = true,
-        evaluationTimeout = Some(evaluationTimeout)
-      )
-    )
+    fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(evaluationTimeout))
 
   /** Create a FeatureFlags layer with explicit evaluation and initialization timeouts (non-blocking).
     *
     * `initTimeout` bounds the async ready window: after that duration, if status is still `NotReady` or `Error`, it
     * atomically transitions to `Fatal`. Pass a very large duration to effectively disable the watchdog.
     */
+  @deprecated(
+    "Use fromProvider(p, FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(evalT).withInitTimeout(initT))",
+    "0.2.0"
+  )
   def fromProviderAsync(
     provider: OFFeatureProvider,
     evaluationTimeout: Duration,
     initTimeout: Duration
   ): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      buildAsync(
-        provider,
-        domain = None,
-        version = None,
-        initialHooks = Nil,
-        statusRef = None,
-        addShutdownFinalizer = true,
-        evaluationTimeout = Some(evaluationTimeout),
-        initTimeout = initTimeout
-      )
+    fromProvider(
+      provider,
+      FeatureFlagsConfig(initMode = InitMode.Async)
+        .withEvaluationTimeout(evaluationTimeout)
+        .withInitTimeout(initTimeout)
     )
 
   /** Create a FeatureFlags layer with a named domain (non-blocking). */
+  @deprecated("Use fromProvider(p, FeatureFlagsConfig(initMode = InitMode.Async).withDomain(d))", "0.2.0")
   def fromProviderWithDomainAsync(
     provider: OFFeatureProvider,
     domain: String
   ): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      buildAsync(
-        provider,
-        domain = Some(domain),
-        version = None,
-        initialHooks = Nil,
-        statusRef = None,
-        addShutdownFinalizer = false
-      )
-    )
+    fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async).withDomain(domain))
 
   /** Create a FeatureFlags layer with a named domain and version (non-blocking). */
+  @deprecated(
+    "Use fromProvider(p, FeatureFlagsConfig(initMode = InitMode.Async).withDomain(d).withVersion(v))",
+    "0.2.0"
+  )
   def fromProviderWithDomainAsync(
     provider: OFFeatureProvider,
     domain: String,
     version: String
   ): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      buildAsync(
-        provider,
-        domain = Some(domain),
-        version = Some(version),
-        initialHooks = Nil,
-        statusRef = None,
-        addShutdownFinalizer = false
-      )
-    )
+    fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async).withDomain(domain).withVersion(version))
 
   /** Create a FeatureFlags layer with a named domain and shared status ref (non-blocking). */
   private[openfeature] def fromProviderWithDomainAsync(
@@ -1062,35 +1063,31 @@ object FeatureFlags {
     )
 
   /** Create a FeatureFlags layer with initial hooks (non-blocking). */
+  @deprecated("Use fromProvider(p, FeatureFlagsConfig(initMode = InitMode.Async).withHooks(hooks))", "0.2.0")
   def fromProviderWithHooksAsync(
     provider: OFFeatureProvider,
     initialHooks: List[FeatureHook]
   ): ZLayer[Scope, Throwable, FeatureFlags] =
-    ZLayer.scoped(
-      buildAsync(
-        provider,
-        domain = None,
-        version = None,
-        initialHooks = initialHooks,
-        statusRef = None,
-        addShutdownFinalizer = true
-      )
-    )
+    fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async).withHooks(initialHooks))
 
   /** Create a FeatureFlags layer from multiple providers (non-blocking, first-match strategy). */
-  def fromMultiProviderAsync(providers: List[OFFeatureProvider]): ZLayer[Scope, Throwable, FeatureFlags] = {
-    import scala.jdk.CollectionConverters._
-    fromProviderAsync(new MultiProvider(providers.asJava))
-  }
+  @deprecated(
+    "Use fromProvider(FeatureFlags.multiProvider(ps), FeatureFlagsConfig(initMode = InitMode.Async))",
+    "0.2.0"
+  )
+  def fromMultiProviderAsync(providers: List[OFFeatureProvider]): ZLayer[Scope, Throwable, FeatureFlags] =
+    fromProvider(multiProvider(providers), FeatureFlagsConfig(initMode = InitMode.Async))
 
   /** Create a FeatureFlags layer from multiple providers with a custom strategy (non-blocking). */
+  @deprecated(
+    "Use fromProvider(FeatureFlags.multiProvider(ps, strategy), FeatureFlagsConfig(initMode = InitMode.Async))",
+    "0.2.0"
+  )
   def fromMultiProviderAsync(
     providers: List[OFFeatureProvider],
     strategy: Strategy
-  ): ZLayer[Scope, Throwable, FeatureFlags] = {
-    import scala.jdk.CollectionConverters._
-    fromProviderAsync(new MultiProvider(providers.asJava, strategy))
-  }
+  ): ZLayer[Scope, Throwable, FeatureFlags] =
+    fromProvider(multiProvider(providers, strategy), FeatureFlagsConfig(initMode = InitMode.Async))
 
   /** Default `compose` for [[fromAcquireAsync]]: layer the real provider over the fallback with a first-successful
     * strategy, so a sick real provider transparently falls through to the fallback. `MultiProvider` keys children by

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsConfig.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsConfig.scala
@@ -1,0 +1,78 @@
+package zio.openfeature
+
+import zio._
+
+/** Everything the `FeatureFlags.fromProvider(provider, config)` factory can configure, in one place. All fields have
+  * defaults; `FeatureFlagsConfig()` reproduces `FeatureFlags.fromProvider(provider)` exactly.
+  */
+final case class FeatureFlagsConfig(
+  domain: Option[String] = None,
+  version: Option[String] = None,
+  initialHooks: List[FeatureHook] = Nil,
+  evaluationTimeout: EvaluationTimeout = EvaluationTimeout.Default,
+  initTimeout: Duration = FeatureFlags.DefaultInitTimeout,
+  initMode: InitMode = InitMode.Sync,
+  apiOwnership: ApiOwnership = ApiOwnership.Auto
+) {
+  def withDomain(d: String): FeatureFlagsConfig               = copy(domain = Some(d))
+  def withVersion(v: String): FeatureFlagsConfig              = copy(version = Some(v))
+  def withHooks(hooks: List[FeatureHook]): FeatureFlagsConfig = copy(initialHooks = hooks)
+  def withHook(hook: FeatureHook): FeatureFlagsConfig         = copy(initialHooks = initialHooks :+ hook)
+  def withEvaluationTimeout(d: Duration): FeatureFlagsConfig  = copy(evaluationTimeout = EvaluationTimeout.After(d))
+  def withoutEvaluationTimeout: FeatureFlagsConfig            = copy(evaluationTimeout = EvaluationTimeout.Disabled)
+  def withInitTimeout(d: Duration): FeatureFlagsConfig        = copy(initTimeout = d)
+  def withAsyncInit: FeatureFlagsConfig                       = copy(initMode = InitMode.Async)
+  def withSyncInit: FeatureFlagsConfig                        = copy(initMode = InitMode.Sync)
+  def withApiOwnership(o: ApiOwnership): FeatureFlagsConfig   = copy(apiOwnership = o)
+}
+
+/** How the provider is initialized.
+  *
+  *   - [[InitMode.Sync]] — `setProviderAndWait`. The layer build blocks until the provider reaches `READY`/`STALE` or
+  *     `initTimeout` elapses; misconfiguration (a bad SDK key, an unreachable endpoint) fails the layer build itself,
+  *     so it surfaces at startup rather than at first evaluation.
+  *   - [[InitMode.Async]] — `setProvider`. The layer builds immediately; evaluations fail with `ProviderNotReady` until
+  *     the provider becomes `Ready`. The `initTimeout` watchdog still runs in the background and flips status to
+  *     `Fatal` if the provider never becomes usable within that window.
+  */
+sealed trait InitMode
+object InitMode {
+  case object Sync  extends InitMode
+  case object Async extends InitMode
+}
+
+/** Who owns the underlying `OpenFeatureAPI`'s lifecycle — i.e. whether this instance's scope closing (or an explicit
+  * `shutdown` call) also shuts down the API, and with it every provider registered on it.
+  *
+  * '''Auto (default) truth table''' — mirrors the pre-#253 implicit behavior, now made explicit:
+  *
+  *   - `domain.isEmpty` -> [[ApiOwnership.Owned]]: this is a sole-owner client on the process-global (or
+  *     caller-supplied) API. Nobody else can reasonably be sharing an unnamed default client, so scope close /
+  *     `shutdown` tears down the API (and its provider) — matching `FeatureFlags.fromProvider`'s historical
+  *     `addShutdownFinalizer = true`.
+  *   - `domain.isDefined` -> [[ApiOwnership.Shared]]: a named domain almost always means multiple domain clients are
+  *     sharing one process-global `OpenFeatureAPI` (see #243). If a domain client shut the API down, every sibling
+  *     domain's provider would die with it. So by default a domain-scoped client leaves the API alone; the API's actual
+  *     owner (e.g. `FeatureFlagRegistry`, or whoever constructed it) is responsible for shutting it down once.
+  *
+  * Override the default when the truth table doesn't match your topology:
+  *
+  *   - [[ApiOwnership.Owned]] — force ownership even with a domain set (e.g. a single-domain app that still wants
+  *     scope-close to tear the API down).
+  *   - [[ApiOwnership.Shared]] — force non-ownership even without a domain (e.g. a caller-supplied `apiOverride` that
+  *     something else already owns).
+  */
+sealed trait ApiOwnership
+object ApiOwnership {
+
+  /** `domain.isEmpty => Owned`, `domain.isDefined => Shared` — see the [[ApiOwnership]] scaladoc for the full
+    * rationale.
+    */
+  case object Auto extends ApiOwnership
+
+  /** Scope close / `shutdown` tears down the underlying API (and every provider registered on it). */
+  case object Owned extends ApiOwnership
+
+  /** Scope close / `shutdown` leaves the underlying API untouched — sibling clients sharing it keep working. */
+  case object Shared extends ApiOwnership
+}

--- a/core/src/main/scala/zio/openfeature/MultiProviderStrategy.scala
+++ b/core/src/main/scala/zio/openfeature/MultiProviderStrategy.scala
@@ -2,7 +2,7 @@ package zio.openfeature
 
 import dev.openfeature.sdk.multiprovider.{FirstMatchStrategy, FirstSuccessfulStrategy}
 
-/** Built-in strategies for [[FeatureFlags.fromMultiProvider]] and [[FeatureFlags.fromMultiProviderAsync]].
+/** Built-in strategies for [[FeatureFlags.multiProvider]].
   *
   * Re-exports the Java SDK's strategy implementations under stable Scala names so callers do not need to depend on the
   * `dev.openfeature.sdk.multiprovider` package directly.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,12 +115,12 @@ FeatureFlags.fromProvider(provider)
 
 | Method | Description |
 |:-------|:------------|
-| `fromProvider(provider)` | Create from any OpenFeature provider |
-| `fromProviderWithDomain(provider, domain)` | Create with named domain/client |
-| `fromProviderWithDomain(provider, domain, version)` | Create with domain and version |
-| `fromProviderWithHooks(provider, hooks)` | Create with initial hooks |
-| `fromMultiProvider(providers)` | Combine multiple providers (first-match strategy) |
-| `fromMultiProvider(providers, strategy)` | Combine multiple providers with custom strategy |
+| `fromProvider(provider)` | Create from any OpenFeature provider (blocking init) |
+| `fromProviderAsync(provider)` | Create from any OpenFeature provider (non-blocking init) |
+| `fromProvider(provider, config)` | The config-driven factory — domain, version, hooks, timeouts, `InitMode`, `ApiOwnership`, in any combination, via [`FeatureFlagsConfig`](providers.md#featureflagsconfig) |
+| `FeatureFlags.multiProvider(providers, strategy)` | Combine multiple providers into one `OFFeatureProvider` (first-match strategy by default), to pass into `fromProvider` |
+
+See [Factory Methods](providers.md#factory-methods) for the full `FeatureFlagsConfig` reference.
 
 ---
 

--- a/docs/extras.md
+++ b/docs/extras.md
@@ -152,7 +152,7 @@ val provider = EnvVarProvider.withLookup(testEnv.get)
 
 ## Deferred Provider
 
-`DeferredProvider` adapts a **constructor-blocking** provider — one that does all its network work in its Java constructor — into an `initialize()`-blocking one. It defers construction to `initialize(ctx)`, which the OpenFeature SDK runs on its own init executor, so every `*Async` factory (`fromProviderAsync`, `fromMultiProviderAsync`) already keeps that work off the caller's thread.
+`DeferredProvider` adapts a **constructor-blocking** provider — one that does all its network work in its Java constructor — into an `initialize()`-blocking one. It defers construction to `initialize(ctx)`, which the OpenFeature SDK runs on its own init executor, so any `InitMode.Async` config already keeps that work off the caller's thread.
 
 ```scala
 import zio.openfeature.extras.DeferredProvider
@@ -259,7 +259,7 @@ How a downstream failure shows up depends on where it originates:
 
 - **HTTP `4xx` / `5xx` from the OFREP endpoint**: the contrib provider catches the response and returns a successful `FlagResolution` with `errorCode` populated (typically `General`) and `errorMessage` set. The ZIO `FeatureFlags` layer hands this back to callers as a *successful* effect — operators are expected to alert on `resolution.errorCode.isDefined`.
 - **Network-level failures** (DNS, `ConnectException`, connection reset): the contrib provider's HTTP client throws synchronously, the throw escapes `attemptBlocking`, and `FeatureFlagError.classify` maps it to a typed error — `Unreachable` for the known network exception types, `ProviderError` as the fallback. These arrive in the effect's error channel.
-- **Evaluation timeout** (via `FeatureFlags.fromProvider(provider, evaluationTimeout)`): surfaces as `ProviderError` wrapping a `TimeoutException`.
+- **Evaluation timeout** (via `FeatureFlagsConfig().withEvaluationTimeout(d)`): surfaces as `ProviderError` wrapping a `TimeoutException`.
 
 The `OFREPFailureModeSpec` in this module pins these behaviours so a contrib-provider upgrade doesn't silently shift them. If you build alerting on top of the OFREP integration, alert on both branches: `errorCode` on resolutions AND `Unreachable`/`ProviderError`/timeout in the error channel.
 
@@ -313,9 +313,9 @@ val resilientProvider = CircuitBreakerProvider(
 )
 
 // Compose with fallback using MultiProvider
-val layer = FeatureFlags.fromMultiProvider(
-  List(resilientProvider, EnvVarProvider()),
-  MultiProviderStrategy.firstSuccessful
+val layer = FeatureFlags.fromProvider(
+  FeatureFlags.multiProvider(List(resilientProvider, EnvVarProvider()), MultiProviderStrategy.firstSuccessful),
+  FeatureFlagsConfig()
 )
 ```
 
@@ -326,9 +326,9 @@ for
   cb   <- CircuitBreakerProvider.make(optimizelyProvider, CircuitBreakerConfig(
              evaluationTimeout = 50.millis
            ))
-  layer = FeatureFlags.fromMultiProvider(
-            List(cb, EnvVarProvider()),
-            MultiProviderStrategy.firstSuccessful
+  layer = FeatureFlags.fromProvider(
+            FeatureFlags.multiProvider(List(cb, EnvVarProvider()), MultiProviderStrategy.firstSuccessful),
+            FeatureFlagsConfig()
           )
 yield layer
 ```
@@ -485,7 +485,7 @@ object MyApp extends ZIOAppDefault:
                       )
 
     // Combine: env vars → HOCON → cached remote
-    layer = FeatureFlags.fromMultiProvider(List(envProvider, hoconProvider, cachedRemote))
+    layer = FeatureFlags.fromProvider(FeatureFlags.multiProvider(List(envProvider, hoconProvider, cachedRemote)), FeatureFlagsConfig())
 
     // Use feature flags
     _ <- FeatureFlags.boolean("new-checkout", default = false).flatMap { enabled =>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -215,35 +215,40 @@ val provider: FeatureProvider = // any OpenFeature provider
 val layer = FeatureFlags.fromProvider(provider)
 ```
 
-### With Domain Isolation
+### With Domain Isolation, Hooks, Timeouts, ...
 
-For multi-provider setups, use domains to isolate providers:
+Anything beyond the plain provider — a named domain, initial hooks, custom timeouts, async init, or any combination —
+goes through `FeatureFlagsConfig` and the config-driven factory `FeatureFlags.fromProvider(provider, config)`:
 
 ```scala
-val layer = FeatureFlags.fromProviderWithDomain(provider, "my-domain")
+// Domain isolation, for multi-provider setups
+val layer = FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain("my-domain"))
 
 // Optionally include a version for telemetry/debugging
-val versionedLayer = FeatureFlags.fromProviderWithDomain(provider, "my-domain", "1.0.0")
-```
+val versionedLayer = FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain("my-domain").withVersion("1.0.0"))
 
-### With Initial Hooks
-
-```scala
+// Initial hooks
 val hooks = List(
   FeatureHook.logging(),
   FeatureHook.metrics((k, d, s) => ZIO.unit)
 )
+val hookedLayer = FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withHooks(hooks))
 
-val layer = FeatureFlags.fromProviderWithHooks(provider, hooks)
+// Domain + hooks together — not expressible with the pre-#253 factory overloads
+val combinedLayer = FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain("my-domain").withHooks(hooks))
 ```
 
 ### With Multiple Providers
 
-Combine multiple providers using the SDK's MultiProvider support:
+Combine multiple providers using the SDK's MultiProvider support via `FeatureFlags.multiProvider`, then pass the
+result into `fromProvider` like any other provider:
 
 ```scala
-val layer = FeatureFlags.fromMultiProvider(List(localProvider, remoteProvider))
+val layer = FeatureFlags.fromProvider(FeatureFlags.multiProvider(List(localProvider, remoteProvider)), FeatureFlagsConfig())
 ```
+
+See [Factory Methods](providers.md#factory-methods) in the Providers guide for the full `FeatureFlagsConfig`
+reference, including `InitMode` (sync vs async) and `ApiOwnership`.
 
 ## Tracking Events
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -392,7 +392,7 @@ val hooks = List(
   FeatureHook.metrics((k, d, s) => ZIO.unit)
 )
 
-val layer = FeatureFlags.fromProviderWithHooks(provider, hooks)
+val layer = FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withHooks(hooks))
 
 // Remove all client hooks
 FeatureFlags.clearHooks

--- a/docs/optimizely.md
+++ b/docs/optimizely.md
@@ -82,13 +82,12 @@ The 30-second default is friendly for most apps. You'll want to tune it in three
 - **Cold start on a constrained network** — raise it if your CI runners or first production deploys regularly need >30 s for the initial datafile fetch.
 - **Run-anywhere CLIs** — set it lower (5–10 s) so users on flaky networks get a clear startup error instead of waiting half a minute.
 
-Override via the 3-arg async factory:
+Override via `FeatureFlagsConfig`:
 
 ```scala
-FeatureFlags.fromProviderAsync(
+FeatureFlags.fromProvider(
   provider,
-  evaluationTimeout = 500.millis,
-  initTimeout       = 5.seconds
+  FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(500.millis).withInitTimeout(5.seconds)
 )
 ```
 
@@ -137,7 +136,7 @@ val program = ZIO.scoped {
     sdkKey   <- ZIO.attempt(sys.env("OPTIMIZELY_SDK_KEY"))
     inner    <- OptimizelyProvider.make(sdkKey).mapError(e => new RuntimeException(e.message))
     wrapped  <- CircuitBreakerProvider.make(inner, breakerConfig)
-    env      <- FeatureFlags.fromProviderAsync(wrapped, evaluationTimeout = 500.millis).build
+    env      <- FeatureFlags.fromProvider(wrapped, FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(500.millis)).build
     ff        = env.get[FeatureFlags]
     enabled  <- ff.boolean("flag", default = false).mapError(e => new RuntimeException(e.message))
   yield enabled
@@ -283,8 +282,8 @@ Highest availability after boot, but during the cold-start window every flag ret
 ZIO.scoped {
   for
     provider <- OptimizelyProvider.make(sys.env("OPTIMIZELY_SDK_KEY"))
-    env      <- FeatureFlags.fromProviderAsync(provider, evaluationTimeout = 500.millis).build
-    // initTimeout uses the library default (30 s); override via the 3-arg overload
+    env      <- FeatureFlags.fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(500.millis)).build
+    // initTimeout uses the library default (30 s); override via .withInitTimeout(...)
   yield env.get[FeatureFlags]
 }
 ```
@@ -303,8 +302,9 @@ ZIO.scoped {
     provider <- OptimizelyProvider.make(sys.env("OPTIMIZELY_SDK_KEY"))
     env      <- FeatureFlags.fromProvider(
                   provider,
-                  evaluationTimeout = 500.millis,
-                  initTimeout       = 15.seconds   // tight — fail fast on misconfig
+                  FeatureFlagsConfig()
+                    .withEvaluationTimeout(500.millis)
+                    .withInitTimeout(15.seconds)   // tight — fail fast on misconfig
                 ).build
   yield env.get[FeatureFlags]
 }
@@ -332,9 +332,9 @@ ZIO.scoped {
   for
     optimizely <- OptimizelyProvider.make(sys.env("OPTIMIZELY_SDK_KEY"))
     envProvider = EnvVarProvider.withLookup(critical.get)
-    env        <- FeatureFlags.fromMultiProviderAsync(
-                    List(optimizely, envProvider),
-                    new FirstSuccessfulStrategy()
+    env        <- FeatureFlags.fromProvider(
+                    FeatureFlags.multiProvider(List(optimizely, envProvider), new FirstSuccessfulStrategy()),
+                    FeatureFlagsConfig(initMode = InitMode.Async)
                   ).build
   yield env.get[FeatureFlags]
 }

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -94,7 +94,7 @@ object MyApp extends ZIOAppDefault:
   }
 ```
 
-`OptimizelyProvider.make(sdkKey)` validates the key shape (non-empty, allowed characters, not a known placeholder) and returns `FeatureFlagError.InvalidConfiguration` on bad input. The async layer uses the library's default 30-second `initTimeout`; override via `FeatureFlags.fromProviderAsync(provider, evaluationTimeout = 500.millis, initTimeout = 5.seconds)`.
+`OptimizelyProvider.make(sdkKey)` validates the key shape (non-empty, allowed characters, not a known placeholder) and returns `FeatureFlagError.InvalidConfiguration` on bad input. The async layer uses the library's default 30-second `initTimeout`; override via `FeatureFlags.fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(500.millis).withInitTimeout(5.seconds))`.
 
 ### User Targeting
 
@@ -248,27 +248,111 @@ object MyApp extends ZIOAppDefault:
 
 ## Factory Methods
 
-ZIO OpenFeature provides several factory methods to create the `FeatureFlags` layer:
-
-### fromProvider
-
-Create from any OpenFeature provider:
+Two shorthands cover the overwhelmingly common cases:
 
 ```scala
 import dev.openfeature.sdk.FeatureProvider
 
 val provider: FeatureProvider = new OptimizelyProvider(config)
 
+// Blocking init — layer build waits for the provider to become ready
 val layer: ZLayer[Scope, Throwable, FeatureFlags] =
   FeatureFlags.fromProvider(provider)
+
+// Non-blocking init — layer builds immediately, provider becomes ready in the background
+val asyncLayer: ZLayer[Scope, Throwable, FeatureFlags] =
+  FeatureFlags.fromProviderAsync(provider)
 ```
 
-### fromProvider with evaluation timeout
-
-Create with a global evaluation timeout to prevent hung providers from blocking fibers indefinitely. If a provider evaluation takes longer than the timeout, it fails with `ProviderError` containing a `TimeoutException`.
+Everything else — a named domain, initial hooks, a custom evaluation/init timeout, async initialization, or any
+*combination* of those — goes through `FeatureFlagsConfig` and the single config-driven factory,
+`FeatureFlags.fromProvider(provider, config)`:
 
 ```scala
-val layer = FeatureFlags.fromProvider(provider, evaluationTimeout = 500.millis)
+val layer: ZLayer[Scope, Throwable, FeatureFlags] =
+  FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain("checkout").withHooks(myHooks))
+```
+
+`FeatureFlagsConfig()` (all defaults) reproduces `fromProvider(provider)` exactly, so there's one code path
+underneath every factory call, however it's spelled.
+
+### FeatureFlagsConfig
+
+| Field | Default | Set via |
+|:------|:--------|:--------|
+| `domain` | `None` | `.withDomain(d)` |
+| `version` | `None` | `.withVersion(v)` (requires `domain`) |
+| `initialHooks` | `Nil` | `.withHooks(hooks)` / `.withHook(hook)` |
+| `evaluationTimeout` | `EvaluationTimeout.Default` (1 second) | `.withEvaluationTimeout(d)` / `.withoutEvaluationTimeout` |
+| `initTimeout` | 30 seconds | `.withInitTimeout(d)` |
+| `initMode` | `InitMode.Sync` | `.withAsyncInit` / `.withSyncInit`, or the constructor arg `initMode = InitMode.Async` |
+| `apiOwnership` | `ApiOwnership.Auto` | `.withApiOwnership(o)` |
+
+**Combinations that were inexpressible before #253** are now one config value away:
+
+```scala
+// Named domain + initial hooks
+FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain("checkout").withHooks(myHooks))
+
+// Named domain + a per-instance evaluation timeout
+FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain("checkout").withEvaluationTimeout(300.millis))
+
+// Named domain + version + a custom init timeout
+FeatureFlags.fromProvider(
+  provider,
+  FeatureFlagsConfig().withDomain("checkout").withVersion("1.4.0").withInitTimeout(10.seconds)
+)
+
+// Initial hooks + a custom init timeout, non-blocking
+FeatureFlags.fromProvider(
+  provider,
+  FeatureFlagsConfig(initMode = InitMode.Async).withHooks(myHooks).withInitTimeout(45.seconds)
+)
+
+// Multi-provider + a named domain (see FeatureFlags.multiProvider below)
+FeatureFlags.fromProvider(
+  FeatureFlags.multiProvider(List(localProvider, remoteProvider)),
+  FeatureFlagsConfig().withDomain("checkout")
+)
+```
+
+### InitMode — sync vs async
+
+`FeatureFlagsConfig.initMode` replaces the old sync/async *factory pairs* (`fromProvider*` vs `fromProvider*Async`)
+with a single field:
+
+- **`InitMode.Sync`** (default) — `setProviderAndWait`. Layer build blocks until the provider is `READY`/`STALE` or
+  `initTimeout` elapses; misconfiguration fails the build itself.
+- **`InitMode.Async`** — `setProvider`. Layer build returns immediately; evaluations fail `ProviderNotReady` until the
+  provider becomes ready. The `initTimeout` watchdog still runs in the background — see
+  [Async Variants](#async-variants-non-blocking-initialization) below.
+
+### ApiOwnership — the domain/finalizer relationship, made explicit
+
+Before #253, whether a factory registered an API-shutdown finalizer was an invisible side effect of which factory
+name you called (`fromProvider` did; `fromProviderWithDomain` didn't). `FeatureFlagsConfig.apiOwnership` makes that
+choice a first-class, documented value:
+
+| `apiOwnership` | Behavior |
+|:---------------|:---------|
+| `ApiOwnership.Auto` (default) | `domain.isEmpty => Owned`, `domain.isDefined => Shared` — the historical behavior |
+| `ApiOwnership.Owned` | Scope close / `shutdown` tears down the underlying API, and with it every provider registered on it |
+| `ApiOwnership.Shared` | Scope close / `shutdown` leaves the API untouched — sibling domain clients sharing it keep working |
+
+The `Auto` default exists because a named domain almost always means several domain clients share one process-global
+`OpenFeatureAPI` (see [Provider Registry](#provider-registry) and #243) — if a domain client tore the whole API down,
+every sibling domain would die with it. An unnamed default client, by contrast, is presumed to be the sole owner.
+Override the default (`.withApiOwnership(ApiOwnership.Owned)` / `.withApiOwnership(ApiOwnership.Shared)`) when your
+topology doesn't match the truth table — e.g. a single-domain app that still wants scope-close to tear the API down.
+
+### Evaluation timeout
+
+`FeatureFlagsConfig.evaluationTimeout` sets a global evaluation timeout to prevent hung providers from blocking
+fibers indefinitely. If a provider evaluation takes longer than the timeout, it fails with `ProviderError` containing
+a `TimeoutException`.
+
+```scala
+FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withEvaluationTimeout(500.millis))
 ```
 
 When the timeout fires, the calling fiber receives the error immediately. The underlying provider thread completes naturally in the background (it is not interrupted, avoiding potential corruption of provider internal state).
@@ -286,17 +370,19 @@ val unbounded = ff.booleanDetails("flag", default = false, options = EvaluationO
 ```
 
 `EvaluationOptions.timeout` is an `EvaluationTimeout` — `Default` (defer to the instance global), `Disabled` (via
-`withoutTimeout`), or `After(d)` (via `withTimeout(d)`).
+`withoutTimeout`), or `After(d)` (via `withTimeout(d)`). `FeatureFlagsConfig.evaluationTimeout` is the same
+`EvaluationTimeout` ADT — `Default` maps to the library's 1-second default, `Disabled` (`.withoutEvaluationTimeout`)
+turns the global timeout off entirely, and `After(d)` (`.withEvaluationTimeout(d)`) sets it.
 
 | Setting | Scope | Default |
 |:--------|:------|:--------|
-| `fromProvider(provider, evaluationTimeout)` | All evaluations on this instance | `Some(1.second)` — `FeatureFlags.DefaultEvaluationTimeout` |
+| `FeatureFlagsConfig().withEvaluationTimeout(d)` / `.withoutEvaluationTimeout` | All evaluations on this instance | `EvaluationTimeout.Default` — `FeatureFlags.DefaultEvaluationTimeout` (1 second) |
 | `EvaluationOptions.empty.withTimeout(duration)` / `.withoutTimeout` | Single evaluation call | `EvaluationTimeout.Default` (uses the global) |
 
 Per-call timeout takes precedence over global. The global default is **1 second**, applied to every evaluation unless
 overridden — so a hung provider can't block a fiber indefinitely out of the box, but a cold-start remote provider may
-time out on its first calls. Pass `evaluationTimeout = Some(largerDuration)` to raise the bound or
-`evaluationTimeout = None` to disable it globally; per call, use `.withTimeout(d)` / `.withoutTimeout`.
+time out on its first calls. Use `.withEvaluationTimeout(largerDuration)` to raise the bound or
+`.withoutEvaluationTimeout` to disable it globally; per call, use `.withTimeout(d)` / `.withoutTimeout`.
 
 ### Runtime provider replacement (hot-swap)
 
@@ -377,18 +463,18 @@ ff.setProvider(cb)
 FeatureFlags.setProvider(newProvider)
 ```
 
-### fromProviderWithDomain
+### Named domains
 
 Create with a named domain. Each domain gets its own client, useful for segmenting feature flag configuration:
 
 ```scala
-val layer = FeatureFlags.fromProviderWithDomain(provider, "my-service")
+val layer = FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain("my-service"))
 ```
 
-Optionally include a version string (useful for telemetry and debugging):
+Optionally include a version string (useful for telemetry and debugging; requires `domain`):
 
 ```scala
-val layer = FeatureFlags.fromProviderWithDomain(provider, "my-service", "1.2.3")
+val layer = FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain("my-service").withVersion("1.2.3"))
 ```
 
 The version is available via `clientMetadata`:
@@ -402,9 +488,7 @@ for {
 
 > For test isolation, prefer `TestFeatureProvider.layer` which automatically creates isolated API instances.
 
-### fromProviderWithHooks
-
-Create with initial hooks:
+### Initial hooks
 
 ```scala
 val hooks = List(
@@ -412,12 +496,12 @@ val hooks = List(
   FeatureHook.metrics((k, d, s) => ZIO.unit)
 )
 
-val layer = FeatureFlags.fromProviderWithHooks(provider, hooks)
+val layer = FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withHooks(hooks))
 ```
 
-### fromMultiProvider
+### FeatureFlags.multiProvider
 
-Create from multiple providers using the SDK's MultiProvider support. By default this uses the first-match strategy — the first provider whose result is not a default value is returned (a provider error from any source aborts the chain):
+Combine multiple providers using the SDK's MultiProvider support. By default this uses the first-match strategy — the first provider whose result is not a default value is returned (a provider error from any source aborts the chain):
 
 ```scala
 import dev.openfeature.sdk.FeatureProvider
@@ -426,7 +510,7 @@ val localProvider: FeatureProvider = // local overrides
 val remoteProvider: FeatureProvider = // remote service
 
 // Uses first-match strategy by default
-val layer = FeatureFlags.fromMultiProvider(List(localProvider, remoteProvider))
+val layer = FeatureFlags.fromProvider(FeatureFlags.multiProvider(List(localProvider, remoteProvider)), FeatureFlagsConfig())
 ```
 
 You can also supply a custom strategy. The two built-in strategies are exposed via `MultiProviderStrategy` so you don't need to import the Java SDK's multiprovider package directly:
@@ -434,56 +518,69 @@ You can also supply a custom strategy. The two built-in strategies are exposed v
 ```scala
 import zio.openfeature.MultiProviderStrategy
 
-val layer = FeatureFlags.fromMultiProvider(
-  List(primaryProvider, fallbackProvider),
-  MultiProviderStrategy.firstSuccessful
+val layer = FeatureFlags.fromProvider(
+  FeatureFlags.multiProvider(List(primaryProvider, fallbackProvider), MultiProviderStrategy.firstSuccessful),
+  FeatureFlagsConfig()
 )
 ```
 
-`MultiProviderStrategy.firstMatch` and `MultiProviderStrategy.firstSuccessful` are the two built-ins. For a custom strategy, implement the `MultiProviderStrategy.Strategy` interface (an alias for the Java SDK's `Strategy`) and pass an instance the same way.
+`MultiProviderStrategy.firstMatch` and `MultiProviderStrategy.firstSuccessful` are the two built-ins. For a custom strategy, implement the `MultiProviderStrategy.Strategy` interface (an alias for the Java SDK's `Strategy`) and pass an instance the same way. Because `multiProvider` just returns an `OFFeatureProvider`, it composes with every other `FeatureFlagsConfig` field — e.g. `FeatureFlags.fromProvider(FeatureFlags.multiProvider(ps), FeatureFlagsConfig().withDomain("checkout"))`, which the old `fromMultiProvider` factory could not express.
 
 ### Initialization Timeout
 
-Every `fromProvider` and `fromProviderAsync` factory bounds initialization at **30 seconds by default**. The bound applies to both modes:
+Every layer bounds initialization at **30 seconds by default** (`FeatureFlagsConfig.initTimeout`). The bound applies to both `InitMode` values:
 
-- **Sync (`fromProvider`)**: if `setProviderAndWait` takes longer than `initTimeout`, the layer build fails with a `TimeoutException`. After init returns, the library verifies the provider's actual state — anything other than `READY` / `STALE` fails the build with an `IllegalStateException`, so a wrong SDK key or unreachable endpoint surfaces at startup instead of returning default values on every evaluation.
-- **Async (`fromProviderAsync`)**: a watchdog fiber forked into the layer's `Scope` sleeps `initTimeout`, then escalates to `Fatal` **only if the provider never became usable** — i.e. it is still `NotReady` / `Error` and has never reached `Ready` / `Stale`. A provider that reached `Ready` before the deadline (even if it has since dipped into a transient `Error`) is left running untouched. On escalation the watchdog also shuts the provider down (so its poller/HTTP threads don't outlive the layer) and publishes a `ProviderEvent.Error` carrying `ErrorCode.ProviderFatal`. Callers polling `providerStatus` stop waiting. Because the provider is shut down, this `Fatal` is terminal (see [Recovery semantics under `Fatal`](#recovery-semantics-under-fatal)).
+- **Sync (`InitMode.Sync`, the default)**: if `setProviderAndWait` takes longer than `initTimeout`, the layer build fails with a `TimeoutException`. After init returns, the library verifies the provider's actual state — anything other than `READY` / `STALE` fails the build with an `IllegalStateException`, so a wrong SDK key or unreachable endpoint surfaces at startup instead of returning default values on every evaluation.
+- **Async (`InitMode.Async`)**: a watchdog fiber forked into the layer's `Scope` sleeps `initTimeout`, then escalates to `Fatal` **only if the provider never became usable** — i.e. it is still `NotReady` / `Error` and has never reached `Ready` / `Stale`. A provider that reached `Ready` before the deadline (even if it has since dipped into a transient `Error`) is left running untouched. On escalation the watchdog also shuts the provider down (so its poller/HTTP threads don't outlive the layer) and publishes a `ProviderEvent.Error` carrying `ErrorCode.ProviderFatal`. Callers polling `providerStatus` stop waiting. Because the provider is shut down, this `Fatal` is terminal (see [Recovery semantics under `Fatal`](#recovery-semantics-under-fatal)).
 
-Override via the explicit-`initTimeout` overload:
+Override via `.withInitTimeout(...)`:
 
 ```scala
 // Lower for tests / quick-start CLIs that should fail fast on a missing flag service
-FeatureFlags.fromProvider(provider, evaluationTimeout = 500.millis, initTimeout = 5.seconds)
+FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withEvaluationTimeout(500.millis).withInitTimeout(5.seconds))
 
 // Raise for cold-start datafile fetches on slow networks
-FeatureFlags.fromProviderAsync(provider, evaluationTimeout = 500.millis, initTimeout = 90.seconds)
+FeatureFlags.fromProvider(
+  provider,
+  FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(500.millis).withInitTimeout(90.seconds)
+)
 
 // Effectively disable (not recommended in production)
-FeatureFlags.fromProvider(provider, evaluationTimeout = 500.millis, initTimeout = 365.days)
+FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withEvaluationTimeout(500.millis).withInitTimeout(365.days))
 ```
 
 ### Async Variants (Non-Blocking Initialization)
 
-Every factory method has an async counterpart that uses the Java SDK's non-blocking `setProvider` instead of `setProviderAndWait`. The provider initializes in the background; evaluations fail with `ProviderNotReady` until the provider is ready. The init-timeout watchdog described above still applies — after the configured `initTimeout` elapses, a provider that never became usable transitions to `Fatal` (and is shut down) so callers stop polling for ready.
+`FeatureFlagsConfig(initMode = InitMode.Async)` uses the Java SDK's non-blocking `setProvider` instead of `setProviderAndWait`. The provider initializes in the background; evaluations fail with `ProviderNotReady` until the provider is ready. The init-timeout watchdog described above still applies — after the configured `initTimeout` elapses, a provider that never became usable transitions to `Fatal` (and is shut down) so callers stop polling for ready.
 
 This is useful for microservices that need fast startup and can tolerate returning default flag values during the brief initialization window.
 
 ```scala
-// Non-blocking: layer is available immediately
+// Non-blocking: layer is available immediately (the kept shorthand)
 val layer = FeatureFlags.fromProviderAsync(provider)
 
 // With domain
-val domainLayer = FeatureFlags.fromProviderWithDomainAsync(provider, "my-service")
+val domainLayer = FeatureFlags.fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async).withDomain("my-service"))
 
 // With domain and version
-val versionedLayer = FeatureFlags.fromProviderWithDomainAsync(provider, "my-service", "1.0.0")
+val versionedLayer = FeatureFlags.fromProvider(
+  provider,
+  FeatureFlagsConfig(initMode = InitMode.Async).withDomain("my-service").withVersion("1.0.0")
+)
 
 // With hooks
-val hookedLayer = FeatureFlags.fromProviderWithHooksAsync(provider, hooks)
+val hookedLayer = FeatureFlags.fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async).withHooks(hooks))
 
 // Multi-provider
-val multiLayer = FeatureFlags.fromMultiProviderAsync(List(provider1, provider2))
+val multiLayer = FeatureFlags.fromProvider(
+  FeatureFlags.multiProvider(List(provider1, provider2)),
+  FeatureFlagsConfig(initMode = InitMode.Async)
+)
 ```
+
+> There is deliberately no `fromProviderAsync(provider, config)` overload — once you have a `FeatureFlagsConfig`, the
+> mode belongs in it (`initMode = InitMode.Async`), so `fromProvider(provider, config)` is the only config-driven
+> entry point.
 
 Use `onProviderReady` or `providerStatus` to detect when the provider becomes available:
 
@@ -579,7 +676,10 @@ In every async configuration without a same-process fallback, there is a window 
    val critical = Map("FF_MAINTENANCE_MODE" -> "false", "FF_FRAUD_CHECK_ENABLED" -> "true")
    val envProvider = EnvVarProvider.withLookup(critical.get)
    val providers   = List(optimizelyProvider, envProvider)
-   FeatureFlags.fromMultiProviderAsync(providers, FirstSuccessfulStrategy())
+   FeatureFlags.fromProvider(
+     FeatureFlags.multiProvider(providers, FirstSuccessfulStrategy()),
+     FeatureFlagsConfig(initMode = InitMode.Async)
+   )
    ```
 
    The cost of a `MultiProvider` lookup is microseconds; the benefit is that your critical flags have a deterministic value even when the remote is down.

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -147,12 +147,12 @@ FeatureFlags.booleanDetails("flag", false, EvaluationContext.empty, options)
 | Requirement | Status | Implementation |
 |:------------|:-------|:---------------|
 | Initialize (blocking) | ✅ | `setProviderAndWait` on layer creation |
-| Initialize (async) | ✅ | `setProvider` via `fromProviderAsync` variants |
+| Initialize (async) | ✅ | `setProvider` via `fromProviderAsync` / `FeatureFlagsConfig(initMode = InitMode.Async)` |
 | Shutdown (1.6.1) | ✅ | Automatic via ZIO Scope finalizer + explicit `shutdown` method |
 | Provider metadata | ✅ | `providerMetadata` returns name and version |
 | Client metadata | ✅ | `clientMetadata` returns domain and version |
-| Domain binding | ✅ | `fromProviderWithDomain` |
-| Client version | ✅ | `fromProviderWithDomain(provider, domain, version)` |
+| Domain binding | ✅ | `FeatureFlagsConfig().withDomain(domain)` |
+| Client version | ✅ | `FeatureFlagsConfig().withDomain(domain).withVersion(version)` |
 
 ---
 

--- a/docs/testkit.md
+++ b/docs/testkit.md
@@ -484,7 +484,7 @@ test("tracks evaluations") {
 }
 ```
 
-> **Note:** The public factory methods (`FeatureFlags.fromProvider`, `fromMultiProvider`, etc.)
+> **Note:** The public factory methods (`FeatureFlags.fromProvider`, `fromProvider(provider, config)`, etc.)
 > use the global `OpenFeatureAPI` singleton and are **not** isolated. If you test with these
 > directly, use `@@ TestAspect.sequential` to prevent conflicts.
 

--- a/examples/ofrep-init-timeout/src/main/scala/example/OfrepInitTimeoutExample.scala
+++ b/examples/ofrep-init-timeout/src/main/scala/example/OfrepInitTimeoutExample.scala
@@ -11,10 +11,10 @@ import zio.openfeature.ofrep.OFREPProvider
   *   1. `OFREPProvider.make(...)` validates the base URL before constructing — bad config fails at layer build, not at
   *      first evaluation. The returned `FeatureFlagError.InvalidConfiguration` is a typed value the caller can match
   *      on for actionable startup errors.
-  *   2. `FeatureFlags.fromProviderAsync(provider, evaluationTimeout)` bounds initialization via the default 30 s
-  *      `initTimeout` and bounds per-evaluation latency via the explicit `evaluationTimeout`. If the OFREP endpoint
-  *      is unreachable, `providerStatus` transitions to `Fatal` after the init timeout so the app stops polling for
-  *      ready.
+  *   2. `FeatureFlags.fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(...))`
+  *      bounds initialization via the default 30 s `initTimeout` and bounds per-evaluation latency via the explicit
+  *      `evaluationTimeout`. If the OFREP endpoint is unreachable, `providerStatus` transitions to `Fatal` after the
+  *      init timeout so the app stops polling for ready.
   *
   * '''Why no `CircuitBreakerProvider`?''' The breaker in `zio-openfeature-extras` requires an `EventProvider`
   * (so it can emit `PROVIDER_*` events when it trips). The OFREP contrib provider extends `FeatureProvider`
@@ -34,9 +34,11 @@ object OfrepInitTimeoutExample extends ZIOAppDefault {
     for {
       baseUrl  <- ZIO.succeed(sys.env.getOrElse("OFREP_BASE_URL", "http://localhost:8016"))
       provider <- OFREPProvider.make(baseUrl).mapError(e => new RuntimeException(e.message))
-      // Per-evaluation latency cap. Init timeout uses the library default (30 s); override via the 3-arg overload:
-      //   FeatureFlags.fromProviderAsync(provider, evaluationTimeout = 500.millis, initTimeout = 5.seconds)
-      env <- FeatureFlags.fromProviderAsync(provider, 500.millis).build
+      // Per-evaluation latency cap. Init timeout uses the library default (30 s); override via .withInitTimeout(...):
+      //   FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(500.millis).withInitTimeout(5.seconds)
+      env <- FeatureFlags
+        .fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(500.millis))
+        .build
       ff = env.get[FeatureFlags]
       _      <- ZIO.logInfo("Resolving feature flag 'new-checkout-flow'…")
       value  <- ff.boolean("new-checkout-flow", default = false).mapError(e => new RuntimeException(e.message))

--- a/extras/src/main/scala/zio/openfeature/extras/DeferredProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/DeferredProvider.scala
@@ -18,10 +18,10 @@ import java.util.concurrent.atomic.AtomicReference
   *
   * Some providers do all their network work in the Java constructor (blocking the call site). Wrapping such a provider
   * in `DeferredProvider` defers construction to `initialize(ctx)`, which the OpenFeature SDK runs on its own init
-  * executor — so every existing `*Async` factory (`fromProviderAsync`, `fromMultiProviderAsync`) already keeps that
-  * work off the caller's thread. Use this when you want plain async semantics (typed `PROVIDER_NOT_READY` until ready);
-  * use [[zio.openfeature.FeatureFlags.fromAcquireAsync]] instead when a fallback must answer during the init window
-  * (inside a `MultiProvider`, `DeferredProvider` still gates overall readiness, since the SDK awaits all children).
+  * executor — so `fromProviderAsync` (or any `FeatureFlagsConfig(initMode = InitMode.Async)`) already keeps that work
+  * off the caller's thread. Use this when you want plain async semantics (typed `PROVIDER_NOT_READY` until ready); use
+  * [[zio.openfeature.FeatureFlags.fromAcquireAsync]] instead when a fallback must answer during the init window (inside
+  * a `MultiProvider`, `DeferredProvider` still gates overall readiness, since the SDK awaits all children).
   *
   *   - Metadata name is stable (`name`) before and after construction, so the event bridge and `MultiProvider` keying
   *     see a single identity.

--- a/extras/src/test/scala/zio/openfeature/extras/DeferredProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/DeferredProviderSpec.scala
@@ -2,7 +2,7 @@ package zio.openfeature.extras
 
 import zio._
 import zio.test._
-import zio.openfeature.{FeatureFlags, ProviderStatus}
+import zio.openfeature.{FeatureFlags, FeatureFlagsConfig, InitMode, ProviderStatus}
 import zio.openfeature.internal.ProviderEvaluations
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
@@ -112,18 +112,22 @@ object DeferredProviderSpec extends ZIOSpecDefault {
         }
       } yield result
     } @@ TestAspect.withLiveClock,
-    // AC5: works through fromMultiProviderAsync
-    test("works through fromMultiProviderAsync") {
+    // AC5: works through an async multi-provider config layer
+    test("works through an async multi-provider config layer") {
       val delegate = new RecordingProvider(true)
       val dp       = DeferredProvider("deferred-multi")(() => delegate)
       val other    = new RecordingProvider(false)
       ZIO.scoped {
-        FeatureFlags.fromMultiProviderAsync(List(dp, other)).build.map(_.get[FeatureFlags]).flatMap { ff =>
-          for {
-            status <- ff.awaitReady(10.seconds)
-            v      <- ff.boolean("flag", false)
-          } yield assertTrue(status == ProviderStatus.Ready, v)
-        }
+        FeatureFlags
+          .fromProvider(FeatureFlags.multiProvider(List(dp, other)), FeatureFlagsConfig(initMode = InitMode.Async))
+          .build
+          .map(_.get[FeatureFlags])
+          .flatMap { ff =>
+            for {
+              status <- ff.awaitReady(10.seconds)
+              v      <- ff.boolean("flag", false)
+            } yield assertTrue(status == ProviderStatus.Ready, v)
+          }
       }
     } @@ TestAspect.withLiveClock
   ) @@ TestAspect.sequential

--- a/ofrep/src/test/scala/zio/openfeature/ofrep/OFREPFailureModeSpec.scala
+++ b/ofrep/src/test/scala/zio/openfeature/ofrep/OFREPFailureModeSpec.scala
@@ -54,8 +54,11 @@ object OFREPFailureModeSpec extends ZIOSpecDefault {
             for {
               provider <- OFREPProvider.make(baseUrl(server))
               env <- evaluationTimeout match {
-                case Some(d) => FeatureFlags.fromProviderAsync(provider, d).build
-                case None    => FeatureFlags.fromProviderAsync(provider).build
+                case Some(d) =>
+                  FeatureFlags
+                    .fromProvider(provider, FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(d))
+                    .build
+                case None => FeatureFlags.fromProviderAsync(provider).build
               }
               ff = env.get[FeatureFlags]
               // Wait briefly so PROVIDER_READY fires before we start evaluating.
@@ -187,7 +190,12 @@ object OFREPFailureModeSpec extends ZIOSpecDefault {
                 .scoped {
                   for {
                     provider <- OFREPProvider.make(baseUrl(server))
-                    env      <- FeatureFlags.fromProviderAsync(provider, 1.second).build
+                    env <- FeatureFlags
+                      .fromProvider(
+                        provider,
+                        FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(1.second)
+                      )
+                      .build
                     ff = env.get[FeatureFlags]
                     _      <- ZIO.sleep(100.millis)
                     before <- ff.booleanDetails("probe", default = false).either

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyProvider.scala
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit
   *                  inner,
   *                  CircuitBreakerProviderConfig(failureThreshold = 5, resetTimeout = 30.seconds)
   *                )
-  *     env     <- FeatureFlags.fromProviderAsync(wrapped, 500.millis).build
+  *     env     <- FeatureFlags.fromProvider(wrapped, FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(500.millis)).build
   *     ff       = env.get[FeatureFlags]
   *     enabled <- ff.boolean("flag", default = false)
   *   } yield enabled
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit
   * '''Failure semantics on bad credentials / unreachable CDN:'''
   *   - If the Optimizely datafile fetch fails (auth, network, 5xx), the underlying client stays `!isValid` and
   *     [[OptimizelyFeatureProvider.initialize]] throws after its `initWait` elapses. The outer
-  *     `FeatureFlags.fromProvider*(initTimeout = …)` translates that into either a layer build failure (sync mode) or a
+  *     `FeatureFlagsConfig().withInitTimeout(…)` translates that into either a layer build failure (sync mode) or a
   *     `ProviderStatus.Fatal` transition (async mode), so an evaluation never silently returns the default value under
   *     a misconfigured provider.
   *   - Construction itself (this object's `make`) does NOT make network calls — it only validates inputs and builds the
@@ -105,7 +105,7 @@ object OptimizelyProvider {
     make(sdkKey, datafileUrl = Some(datafileUrl), initWait = DefaultInitWait)
 
   /** Full-control overload exposing the internal `initWait`. Most callers should prefer one of the simpler overloads
-    * plus the outer `FeatureFlags.fromProvider*` `initTimeout`.
+    * plus the outer `FeatureFlagsConfig.initTimeout`.
     */
   def make(
     sdkKey: String,

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/matrix/RecommendationServiceSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/matrix/RecommendationServiceSpec.scala
@@ -43,11 +43,11 @@ object RecommendationServiceSpec extends ZIOSpecDefault {
           blockingTimeout = Some(java.time.Duration.ofSeconds(2))
         )
         provider <- OptimizelyProvider.scoped(config).mapError(e => new RuntimeException(e.message))
-        // fromProviderWithDomain (not the plain fromProvider) so each call gets its own named slot on
-        // the global OpenFeatureAPI singleton instead of overwriting the shared unnamed default client —
-        // fromProvider would let concurrently-running tests race to swap each other's active provider.
+        // A domain config (not the plain fromProvider) so each call gets its own named slot on the global
+        // OpenFeatureAPI singleton instead of overwriting the shared unnamed default client — fromProvider would
+        // let concurrently-running tests race to swap each other's active provider.
         domain = s"flag-matrix-${java.util.UUID.randomUUID()}"
-        env <- FeatureFlags.fromProviderWithDomain(provider, domain).build
+        env <- FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain(domain)).build
         ff  = env.get[FeatureFlags]
         svc = new RecommendationService(ff)
         result <- body(svc)

--- a/testkit/src/test/scala/zio/openfeature/testkit/FactoryConfigSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FactoryConfigSpec.scala
@@ -1,0 +1,442 @@
+package zio.openfeature.testkit
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.withLiveClock
+import zio.openfeature._
+import zio.openfeature.internal.ProviderEvaluations
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  EventProvider,
+  Metadata,
+  OpenFeatureAPIFactory,
+  ProviderState,
+  Value
+}
+import dev.openfeature.sdk.multiprovider.FirstSuccessfulStrategy
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Gate tests for #253's config-driven factory (`FeatureFlags.fromProvider(provider, config)`). Each test exercises a
+  * combination the pre-#253 factory-overload surface could not express (T1-T5), plus a behavioral-equivalence pin
+  * between the deprecated forwards and the config path (T6).
+  *
+  * Isolated `OpenFeatureAPI` instances (`OpenFeatureAPIFactory.create()`) + the `private[openfeature]`
+  * `FeatureFlags.fromProvider(provider, config, statusRef, apiOverride, onReady)` variant are used throughout so these
+  * tests never touch the process-global singleton and can run in parallel with every other spec.
+  */
+object FactoryConfigSpec extends ZIOSpecDefault {
+
+  private def uniqueDomain(label: String): String = s"cfg-$label-${java.util.UUID.randomUUID()}"
+
+  /** A minimal tracking provider (mirrors `FeatureFlagsShutdownSpec`'s) so T4a/T4b can observe `shutdown()` directly,
+    * independent of `TestFeatureProvider`'s own state-transition semantics.
+    */
+  private class TrackingProvider(name: String, shutCalled: AtomicBoolean) extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = name }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = shutCalled.set(true)
+
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](d, "DEFAULT")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  private def coreSuite = suite("Factory Config — FeatureFlagsConfig-driven fromProvider")(
+    test("T1: domain + hooks (impossible before) — hooks fire AND clientMetadata reflects the domain") {
+      for {
+        provider  <- TestFeatureProvider.make(Map("flag" -> true))
+        hookCalls <- Ref.make(0)
+        hook = new FeatureHook {
+          override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+            hookCalls.update(_ + 1)
+        }
+        domain = uniqueDomain("t1")
+        config = FeatureFlagsConfig().withDomain(domain).withHooks(List(hook))
+        result <- ZIO.scoped {
+          FeatureFlags
+            .fromProvider(provider, config, statusRef = None, apiOverride = Some(OpenFeatureAPIFactory.create()))
+            .build
+            .flatMap { env =>
+              val ff = env.get[FeatureFlags]
+              for {
+                meta  <- ff.clientMetadata
+                flag  <- ff.boolean("flag", default = false)
+                calls <- hookCalls.get
+              } yield assertTrue(meta.domain.contains(domain), flag, calls == 1)
+            }
+        }
+      } yield result
+    },
+    test("T2: domain + evaluationTimeout — a slow provider fails with ProviderError(TimeoutException)") {
+      for {
+        provider <- TestFeatureProvider.make(Map("flag" -> true))
+        _        <- provider.setDelay(500.millis)
+        domain = uniqueDomain("t2")
+        config = FeatureFlagsConfig().withDomain(domain).withEvaluationTimeout(20.millis)
+        result <- ZIO.scoped {
+          FeatureFlags
+            .fromProvider(provider, config, statusRef = None, apiOverride = Some(OpenFeatureAPIFactory.create()))
+            .build
+            .flatMap(env => env.get[FeatureFlags].boolean("flag", default = false).either)
+        }
+      } yield assertTrue(
+        result.left.toOption.exists {
+          case FeatureFlagError.ProviderError(underlying) => underlying.isInstanceOf[TimeoutException]
+          case _                                          => false
+        }
+      )
+    } @@ withLiveClock,
+    test("T3: initMode = Async — layer builds immediately; first eval fails ProviderNotReady, then succeeds") {
+      for {
+        provider <- TestFeatureProvider.makeNotReady(Map("flag" -> true))
+        domain = uniqueDomain("t3")
+        config = FeatureFlagsConfig(initMode = InitMode.Async).withDomain(domain)
+        result <- ZIO.scoped {
+          FeatureFlags
+            .fromProvider(
+              provider,
+              config,
+              statusRef = Some(provider.statusRef),
+              apiOverride = Some(OpenFeatureAPIFactory.create()),
+              onReady = provider.initDone
+            )
+            .build
+            .flatMap { env =>
+              val ff = env.get[FeatureFlags]
+              for {
+                before <- ff.boolean("flag", default = false).either
+                _      <- provider.setStatus(ProviderStatus.Ready)
+                after  <- ff.boolean("flag", default = false)
+              } yield assertTrue(
+                before == Left(FeatureFlagError.ProviderNotReady(ProviderStatus.NotReady)),
+                after
+              )
+            }
+        }
+      } yield result
+    } @@ withLiveClock,
+    test("T4a: Auto + domain — closing the config-layer scope does NOT shut the shared api (#243)") {
+      val shutA = new AtomicBoolean(false)
+      val shutB = new AtomicBoolean(false)
+      val api   = OpenFeatureAPIFactory.create()
+      ZIO.scoped {
+        for {
+          ffA <- FeatureFlags
+            .fromProvider(
+              new TrackingProvider("A", shutA),
+              FeatureFlagsConfig(initMode = InitMode.Async).withDomain(uniqueDomain("t4a-A")),
+              statusRef = None,
+              apiOverride = Some(api)
+            )
+            .build
+            .map(_.get[FeatureFlags])
+          ffB <- FeatureFlags
+            .fromProvider(
+              new TrackingProvider("B", shutB),
+              FeatureFlagsConfig(initMode = InitMode.Async).withDomain(uniqueDomain("t4a-B")),
+              statusRef = None,
+              apiOverride = Some(api)
+            )
+            .build
+            .map(_.get[FeatureFlags])
+          _      <- ffA.awaitReady(5.seconds)
+          _      <- ffB.awaitReady(5.seconds)
+          _      <- ffA.shutdown
+          sibRes <- ffB.boolean("flag", default = false)
+        } yield assertTrue(
+          !shutA.get(),   // own provider left to the (still-alive) shared api
+          !shutB.get(),   // sibling untouched
+          sibRes == false // sibling still evaluable after ffA's shutdown
+        )
+      }
+    } @@ withLiveClock,
+    test("T4b: Owned override + domain — scope close DOES shut that (private) api's provider") {
+      val shut = new AtomicBoolean(false)
+      for {
+        // The inner `ZIO.scoped` fully closes (running finalizers, including the api-shutdown one) before this
+        // for-comprehension continues — so `shut.get()` below observes the post-close state deterministically.
+        _ <- ZIO.scoped {
+          FeatureFlags
+            .fromProvider(
+              new TrackingProvider("owned", shut),
+              FeatureFlagsConfig(initMode = InitMode.Async)
+                .withDomain(uniqueDomain("t4b"))
+                .withApiOwnership(ApiOwnership.Owned),
+              statusRef = None,
+              apiOverride = Some(OpenFeatureAPIFactory.create())
+            )
+            .build
+            .flatMap(env => env.get[FeatureFlags].awaitReady(5.seconds))
+        }
+      } yield assertTrue(shut.get())
+    } @@ withLiveClock,
+    test("T5: withoutEvaluationTimeout — a provider slower than DefaultEvaluationTimeout does not time out") {
+      for {
+        provider <- TestFeatureProvider.make(Map("flag" -> true))
+        _        <- provider.setDelay(FeatureFlags.DefaultEvaluationTimeout + 500.millis)
+        domain = uniqueDomain("t5")
+        config = FeatureFlagsConfig().withDomain(domain).withoutEvaluationTimeout
+        result <- ZIO.scoped {
+          FeatureFlags
+            .fromProvider(provider, config, statusRef = None, apiOverride = Some(OpenFeatureAPIFactory.create()))
+            .build
+            .flatMap(env => env.get[FeatureFlags].boolean("flag", default = false))
+        }
+      } yield assertTrue(result)
+    } @@ withLiveClock
+  )
+
+  /** T6 (equivalence gate): every deprecated forward is a one-line call into the config path, so this suite pins that
+    * forwarding itself — the ONE place in the codebase still allowed to call the deprecated overloads directly,
+    * suppressed here rather than migrated because exercising the forwards *is* the test.
+    */
+  @scala.annotation.nowarn("cat=deprecation")
+  private def t6EquivalenceSuite =
+    suite("T6: deprecated forwards behave identically to their config-form equivalents")(
+      test("fromProviderWithDomain(p, d, v) == fromProvider(p, config.withDomain(d).withVersion(v))") {
+        for {
+          providerA <- TestFeatureProvider.make(Map("flag" -> true))
+          providerB <- TestFeatureProvider.make(Map("flag" -> true))
+          domainA = uniqueDomain("t6-legacy")
+          domainB = uniqueDomain("t6-config")
+          legacy <- ZIO.scoped {
+            FeatureFlags
+              .fromProviderWithDomain(providerA, domainA, "9.9.9")
+              .build
+              .flatMap { env =>
+                val ff = env.get[FeatureFlags]
+                for {
+                  meta <- ff.clientMetadata
+                  flag <- ff.boolean("flag", default = false)
+                } yield (meta.domain, meta.version, flag)
+              }
+          }
+          viaConfig <- ZIO.scoped {
+            FeatureFlags
+              .fromProvider(providerB, FeatureFlagsConfig().withDomain(domainB).withVersion("9.9.9"))
+              .build
+              .flatMap { env =>
+                val ff = env.get[FeatureFlags]
+                for {
+                  meta <- ff.clientMetadata
+                  flag <- ff.boolean("flag", default = false)
+                } yield (meta.domain, meta.version, flag)
+              }
+          }
+        } yield assertTrue(
+          legacy._1.contains(domainA),
+          viaConfig._1.contains(domainB),
+          legacy._2 == viaConfig._2,
+          legacy._3 == viaConfig._3
+        )
+      },
+      test("fromProviderWithHooksAsync(p, hooks) == fromProvider(p, asyncConfig.withHooks(hooks))") {
+        for {
+          providerA <- TestFeatureProvider.make(Map("flag" -> true))
+          providerB <- TestFeatureProvider.make(Map("flag" -> true))
+          callsA    <- Ref.make(0)
+          callsB    <- Ref.make(0)
+          hookA = new FeatureHook {
+            override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+              callsA.update(_ + 1)
+          }
+          hookB = new FeatureHook {
+            override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+              callsB.update(_ + 1)
+          }
+          legacy <- ZIO.scoped {
+            FeatureFlags.fromProviderWithHooksAsync(providerA, List(hookA)).build.flatMap { env =>
+              val ff = env.get[FeatureFlags]
+              ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(5.seconds) *>
+                ff.boolean("flag", default = false) *> callsA.get
+            }
+          }
+          viaConfig <- ZIO.scoped {
+            FeatureFlags
+              .fromProvider(providerB, FeatureFlagsConfig(initMode = InitMode.Async).withHooks(List(hookB)))
+              .build
+              .flatMap { env =>
+                val ff = env.get[FeatureFlags]
+                ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(5.seconds) *>
+                  ff.boolean("flag", default = false) *> callsB.get
+              }
+          }
+        } yield assertTrue(legacy == 1, viaConfig == 1, legacy == viaConfig)
+      } @@ withLiveClock
+    )
+
+  // --- T6 equivalence helpers: build a layer in an isolated scope and extract the observable it pins ---
+
+  private def awaitReady(ff: FeatureFlags): UIO[Any] =
+    ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(5.seconds)
+
+  // Build fails with Throwable, evaluation with FeatureFlagError (not a Throwable). Convert the evaluation error to a
+  // Throwable INSIDE the effect (cross-build safe — no Scala 3 union type in source) so the outer `.orDie` type-checks.
+  private def evalDefect(e: FeatureFlagError): Throwable = new RuntimeException(String.valueOf(e))
+
+  private def metaFlag(
+    layer: ZLayer[Scope, Throwable, FeatureFlags]
+  ): UIO[(Option[String], Option[String], Boolean)] =
+    ZIO.scoped {
+      layer.build.flatMap { env =>
+        val ff = env.get[FeatureFlags]
+        (awaitReady(ff) *>
+          ff.clientMetadata.zip(ff.boolean("flag", default = false)).map { case (m, v) => (m.domain, m.version, v) })
+          .mapError(evalDefect)
+      }
+    }.orDie
+
+  private def hookCalls(layer: ZLayer[Scope, Throwable, FeatureFlags], calls: Ref[Int]): UIO[Int] =
+    ZIO.scoped {
+      layer.build.flatMap { env =>
+        val ff = env.get[FeatureFlags]
+        (awaitReady(ff) *> ff.boolean("flag", default = false) *> calls.get).mapError(evalDefect)
+      }
+    }.orDie
+
+  private def countingHook(calls: Ref[Int]): FeatureHook =
+    new FeatureHook {
+      override def after[A](ctx: HookContext, details: FlagResolution[A], hints: HookHints): UIO[Unit] =
+        calls.update(_ + 1)
+    }
+
+  /** Build a layer whose provider evaluates slowly and report whether the evaluation timed out. Distinguishes the
+    * two-`Duration` forwards from an `evaluationTimeout`/`initTimeout` argument transposition: a short eval timeout
+    * with a long init timeout must time out the (fast-to-init, slow-to-evaluate) provider; if the two were swapped in
+    * the forward, the eval timeout would be the long one and this would return false.
+    */
+  private def evalTimesOut(layer: ZLayer[Scope, Throwable, FeatureFlags]): UIO[Boolean] =
+    ZIO
+      .scoped {
+        layer.build.flatMap { env =>
+          val ff = env.get[FeatureFlags]
+          awaitReady(ff) *> ff.boolean("flag", default = false).either
+        }
+      }
+      .map {
+        case Left(FeatureFlagError.ProviderError(u)) => u.isInstanceOf[TimeoutException]
+        case _                                       => false
+      }
+      .orDie
+
+  /** T6, part 2 (#253 review): the first two suite entries pin two representative forwards; these pin the remaining 12
+    * so every deprecated forward is covered, per the design's "each deprecated forward" gate.
+    */
+  @scala.annotation.nowarn("cat=deprecation")
+  private def t6RemainingForwardsSuite =
+    suite("T6b: the remaining deprecated forwards each behave identically to their config form")(
+      test("domain/version forwards match config (WithDomain(p,d), WithDomainAsync(p,d), WithDomainAsync(p,d,v))") {
+        for {
+          p1 <- TestFeatureProvider.make(Map("flag" -> true))
+          p2 <- TestFeatureProvider.make(Map("flag" -> true))
+          p3 <- TestFeatureProvider.make(Map("flag" -> true))
+          p4 <- TestFeatureProvider.make(Map("flag" -> true))
+          p5 <- TestFeatureProvider.make(Map("flag" -> true))
+          p6 <- TestFeatureProvider.make(Map("flag" -> true))
+          dA = uniqueDomain("t6-wd"); dB   = uniqueDomain("t6-wd-cfg")
+          dC = uniqueDomain("t6-wda"); dD  = uniqueDomain("t6-wda-cfg")
+          dE = uniqueDomain("t6-wdav"); dF = uniqueDomain("t6-wdav-cfg")
+          l1 <- metaFlag(FeatureFlags.fromProviderWithDomain(p1, dA))
+          c1 <- metaFlag(FeatureFlags.fromProvider(p2, FeatureFlagsConfig().withDomain(dB)))
+          l2 <- metaFlag(FeatureFlags.fromProviderWithDomainAsync(p3, dC))
+          c2 <- metaFlag(FeatureFlags.fromProvider(p4, FeatureFlagsConfig(initMode = InitMode.Async).withDomain(dD)))
+          l3 <- metaFlag(FeatureFlags.fromProviderWithDomainAsync(p5, dE, "2.0.0"))
+          c3 <- metaFlag(
+            FeatureFlags
+              .fromProvider(p6, FeatureFlagsConfig(initMode = InitMode.Async).withDomain(dF).withVersion("2.0.0"))
+          )
+        } yield assertTrue(
+          l1._1.contains(dA) && c1._1.contains(dB) && l1._2 == c1._2 && l1._3 == c1._3,
+          l2._1.contains(dC) && c2._1.contains(dD) && l2._2 == c2._2 && l2._3 == c2._3,
+          l3._2.contains("2.0.0") && c3._2.contains("2.0.0") && l3._3 == c3._3
+        )
+      } @@ withLiveClock,
+      test("hooks forward matches config (fromProviderWithHooks(p, hooks))") {
+        for {
+          pA     <- TestFeatureProvider.make(Map("flag" -> true))
+          pB     <- TestFeatureProvider.make(Map("flag" -> true))
+          cA     <- Ref.make(0)
+          cB     <- Ref.make(0)
+          legacy <- hookCalls(FeatureFlags.fromProviderWithHooks(pA, List(countingHook(cA))), cA)
+          cfg    <- hookCalls(FeatureFlags.fromProvider(pB, FeatureFlagsConfig().withHooks(List(countingHook(cB)))), cB)
+        } yield assertTrue(legacy == 1, cfg == 1)
+      } @@ withLiveClock,
+      test("evaluation-timeout forwards match config, incl. the two-Duration forms (transposition guard)") {
+        val delay = 500.millis
+        val evalT = 20.millis
+        val initT = 30.seconds
+        for {
+          p1  <- TestFeatureProvider.make(Map("flag" -> true)); _ <- p1.setDelay(delay)
+          p2  <- TestFeatureProvider.make(Map("flag" -> true)); _ <- p2.setDelay(delay)
+          p3  <- TestFeatureProvider.make(Map("flag" -> true)); _ <- p3.setDelay(delay)
+          p4  <- TestFeatureProvider.make(Map("flag" -> true)); _ <- p4.setDelay(delay)
+          p5  <- TestFeatureProvider.make(Map("flag" -> true)); _ <- p5.setDelay(delay)
+          p6  <- TestFeatureProvider.make(Map("flag" -> true)); _ <- p6.setDelay(delay)
+          p7  <- TestFeatureProvider.make(Map("flag" -> true)); _ <- p7.setDelay(delay)
+          p8  <- TestFeatureProvider.make(Map("flag" -> true)); _ <- p8.setDelay(delay)
+          lo1 <- evalTimesOut(FeatureFlags.fromProvider(p1, evalT))
+          co1 <- evalTimesOut(FeatureFlags.fromProvider(p2, FeatureFlagsConfig().withEvaluationTimeout(evalT)))
+          lo2 <- evalTimesOut(FeatureFlags.fromProvider(p3, evalT, initT))
+          co2 <- evalTimesOut(
+            FeatureFlags.fromProvider(p4, FeatureFlagsConfig().withEvaluationTimeout(evalT).withInitTimeout(initT))
+          )
+          lo3 <- evalTimesOut(FeatureFlags.fromProviderAsync(p5, evalT))
+          co3 <- evalTimesOut(
+            FeatureFlags.fromProvider(p6, FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(evalT))
+          )
+          lo4 <- evalTimesOut(FeatureFlags.fromProviderAsync(p7, evalT, initT))
+          co4 <- evalTimesOut(
+            FeatureFlags.fromProvider(
+              p8,
+              FeatureFlagsConfig(initMode = InitMode.Async).withEvaluationTimeout(evalT).withInitTimeout(initT)
+            )
+          )
+        } yield assertTrue(lo1, co1, lo2, co2, lo3, co3, lo4, co4)
+      } @@ withLiveClock,
+      test("multi-provider forwards match config, incl. the strategy-carrying forms") {
+        def pair = TestFeatureProvider.make(Map("flag" -> true)).zip(TestFeatureProvider.make(Map("flag" -> true)))
+        for {
+          ab1 <- pair; ab2 <- pair; ab3 <- pair; ab4 <- pair
+          ab5 <- pair; ab6 <- pair; ab7 <- pair; ab8 <- pair
+          l1  <- metaFlag(FeatureFlags.fromMultiProvider(List(ab1._1, ab1._2)))
+          c1 <- metaFlag(
+            FeatureFlags.fromProvider(FeatureFlags.multiProvider(List(ab2._1, ab2._2)), FeatureFlagsConfig())
+          )
+          l2 <- metaFlag(FeatureFlags.fromMultiProvider(List(ab3._1, ab3._2), new FirstSuccessfulStrategy()))
+          c2 <- metaFlag(
+            FeatureFlags.fromProvider(
+              FeatureFlags.multiProvider(List(ab4._1, ab4._2), new FirstSuccessfulStrategy()),
+              FeatureFlagsConfig()
+            )
+          )
+          l3 <- metaFlag(FeatureFlags.fromMultiProviderAsync(List(ab5._1, ab5._2)))
+          c3 <- metaFlag(
+            FeatureFlags
+              .fromProvider(
+                FeatureFlags.multiProvider(List(ab6._1, ab6._2)),
+                FeatureFlagsConfig(initMode = InitMode.Async)
+              )
+          )
+          l4 <- metaFlag(FeatureFlags.fromMultiProviderAsync(List(ab7._1, ab7._2), new FirstSuccessfulStrategy()))
+          c4 <- metaFlag(
+            FeatureFlags.fromProvider(
+              FeatureFlags.multiProvider(List(ab8._1, ab8._2), new FirstSuccessfulStrategy()),
+              FeatureFlagsConfig(initMode = InitMode.Async)
+            )
+          )
+        } yield assertTrue(l1._3 == c1._3, l2._3 == c2._3, l3._3 == c3._3, l4._3 == c4._3)
+      } @@ withLiveClock
+    )
+
+  def spec = (coreSuite + t6EquivalenceSuite + t6RemainingForwardsSuite) @@ TestAspect.sequential
+}

--- a/testkit/src/test/scala/zio/openfeature/testkit/FactoryMethodsSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/FactoryMethodsSpec.scala
@@ -9,11 +9,15 @@ import zio.openfeature._
   *
   * These tests must run sequentially because they share the singleton's default provider slot. Isolated from other
   * specs to avoid cross-test contamination.
+  *
+  * Exercises the `FeatureFlagsConfig`-driven `fromProvider(provider, config)` factory (#253). The behavioral
+  * equivalence between this and the now-deprecated overloads it replaced is pinned separately, under
+  * `@nowarn("cat=deprecation")`, by `FactoryConfigSpec`'s T6 suite.
   */
 object FactoryMethodsSpec extends ZIOSpecDefault {
 
   def spec = suite("Factory Methods — global singleton API")(
-    suite("fromProviderWithHooks")(
+    suite("fromProvider with hooks")(
       test("layer created with initial hooks has those hooks") {
         val callsRef = Unsafe.unsafe { implicit u =>
           Runtime.default.unsafe.run(Ref.make(0)).getOrThrow()
@@ -26,48 +30,57 @@ object FactoryMethodsSpec extends ZIOSpecDefault {
 
         for {
           provider <- TestFeatureProvider.make(Map("flag" -> true))
-          layer = FeatureFlags.fromProviderWithHooks(provider, List(hook))
+          layer = FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withHooks(List(hook)))
           _     <- FeatureFlags.boolean("flag", default = false).provide(Scope.default >>> layer)
           calls <- callsRef.get
         } yield assertTrue(calls == 1)
       }
     ),
-    suite("fromProviderWithDomain")(
-      test("fromProviderWithDomain with version exposes version in clientMetadata") {
+    suite("fromProvider with domain")(
+      test("domain + version config exposes version in clientMetadata") {
         for {
           provider <- TestFeatureProvider.make(Map("flag" -> true))
           domain = s"test-versioned-${java.util.UUID.randomUUID()}"
           result <- ZIO.scoped {
-            FeatureFlags.fromProviderWithDomain(provider, domain, "2.0.0").build.flatMap { env =>
-              val ff = env.get[FeatureFlags]
-              for {
-                meta <- ff.clientMetadata
-                flag <- ff.boolean("flag", default = false)
-              } yield assertTrue(meta.domain.contains(domain)) &&
-                assertTrue(meta.version.contains("2.0.0")) &&
-                assertTrue(flag == true)
-            }
+            FeatureFlags
+              .fromProvider(provider, FeatureFlagsConfig().withDomain(domain).withVersion("2.0.0"))
+              .build
+              .flatMap { env =>
+                val ff = env.get[FeatureFlags]
+                for {
+                  meta <- ff.clientMetadata
+                  flag <- ff.boolean("flag", default = false)
+                } yield assertTrue(meta.domain.contains(domain)) &&
+                  assertTrue(meta.version.contains("2.0.0")) &&
+                  assertTrue(flag == true)
+              }
           }
         } yield result
       }
     ),
-    suite("fromMultiProvider")(
-      test("fromMultiProvider creates a usable layer") {
+    suite("fromProvider with FeatureFlags.multiProvider")(
+      test("multiProvider creates a usable layer (first-match default)") {
         ZIO.scoped {
           for {
             provider <- TestFeatureProvider.make(Map("flag" -> true))
-            ff       <- FeatureFlags.fromMultiProvider(List(provider)).build.map(_.get)
-            result   <- ff.boolean("flag", default = false)
+            ff <- FeatureFlags
+              .fromProvider(FeatureFlags.multiProvider(List(provider)), FeatureFlagsConfig())
+              .build
+              .map(_.get)
+            result <- ff.boolean("flag", default = false)
           } yield assertTrue(result == true)
         }
       },
-      test("fromMultiProvider with custom strategy creates a usable layer") {
+      test("multiProvider with a custom strategy creates a usable layer") {
         import dev.openfeature.sdk.multiprovider.FirstSuccessfulStrategy
         ZIO.scoped {
           for {
             provider <- TestFeatureProvider.make(Map("flag" -> "hello"))
             ff <- FeatureFlags
-              .fromMultiProvider(List(provider), new FirstSuccessfulStrategy())
+              .fromProvider(
+                FeatureFlags.multiProvider(List(provider), new FirstSuccessfulStrategy()),
+                FeatureFlagsConfig()
+              )
               .build
               .map(_.get)
             result <- ff.string("flag", default = "none")
@@ -75,7 +88,7 @@ object FactoryMethodsSpec extends ZIOSpecDefault {
         }
       }
     ),
-    suite("fromProviderAsync")(
+    suite("fromProviderAsync / async config")(
       test("fromProviderAsync creates a working layer") {
         for {
           tp <- TestFeatureProvider.make(Map("flag" -> true))
@@ -88,7 +101,7 @@ object FactoryMethodsSpec extends ZIOSpecDefault {
           }
         } yield assertTrue(result == true)
       },
-      test("fromProviderWithHooksAsync includes hooks") {
+      test("async config with hooks includes hooks") {
         for {
           hookCalled <- Ref.make(false)
           hook = new FeatureHook {
@@ -97,50 +110,65 @@ object FactoryMethodsSpec extends ZIOSpecDefault {
           }
           tp <- TestFeatureProvider.make(Map("flag" -> true))
           result <- ZIO.scoped {
-            FeatureFlags.fromProviderWithHooksAsync(tp, List(hook)).build.flatMap { env =>
-              val ff = env.get[FeatureFlags]
-              ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
-                ff.boolean("flag", default = false) *>
-                hookCalled.get
-            }
+            FeatureFlags
+              .fromProvider(tp, FeatureFlagsConfig(initMode = InitMode.Async).withHooks(List(hook)))
+              .build
+              .flatMap { env =>
+                val ff = env.get[FeatureFlags]
+                ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
+                  ff.boolean("flag", default = false) *>
+                  hookCalled.get
+              }
           }
         } yield assertTrue(result)
       },
-      test("fromProviderWithDomainAsync creates a working layer") {
+      test("async config with domain creates a working layer") {
         for {
           tp <- TestFeatureProvider.make(Map("flag" -> true))
           domain = s"test-async-factory-${java.util.UUID.randomUUID()}"
           result <- ZIO.scoped {
-            FeatureFlags.fromProviderWithDomainAsync(tp, domain).build.flatMap { env =>
-              val ff = env.get[FeatureFlags]
-              ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
-                ff.boolean("flag", default = false)
-            }
+            FeatureFlags
+              .fromProvider(tp, FeatureFlagsConfig(initMode = InitMode.Async).withDomain(domain))
+              .build
+              .flatMap { env =>
+                val ff = env.get[FeatureFlags]
+                ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
+                  ff.boolean("flag", default = false)
+              }
           }
         } yield assertTrue(result == true)
       },
-      test("fromProviderWithDomainAsync with version creates a working layer") {
+      test("async config with domain and version creates a working layer") {
         for {
           tp <- TestFeatureProvider.make(Map("flag" -> true))
           domain = s"test-async-versioned-${java.util.UUID.randomUUID()}"
           result <- ZIO.scoped {
-            FeatureFlags.fromProviderWithDomainAsync(tp, domain, "1.2.3").build.flatMap { env =>
-              val ff = env.get[FeatureFlags]
-              ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
-                ff.boolean("flag", default = false)
-            }
+            FeatureFlags
+              .fromProvider(
+                tp,
+                FeatureFlagsConfig(initMode = InitMode.Async).withDomain(domain).withVersion("1.2.3")
+              )
+              .build
+              .flatMap { env =>
+                val ff = env.get[FeatureFlags]
+                ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
+                  ff.boolean("flag", default = false)
+              }
           }
         } yield assertTrue(result == true)
       },
-      test("fromMultiProviderAsync creates a working layer") {
+      test("async config with FeatureFlags.multiProvider creates a working layer") {
         for {
           tp <- TestFeatureProvider.make(Map("flag" -> true))
           result <- ZIO.scoped {
-            FeatureFlags.fromMultiProviderAsync(List(tp)).build.flatMap { env =>
-              val ff = env.get[FeatureFlags]
-              ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
-                ff.boolean("flag", default = false)
-            }
+            FeatureFlags
+              .fromProvider(FeatureFlags.multiProvider(List(tp)), FeatureFlagsConfig(initMode = InitMode.Async))
+              .build
+              .flatMap { env =>
+                val ff = env.get[FeatureFlags]
+                ff.providerStatus.repeatUntil(_ == ProviderStatus.Ready).timeout(2.seconds) *>
+                  ff.boolean("flag", default = false)
+              }
           }
         } yield assertTrue(result == true)
       }


### PR DESCRIPTION
## Summary
Adds a config-driven factory `FeatureFlags.fromProvider(provider, FeatureFlagsConfig)` that can express provider-parameter combinations the 16+ `fromProvider*` overloads could not (domain+hooks, domain+evaluationTimeout, multi-provider+domain, etc.). Introduces `FeatureFlagsConfig` (with `InitMode` and an explicit `ApiOwnership` ADT that makes the previously-invisible `addShutdownFinalizer` lifecycle semantics documented and configurable) plus a `multiProvider` helper.

The 14 redundant overloads are now one-line forwards to the config path (`@deprecated(..., since = "0.2.0")`), collapsing to a single construction code path; `fromProvider(p)` / `fromProviderAsync(p)` are kept as shorthands. All internal callers are migrated to the config form so the build stays clean under `-Xfatal-warnings`.

## Tests
New `FactoryConfigSpec` gates T1–T6 from the design: domain+hooks, domain+evaluationTimeout, async init, `Auto`/`Owned` API-ownership lifecycle, no-timeout, and behavioral-equivalence of all 14 deprecated forwards to their config forms (including a timeout-argument-transposition guard on the two-`Duration` forms). Full cross-build (Scala 2.13 + 3.3), conformance, and examples all green.

## Docs
Rewrites the Factory Methods section of `docs/providers.md` around the config; CHANGELOG `Added` + `Deprecated` entries.

Closes #253
