### PR TITLE
Docs accuracy sweep: broken provider snippet, Jekyll placeholder in README, three modules missing from all entry-point tables, quick-start ceremony

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ object MyApp extends ZIOAppDefault:
   yield ()
 
   def run = program.provide(
-    Scope.default >>> TestFeatureProvider.layer(Map("my-feature" -> true))
+    TestFeatureProvider.scopedLayer(Map("my-feature" -> true))
   )
 ```
 
@@ -112,7 +112,7 @@ object ProductionApp extends ZIOAppDefault:
 
 ### Using Optimizely Feature Experimentation
 
-`zio-openfeature-optimizely` is the first-party integration with [Optimizely](https://www.optimizely.com/products/feature-experimentation/). It validates the SDK key before constructing, uses the default 30 s `initTimeout`, and composes cleanly with `CircuitBreakerProvider` from `zio-openfeature-extras` for production resilience. See the [Optimizely guide]({{ site.baseurl }}/optimizely) for the full story (init timeout tuning, self-hosted Agent, what to alert on).
+`zio-openfeature-optimizely` is the first-party integration with [Optimizely](https://www.optimizely.com/products/feature-experimentation/). It validates the SDK key before constructing, uses the default 30 s `initTimeout`, and composes cleanly with `CircuitBreakerProvider` from `zio-openfeature-extras` for production resilience. See the [Optimizely guide](https://etacassiopeia.github.io/zio-openfeature/optimizely) for the full story (init timeout tuning, self-hosted Agent, what to alert on).
 
 ```scala
 import zio.*
@@ -254,6 +254,9 @@ FeatureFlags.onConfigurationChanged { (flags, _) =>
 | Module | Description |
 |--------|-------------|
 | **core** | ZIO wrapper around OpenFeature SDK with FeatureFlags service |
+| **extras** | Built-in providers: HOCON, env vars, and a caching wrapper |
+| **ofrep** | OpenFeature Remote Evaluation Protocol (OFREP) provider over HTTP |
+| **optimizely** | First-party Optimizely Feature Experimentation integration |
 | **testkit** | TestFeatureProvider for testing without external dependencies |
 
 ## Documentation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,6 +28,12 @@ libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-core" % "<v
 // Built-in providers: HOCON, env vars, caching wrapper (optional)
 libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-extras" % "<version>"
 
+// OFREP — OpenFeature Remote Evaluation Protocol provider (HTTP)
+libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-ofrep" % "<version>"
+
+// Optimizely Feature Experimentation — direct integration on top of the Optimizely Java SDK
+libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-optimizely" % "<version>"
+
 // For testing
 libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-testkit" % "<version>" % Test
 ```
@@ -80,7 +86,7 @@ object TestApp extends ZIOAppDefault:
   yield ()
 
   def run = program.provide(
-    Scope.default >>> TestFeatureProvider.layer(Map("my-feature" -> true))
+    TestFeatureProvider.scopedLayer(Map("my-feature" -> true))
   )
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,8 @@ object MyApp extends ZIOAppDefault:
 | [Getting Started]({{ site.baseurl }}/getting-started) | Installation and basic usage |
 | [Architecture]({{ site.baseurl }}/architecture) | Core design and components |
 | [Providers]({{ site.baseurl }}/providers) | Using OpenFeature providers |
+| [Extras]({{ site.baseurl }}/extras) | HOCON, env var, and caching providers |
+| [Optimizely]({{ site.baseurl }}/optimizely) | Optimizely Feature Experimentation integration |
 | [Evaluation Context]({{ site.baseurl }}/context) | Targeting and context hierarchy |
 | [Hooks]({{ site.baseurl }}/hooks) | Cross-cutting concerns |
 | [Transactions]({{ site.baseurl }}/transactions) | Flag overrides and tracking |
@@ -65,6 +67,9 @@ object MyApp extends ZIOAppDefault:
 | Module | Description |
 |:-------|:------------|
 | **core** | ZIO wrapper around OpenFeature SDK |
+| **extras** | Built-in HOCON, env var, and caching providers |
+| **ofrep** | OpenFeature Remote Evaluation Protocol (OFREP) provider over HTTP |
+| **optimizely** | First-party Optimizely Feature Experimentation integration |
 | **testkit** | In-memory provider for testing |
 
 ## Requirements

--- a/docs/optimizely.md
+++ b/docs/optimizely.md
@@ -321,7 +321,7 @@ Hybrid: Optimizely serves the bulk of flags; a small `EnvVarProvider` is the sec
 
 ```scala
 import zio.openfeature.extras.EnvVarProvider
-import dev.openfeature.sdk.multiprovider.FirstSuccessfulStrategy
+import zio.openfeature.MultiProviderStrategy
 
 val critical = Map(
   "FF_MAINTENANCE_MODE"    -> "false",
@@ -333,14 +333,14 @@ ZIO.scoped {
     optimizely <- OptimizelyProvider.make(sys.env("OPTIMIZELY_SDK_KEY"))
     envProvider = EnvVarProvider.withLookup(critical.get)
     env        <- FeatureFlags.fromProvider(
-                    FeatureFlags.multiProvider(List(optimizely, envProvider), new FirstSuccessfulStrategy()),
+                    FeatureFlags.multiProvider(List(optimizely, envProvider), MultiProviderStrategy.firstSuccessful),
                     FeatureFlagsConfig(initMode = InitMode.Async)
                   ).build
   yield env.get[FeatureFlags]
 }
 ```
 
-`FirstSuccessfulStrategy` tries Optimizely first; if it fails or is unready, falls through to `EnvVarProvider`. Because `EnvVarProvider` is instantly `Ready`, the `MultiProvider`'s aggregate state is `Ready` immediately and the 30-second watchdog never fires — meaning Optimizely-specific failures are no longer visible at the `FeatureFlags` layer. If you want to alert on Optimizely-side problems anyway, poll the underlying client's `isValid` from a side healthcheck or hook into `onProviderError`.
+`MultiProviderStrategy.firstSuccessful` tries Optimizely first; if it fails or is unready, falls through to `EnvVarProvider`. Because `EnvVarProvider` is instantly `Ready`, the `MultiProvider`'s aggregate state is `Ready` immediately and the 30-second watchdog never fires — meaning Optimizely-specific failures are no longer visible at the `FeatureFlags` layer. If you want to alert on Optimizely-side problems anyway, poll the underlying client's `isValid` from a side healthcheck or hook into `onProviderError`.
 
 ### Picking between A, B, and C
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -22,9 +22,9 @@ ZIO OpenFeature wraps the [OpenFeature Java SDK](https://openfeature.dev/docs/re
 ```scala
 import zio.*
 import zio.openfeature.*
-import dev.openfeature.contrib.providers.optimizely.OptimizelyProvider
+import dev.openfeature.contrib.providers.flagd.FlagdProvider
 
-val layer = FeatureFlags.fromProvider(provider)
+val layer = FeatureFlags.fromProvider(new FlagdProvider())
 
 program.provide(Scope.default >>> layer)
 ```


### PR DESCRIPTION
## Summary

- Fixed broken Scala code snippet in README (TestFeatureProvider layer method)
- Fixed Jekyll template placeholder in README link to Optimizely guide
- Added three missing modules to module tables: extras, ofrep, optimizely
- Updated getting-started.md quick-start instructions with missing imports
- Fixed incorrect import statements in optimizely.md documentation

Closes #270