### PR TITLE
Testkit DX: return Scala context from getEvaluations; setFlags merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   successful fetch. Configurable via `OptimizelyProviderConfig.staleAfter` (default `3 × pollingInterval`; disabled when
   polling is off). The watchdog thread is a daemon and is cancelled on shutdown.
 
+### Changed
+
+- **Testkit `TestFeatureProvider` DX** (#272). `getEvaluations` now returns the library's own
+  `List[(String, zio.openfeature.EvaluationContext)]` instead of leaking the Java SDK's
+  `dev.openfeature.sdk.EvaluationContext`, so context-propagation assertions use the Scala API
+  (`.targetingKey`, `.getString(...)`) directly; the raw Java contexts remain available via the new
+  `getRawEvaluations`. `setFlags` now **merges** into the existing flags (a key overwrites its previous value) rather
+  than silently clearing everything first — flags seeded via `make(Map(...))` / `layer(Map(...))` or earlier
+  `setFlag`/`setFlags` calls survive; the previous replace-all behavior is available as the new `replaceFlags`. Both
+  are breaking changes for testkit users: switch `getEvaluations` call sites that need the Java type to
+  `getRawEvaluations`, and `setFlags` call sites that relied on the clear-first behavior to `replaceFlags`.
+
 ### Deprecated
 
 - **14 `FeatureFlags` factory overloads, superseded by `fromProvider(provider, config)`** (#253):

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/ConformanceSpec.scala
@@ -436,7 +436,7 @@ object ConformanceSpec extends ZIOSteps[Any, World] {
         case None     => eval.unit.orDieWith(e => new RuntimeException(String.valueOf(e)))
       }
       _      <- run
-      merged <- w.testProvider.get.getEvaluations.map(_.last._2)
+      merged <- w.testProvider.get.getRawEvaluations.map(_.last._2)
       _      <- ScenarioContext.update(_.copy(mergedCtx = Some(merged)))
     } yield ()
   }

--- a/conformance/src/test/scala/zio/openfeature/conformance/ConformanceSteps.scala
+++ b/conformance/src/test/scala/zio/openfeature/conformance/ConformanceSteps.scala
@@ -397,7 +397,7 @@ class ConformanceSteps extends ScalaDsl with EN {
       case None => eval.unit.orDieWith(e => new RuntimeException(String.valueOf(e)))
     }
     run(full)
-    mergedCtx = run(testProvider.getEvaluations).last._2
+    mergedCtx = run(testProvider.getRawEvaluations).last._2
   }
 
   Then("""^The merged context contains an entry with key "([^"]*)" and value "([^"]*)"$""") {

--- a/docs/testkit.md
+++ b/docs/testkit.md
@@ -108,14 +108,26 @@ for
 yield ()
 ```
 
-### Replacing All Flags
+### Setting Multiple Flags
+
+`setFlags` **merges** into the existing flags — flags seeded via `make(Map(...))` / `layer(Map(...))` or set earlier
+are kept, and a key present in the new map overwrites its previous value:
 
 ```scala
 provider.setFlags(Map(
   "flag-1" -> true,
   "flag-2" -> "value"
 ))
-// Previous flags are removed
+// Existing flags are kept; flag-1 / flag-2 are added or overwritten
+```
+
+Use `replaceFlags` to discard every existing flag first:
+
+```scala
+provider.replaceFlags(Map(
+  "flag-1" -> true
+))
+// All previous flags are removed; only flag-1 remains
 ```
 
 ### Removing Flags
@@ -169,8 +181,9 @@ for
                .provide(Scope.default >>> layer)
   evals    <- provider.getEvaluations
 yield
-  // evals is List[(String, dev.openfeature.sdk.EvaluationContext)]
-  // The context is the OpenFeature SDK's EvaluationContext (after conversion)
+  // evals is List[(String, zio.openfeature.EvaluationContext)] — the library's own context type,
+  // so you can assert on evals.head._2.targetingKey / .getString(...) directly.
+  // Need the raw dev.openfeature.sdk.EvaluationContext instead? Use provider.getRawEvaluations.
   assertTrue(evals.length == 2)
 ```
 
@@ -360,7 +373,8 @@ test("service evaluates expected flags") {
 
 ### Testing Context Propagation
 
-The `getEvaluations` method returns OpenFeature SDK contexts (after conversion from ZIO contexts). You can verify that context attributes were correctly propagated:
+The `getEvaluations` method returns each captured context as the library's own `EvaluationContext`, so you can assert
+on context propagation with the Scala API — no Java SDK types required:
 
 ```scala
 test("context is passed to provider") {
@@ -373,13 +387,16 @@ test("context is passed to provider") {
     _        <- FeatureFlags.boolean("feature", false, ctx)
                  .provide(Scope.default >>> layer)
     evals    <- provider.getEvaluations
-    (_, sdkCtx) = evals.head
+    (_, captured) = evals.head
   yield
-    // sdkCtx is dev.openfeature.sdk.EvaluationContext (Java SDK type)
-    assertTrue(sdkCtx.getTargetingKey == "user-123") &&
-    assertTrue(sdkCtx.getValue("plan") != null)
+    // captured is zio.openfeature.EvaluationContext (the library type)
+    assertTrue(captured.targetingKey.contains("user-123")) &&
+    assertTrue(captured.getString("plan").contains("premium"))
 }
 ```
+
+If you specifically need the raw `dev.openfeature.sdk.EvaluationContext` (e.g. to assert on the SDK type), use
+`getRawEvaluations` instead, which returns `List[(String, dev.openfeature.sdk.EvaluationContext)]`.
 
 ### Using Transactions for Override Testing
 

--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -3,7 +3,7 @@ package zio.openfeature.testkit
 import zio._
 import zio.stream._
 import zio.openfeature._
-import zio.openfeature.internal.{ErrorCodeConverter, ProviderEvaluations}
+import zio.openfeature.internal.{ContextConverter, ErrorCodeConverter, ProviderEvaluations}
 import dev.openfeature.sdk.{
   EvaluationContext => OFEvaluationContext,
   EventProvider,
@@ -191,8 +191,15 @@ final class TestFeatureProvider private (
   def setFlag[A](key: String, value: A): UIO[Unit] =
     ZIO.succeed(flags.put(key, value)).unit
 
-  /** Set multiple flag values. */
+  /** Merge these flag values into the existing flags. Flags seeded via `layer(Map(...))` / `make(Map(...))` or set by
+    * earlier `setFlag`/`setFlags` calls are kept; a key present in `newFlags` overwrites its previous value. Use
+    * [[replaceFlags]] to discard the existing flags first.
+    */
   def setFlags(newFlags: Map[String, Any]): UIO[Unit] =
+    ZIO.succeed(newFlags.foreach { case (k, v) => flags.put(k, v) })
+
+  /** Replace ALL flags with these — every existing flag is discarded first. */
+  def replaceFlags(newFlags: Map[String, Any]): UIO[Unit] =
     ZIO.succeed {
       flags.clear()
       newFlags.foreach { case (k, v) => flags.put(k, v) }
@@ -276,8 +283,15 @@ final class TestFeatureProvider private (
         }
       }
 
-  /** Get all evaluations that have been made. */
-  def getEvaluations: UIO[List[(String, OFEvaluationContext)]] =
+  /** All evaluations made so far, each captured context converted to the library's [[EvaluationContext]] so you can
+    * assert on `.targetingKey` / `.getString(...)` etc. directly instead of the Java SDK type. Use
+    * [[getRawEvaluations]] if you need the raw `dev.openfeature.sdk.EvaluationContext`.
+    */
+  def getEvaluations: UIO[List[(String, EvaluationContext)]] =
+    ZIO.succeed(evaluations.asScala.toList.map { case (key, ctx) => (key, ContextConverter.fromOpenFeature(ctx)) })
+
+  /** All evaluations made so far, with each captured context as the raw Java SDK `EvaluationContext`. */
+  def getRawEvaluations: UIO[List[(String, OFEvaluationContext)]] =
     ZIO.succeed(evaluations.asScala.toList)
 
   /** Clear the evaluation history. */

--- a/testkit/src/test/scala/zio/openfeature/testkit/TestFeatureProviderSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/TestFeatureProviderSpec.scala
@@ -10,6 +10,49 @@ import dev.openfeature.sdk.{ImmutableContext, MutableContext, ProviderState}
 object TestFeatureProviderSpec extends ZIOSpecDefault {
 
   def spec = suite("TestFeatureProviderSpec")(
+    suite("#272 testkit DX")(
+      test("G1: getEvaluations returns the library EvaluationContext (no Java SDK type leak)") {
+        for {
+          provider <- TestFeatureProvider.make
+          jctx = new MutableContext("user-1").add("tier", "gold")
+          _    = provider.getBooleanEvaluation("flag", true, jctx)
+          evals <- provider.getEvaluations
+        } yield {
+          val captured: EvaluationContext = evals.head._2
+          assertTrue(
+            captured.targetingKey.contains("user-1"),
+            captured.getString("tier").contains("gold")
+          )
+        }
+      },
+      test("G2: getRawEvaluations still exposes the raw Java SDK EvaluationContext") {
+        for {
+          provider <- TestFeatureProvider.make
+          jctx = new MutableContext("user-2")
+          _    = provider.getBooleanEvaluation("flag", true, jctx)
+          raw <- provider.getRawEvaluations
+        } yield {
+          val captured: dev.openfeature.sdk.EvaluationContext = raw.head._2
+          assertTrue(captured.getTargetingKey == "user-2")
+        }
+      },
+      test("G3: setFlags merges into existing flags — seeded flags survive") {
+        for {
+          provider <- TestFeatureProvider.make(Map("seeded" -> 1))
+          _        <- provider.setFlags(Map("added" -> 2))
+          seeded = provider.getIntegerEvaluation("seeded", 0, new ImmutableContext())
+          added  = provider.getIntegerEvaluation("added", 0, new ImmutableContext())
+        } yield assertTrue(seeded.getValue == 1, added.getValue == 2)
+      },
+      test("G4: replaceFlags discards existing flags") {
+        for {
+          provider <- TestFeatureProvider.make(Map("old" -> 1))
+          _        <- provider.replaceFlags(Map("new" -> 2))
+          old = provider.getIntegerEvaluation("old", 0, new ImmutableContext())
+          nw  = provider.getIntegerEvaluation("new", 0, new ImmutableContext())
+        } yield assertTrue(old.getValue == 0, nw.getValue == 2)
+      }
+    ),
     suite("initialization")(
       test("starts with Ready status after creation") {
         for {
@@ -73,10 +116,10 @@ object TestFeatureProviderSpec extends ZIOSpecDefault {
           result = provider.getStringEvaluation("new-flag", "default", new ImmutableContext())
         } yield assertTrue(result.getValue == "value")
       },
-      test("setFlags replaces all flags") {
+      test("replaceFlags replaces all flags") {
         for {
           provider <- TestFeatureProvider.make(Map("old" -> 1))
-          _        <- provider.setFlags(Map("new" -> 2))
+          _        <- provider.replaceFlags(Map("new" -> 2))
           oldResult = provider.getIntegerEvaluation("old", 0, new ImmutableContext())
           newResult = provider.getIntegerEvaluation("new", 0, new ImmutableContext())
         } yield assertTrue(oldResult.getValue == 0) && // default, flag no longer exists
@@ -161,7 +204,7 @@ object TestFeatureProviderSpec extends ZIOSpecDefault {
           ctx = new ImmutableContext("user-123")
           _   = provider.getBooleanEvaluation("flag", true, ctx)
           evals <- provider.getEvaluations
-        } yield assertTrue(evals.head._2.getTargetingKey == "user-123")
+        } yield assertTrue(evals.head._2.targetingKey.contains("user-123"))
       }
     ),
     suite("layer integration")(


### PR DESCRIPTION
## Summary
Two testkit ergonomics fixes for `TestFeatureProvider`.

## Changes
- **`getEvaluations` returns the library's own `EvaluationContext`** — `List[(String, zio.openfeature.EvaluationContext)]` (converted via the existing `ContextConverter.fromOpenFeature`) instead of leaking the Java SDK's `dev.openfeature.sdk.EvaluationContext`. Context-propagation assertions now use the Scala API (`.targetingKey`, `.getString(...)`) directly. The raw Java contexts remain available via the new **`getRawEvaluations`**.
- **`setFlags` now merges** into the existing flags rather than silently clearing everything first — flags seeded via `make(Map(...))` / `layer(Map(...))` or earlier `setFlag`/`setFlags` calls survive. The previous replace-all behavior is the new **`replaceFlags`**.

Both are breaking for testkit users; the CHANGELOG `Changed` entry documents the migration. Internal callers migrated in the same PR: the conformance harnesses use `getRawEvaluations`, and the testkit specs use the Scala API / `replaceFlags`.

## Tests
New gates G1–G4 (Scala-context return, raw Java escape hatch, merge semantics, replace semantics). Full cross-build (Scala 2.13 + 3.3) and both conformance suites green.

## Docs
`docs/testkit.md` updated for both methods.

Closes #272
