### PR TITLE
CI/build hygiene: coverage gate never runs; examples job skips the testkit example's spec; no dependency-update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+# Dependabot keeps the GitHub Actions used by our workflows current. It does not support sbt/Scala
+# dependencies — those are handled by Scala Steward (see .github/workflows/scala-steward.yml).
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "kind:chore"
+      - "area:release"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
         run: sbt +mimaReportBinaryIssues
 
   # Examples are not published artifacts but must compile so the README snippets and `examples/` reference code stay
-  # honest. Cheap to run; gives early signal when a public API change breaks the documented usage.
+  # honest. The testkit example additionally runs its spec (UserServiceSpec) — the canonical demonstration of the
+  # testing story — so a public API change that breaks the documented usage fails CI instead of rotting silently.
   examples:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -94,8 +95,8 @@ jobs:
           cache: sbt
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-      - name: Compile examples
-        run: sbt "examplesOfrepInitTimeout/compile" "examplesTestkitApp/compile"
+      - name: Compile and test examples
+        run: sbt "examplesOfrepInitTimeout/compile" "examplesTestkitApp/test"
 
   # Conformance runs the vendored OpenFeature gherkin suite via Cucumber. It is Scala 3 only and not aggregated by
   # root (so `++2.13.16 test` doesn't try to compile it), hence its own job on the primary JDK / default Scala.

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,26 @@
+name: Scala Steward
+
+# Scala Steward opens PRs to update sbt/Scala dependencies (the scala-version, plugins, and library
+# dependencies in build.sbt / project/*), which Dependabot cannot do. It runs on a schedule and can be
+# triggered manually; it never runs on pull_request, so it is not part of the CI merge gate.
+#
+# By default it authenticates with the built-in GITHUB_TOKEN. PRs opened by that token do not themselves
+# trigger CI; to have Steward's update PRs run CI automatically, create a Personal Access Token with `repo`
+# scope, store it as the `SCALA_STEWARD_TOKEN` secret, and set `github-token: ${{ secrets.SCALA_STEWARD_TOKEN }}`.
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  scala-steward:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Scala Steward
+        uses: scala-steward-org/scala-steward-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/build.sbt
+++ b/build.sbt
@@ -78,9 +78,12 @@ ThisBuild / scalacOptions ++= {
   }
 }
 
-ThisBuild / coverageEnabled          := false
-ThisBuild / coverageMinimumStmtTotal := 80
-ThisBuild / coverageFailOnMinimum    := true
+// Coverage is opt-in (`sbt coverage test coverageReport`), never wired into CI. No fail-on-minimum gate is set:
+// under the pinned sbt-scoverage 2.0.9, coverage instrumentation fails to compile the testkit module on Scala 3.3.4
+// (the instrumenter cannot rewrite `<FromJavaObject>` terms from the OpenFeature Java SDK), so an enforced 80% gate
+// would be an unrunnable, always-red trap. The Scala Steward automation (.github/workflows/scala-steward.yml) will
+// surface the sbt-scoverage 2.3.x bump; once instrumentation compiles again, a coverage CI job can be reintroduced.
+ThisBuild / coverageEnabled := false
 
 // Binary-compatibility check via sbt-mima. `mimaPreviousArtifacts` is intentionally empty across all modules while
 // the project is pre-1.0: the `1.0.0-RCx` line is still making deliberate breaking changes, so baselining against an

--- a/examples/testkit-app/src/test/scala/example/UserServiceSpec.scala
+++ b/examples/testkit-app/src/test/scala/example/UserServiceSpec.scala
@@ -35,10 +35,10 @@ object UserServiceSpec extends ZIOSpecDefault {
         greeting <- svc.welcome("bob")
       } yield assertTrue(greeting.contains("Hey bob"))
     },
-    test("evaluation fails fast when the provider is in Error state") {
+    test("evaluation fails fast when the provider is not ready") {
       for {
         provider <- ZIO.service[TestFeatureProvider]
-        _        <- provider.setStatus(ProviderStatus.Error)
+        _        <- provider.setStatus(ProviderStatus.NotReady)
         svc      <- ZIO.service[UserService]
         result   <- svc.welcome("carol").either
       } yield assertTrue(


### PR DESCRIPTION
## Summary

- **Coverage**: Removed never-enforced 80% coverage gate. It was unrunnable — `sbt coverage test` fails to compile the testkit module under sbt-scoverage 2.0.9 on Scala 3.3.4 (instrumenter can't rewrite `<FromJavaObject>` terms). Scala Steward automation will surface the sbt-scoverage 2.3.x bump that could re-enable a coverage job.
- **Examples**: CI now runs `examplesTestkitApp/test`. This surfaced that UserServiceSpec had silently rotted — third test asserted pre-#245 behavior; per spec 1.7.6/1.7.7 Error-state providers now proceed. Corrected test to drive `ProviderStatus.NotReady` (which does fail fast) and expect `ProviderNotReady`. 3/3 green.
- **Dependency automation**: Added `.github/dependabot.yml` (GitHub Actions) + `.github/workflows/scala-steward.yml` (sbt/Scala deps; schedule + manual only, does not gate CI).

Closes #271