### PR TITLE
Add a Rift intercept (TLS-MITM) matrix test exercising the real Optimizely CDN URL path

### DIFF
--- a/conformance-zio-bdd/src/test/java/com/optimizely/ab/OptimizelyHttpClients.java
+++ b/conformance-zio-bdd/src/test/java/com/optimizely/ab/OptimizelyHttpClients.java
@@ -1,0 +1,23 @@
+package com.optimizely.ab;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+
+/**
+ * Test-only factory that wraps a fully-configured Apache {@link CloseableHttpClient} in an
+ * {@link OptimizelyHttpClient}. It lives in the {@code com.optimizely.ab} package specifically so it can
+ * call the package-private {@code OptimizelyHttpClient(CloseableHttpClient)} constructor — the same
+ * technique the production {@link ObservingOptimizelyHttpClient} uses (issue #267).
+ *
+ * <p>The SDK's public {@code OptimizelyHttpClient.Builder} exposes only connection-pool / timeout /
+ * retry knobs — no custom {@code SSLContext} or proxy. The Rift TLS-MITM intercept test needs both (trust
+ * Rift's CA, route {@code cdn.optimizely.com:443} through the intercept listener), so it builds the Apache
+ * client itself and wraps it here rather than going through the closed builder.
+ */
+public final class OptimizelyHttpClients {
+
+    private OptimizelyHttpClients() {}
+
+    public static OptimizelyHttpClient fromApache(CloseableHttpClient underlying) {
+        return new OptimizelyHttpClient(underlying);
+    }
+}

--- a/conformance-zio-bdd/src/test/resources/features/optimizely-intercept/intercept.feature
+++ b/conformance-zio-bdd/src/test/resources/features/optimizely-intercept/intercept.feature
@@ -1,0 +1,9 @@
+Feature: Optimizely datafile over the real default CDN URL via TLS-MITM
+
+  The provider keeps its default datafile URL (datafileUrl = None), so the SDK constructs the production
+  URL https://cdn.optimizely.com/datafiles/<key>.json and performs a real HTTPS fetch. Rift's intercept
+  engine MITMs that request and serves the datafile fixture, proving the default-CDN transport path works.
+
+  @flags(datafile=kill-switch-off)
+  Scenario: Datafile fetched over the default CDN URL via TLS-MITM resolves flags
+    Then the recommendation service returns kind "alpha"

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/InterceptFlagMatrixSpec.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/conformance/bdd/matrix/InterceptFlagMatrixSpec.scala
@@ -1,0 +1,44 @@
+package zio.openfeature.conformance.bdd.matrix
+
+import zio._
+import zio.bdd.core.Suite
+import zio.bdd.core.Assertions.assertTrue
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.gherkin.ScenarioMetadata
+import zio.openfeature._
+import zio.openfeature.optimizely.matrix.{InterceptHarness, RecommendationService}
+
+/** Rift intercept (TLS-MITM) suite — exercises the SDK's REAL default-CDN transport path (#280).
+  *
+  * Unlike [[FlagMatrixSpec]] / [[MatrixHarness]], which override `datafileUrl` to a mock URL and fetch over
+  * plain HTTP, this suite leaves `datafileUrl = None` so the Optimizely SDK builds its production URL
+  * (`https://cdn.optimizely.com/datafiles/<key>.json`) and performs a real HTTPS fetch — which Rift's intercept
+  * engine transparently MITMs, serving the datafile fixture. It proves the same decision logic works over the
+  * default URL template + HTTPS + TLS-trust path a production deployment uses.
+  *
+  * `scenarioParallelism = 1`: the intercept listener is per-engine, and each scenario stands up its own intercept
+  * engine + per-provider `OptimizelyHttpClient` (trusting Rift's CA, routing through the intercept listener) — no
+  * JVM-global proxy/truststore, so nothing leaks across suites (#278).
+  */
+@Suite(
+  featureDirs         = Array("conformance-zio-bdd/src/test/resources/features/optimizely-intercept"),
+  reporters           = Array("pretty"),
+  parallelism         = 1,
+  scenarioParallelism = 1,
+  logLevel            = "warning"
+)
+object InterceptFlagMatrixSpec extends ZIOSteps[FeatureFlags, World] {
+
+  override def flagLayer(meta: ScenarioMetadata, flags: Map[String, String]): ZLayer[Any, Throwable, FeatureFlags] =
+    InterceptHarness.layerForDatafile(flags.getOrElse("datafile", "kill-switch-off"))
+
+  Then("the recommendation service returns kind " / string) { (expected: String) =>
+    ZIO.serviceWithZIO[FeatureFlags] { ff =>
+      val svc = new RecommendationService(ff)
+      for {
+        kind <- svc.recommend
+        _    <- assertTrue(kind == expected, s"recommendation kind '$kind' != '$expected'")
+      } yield ()
+    }
+  }
+}

--- a/conformance-zio-bdd/src/test/scala/zio/openfeature/optimizely/matrix/InterceptHarness.scala
+++ b/conformance-zio-bdd/src/test/scala/zio/openfeature/optimizely/matrix/InterceptHarness.scala
@@ -1,0 +1,109 @@
+package zio.openfeature.optimizely.matrix
+
+import zio._
+import zio.bdd.mock._
+import zio.bdd.mock.rift.embedded.EmbeddedRift
+import zio.openfeature._
+import zio.openfeature.optimizely.{OptimizelyProvider, OptimizelyProviderConfig}
+
+import java.io.FileInputStream
+import java.security.KeyStore
+import javax.net.ssl.{SSLContext, TrustManagerFactory}
+import org.apache.http.HttpHost
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.impl.client.HttpClients
+
+/** Builds a per-scenario `ZLayer[Any, Throwable, FeatureFlags]` in which the Optimizely SDK fetches its
+  * datafile over its REAL default CDN URL (`https://cdn.optimizely.com/datafiles/<key>.json`, `datafileUrl =
+  * None`) — the datafile is delivered by Rift's TLS-MITM intercept engine instead of the real CDN.
+  *
+  * This exercises the production transport path (default URL template + HTTPS + TLS trust) that the direct-URL
+  * matrix suites (`MatrixHarness`) deliberately bypass by overriding `datafileUrl`.
+  *
+  * Everything is per-provider-instance — the SDK is handed an `OptimizelyHttpClient` that trusts Rift's CA and
+  * routes through the intercept listener. No `javax.net.ssl.trustStore` / `https.proxyHost` system properties are
+  * set, so nothing leaks across suites (the JVM-global-proxy leakage that #278 removed stays gone).
+  *
+  * Lives in package `zio.openfeature.optimizely.matrix` so it can inject the client via the
+  * `private[optimizely]` `OptimizelyProvider.scoped(config, httpClient)` seam.
+  */
+object InterceptHarness {
+
+  private val CdnHost = "cdn.optimizely.com"
+
+  private def loadDatafile(name: String): String = {
+    val path = s"/datafiles/$name.json"
+    val is   = getClass.getResourceAsStream(path)
+    require(is != null, s"Datafile fixture not found on classpath: $path")
+    try scala.io.Source.fromInputStream(is).mkString
+    finally is.close()
+  }
+
+  /** Build an SSLContext that trusts the CA behind Rift's intercept-generated (PKCS12) truststore. */
+  private def sslContextTrusting(trust: TrustStore): SSLContext = {
+    val ks  = KeyStore.getInstance("PKCS12")
+    val fis = new FileInputStream(trust.path.toFile)
+    try ks.load(fis, trust.password.toCharArray)
+    finally fis.close()
+    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+    tmf.init(ks)
+    val ctx = SSLContext.getInstance("TLS")
+    ctx.init(null, tmf.getTrustManagers, null)
+    ctx
+  }
+
+  def layerForDatafile(name: String): ZLayer[Any, Throwable, FeatureFlags] =
+    ZLayer.scoped {
+      for {
+        mc <- (Provisioning.live >>> EmbeddedRift.layer(EmbeddedRift.InterceptConfig())).build
+                .map(_.get[MockControl])
+                .mapError(e => new RuntimeException(s"intercept engine init failed: $e"))
+        icept <- mc.intercept.mapError(e => new RuntimeException(s"intercept unsupported: $e"))
+        _ <- icept
+               .respondWith(
+                 CdnHost,
+                 InterceptStub(200, Map("Content-Type" -> "application/json"), Some(loadDatafile(name)))
+               )
+               .mapError(e => new RuntimeException(s"intercept respondWith failed: $e"))
+        endpoint <- icept.proxyEndpoint.mapError(e => new RuntimeException(s"proxyEndpoint failed: $e"))
+        (proxyHost, proxyPort) = endpoint
+        trust <- icept.trustStore().mapError(e => new RuntimeException(s"trustStore export failed: $e"))
+        ssl   <- ZIO.attemptBlocking(sslContextTrusting(trust)).mapError(e => new RuntimeException(s"SSLContext build failed: $e"))
+        // Explicit connect/socket timeouts: bypassing OptimizelyHttpClient.Builder also drops its default 10s
+        // timeouts, so an unreachable intercept endpoint would otherwise only fail via the provider's init latch.
+        // These make a broken MITM fail fast at the HTTP layer instead.
+        requestConfig = RequestConfig
+                          .custom()
+                          .setConnectTimeout(5000)
+                          .setSocketTimeout(5000)
+                          .setConnectionRequestTimeout(5000)
+                          .build()
+        apache <- ZIO
+                    .attempt(
+                      HttpClients
+                        .custom()
+                        .setSSLContext(ssl)
+                        .setProxy(new HttpHost(proxyHost, proxyPort.toInt))
+                        .setDefaultRequestConfig(requestConfig)
+                        .build()
+                    )
+                    .mapError(e => new RuntimeException(s"HTTP client build failed: $e"))
+        // Bound the close like the production releaseProvider: a client wedged mid-handshake must not hang scope
+        // teardown, and finalizers run uninterruptibly, so `.disconnect` lets the timeout still fire.
+        _ <- ZIO.addFinalizer(
+               ZIO.attempt(apache.close()).disconnect.timeout(5.seconds).ignore
+             )
+        optClient <- ZIO.succeed(com.optimizely.ab.OptimizelyHttpClients.fromApache(apache))
+        config = OptimizelyProviderConfig(
+                   sdkKey = "intercept-matrix-key",
+                   datafileUrl = None, // real default CDN URL — MITM'd by Rift
+                   initWait = java.time.Duration.ofSeconds(10),
+                   pollingInterval = Some(java.time.Duration.ofSeconds(3600)),
+                   blockingTimeout = Some(java.time.Duration.ofSeconds(5))
+                 )
+        provider <- OptimizelyProvider.scoped(config, Some(optClient)).mapError(e => new RuntimeException(e.message))
+        domain    = s"intercept-matrix-${java.util.UUID.randomUUID()}"
+        env      <- FeatureFlags.fromProvider(provider, FeatureFlagsConfig().withDomain(domain)).build
+      } yield env.get[FeatureFlags]
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one zio-bdd scenario that exercises the SDK's default-CDN transport path
- Provider keeps datafileUrl=None so SDK builds https://cdn.optimizely.com/datafiles/<key>.json and fetches over HTTPS
- Rift's intercept engine TLS-MITMs to serve the datafile fixture
- Per-provider OptimizelyHttpClient injection trusts Rift's CA via exported PKCS12 truststore and routes through the intercept listener
- No JVM-global proxy/truststore sysprops (keeps #278's leakage gone)
- Complements existing direct-URL matrix suites (keeps both)
- Verified green locally on JDK21 (full conformanceZioBdd module)

Closes #280