### PR TITLE
NonBlockingInitSpec AC3 flaky — await the SDK's async fallback shutdown before asserting

### DIFF
--- a/core/src/test/scala/zio/openfeature/NonBlockingInitSpec.scala
+++ b/core/src/test/scala/zio/openfeature/NonBlockingInitSpec.scala
@@ -182,13 +182,15 @@ object NonBlockingInitSpec extends ZIOSpecDefault {
               hooks    <- ff.hooks
               ctx      <- ff.globalContext
               createdN <- ZIO.succeed(created.get())
-              fbDown   <- ZIO.succeed(fbShutdowns.get())
+              // The SDK's ProviderRepository.shutDownOld runs the old fallback's shutdown() asynchronously on its
+              // task executor, so poll for the count rather than reading immediately (which could race it, #320).
+              fbDown <- Live.live(ZIO.succeed(fbShutdowns.get()).repeatUntil(_ >= 1).timeout(5.seconds))
             } yield assertTrue(
               swapped.contains(Right(true)),
               hooks.contains(hook),                     // hooks survive the swap
               ctx.getString("marker").contains("keep"), // context survives the swap
               createdN == 2,                            // first fallback + fresh fallback
-              fbDown == 1                               // pre-swap fallback shut down exactly once
+              fbDown.contains(1)                        // pre-swap fallback shut down exactly once
             )
           }
       }


### PR DESCRIPTION
AC3 test read `fbShutdowns.get()` eagerly after confirming the provider swap, but the OpenFeature SDK's `ProviderRepository.shutDownOld` runs the old fallback's `shutdown()` asynchronously on its task executor, so a fast read intermittently observed 0 (issue evidence: failed once in a full `sbt test`, 3/3 green isolated). Fix mirrors the #311 AC4 hardening in the same file: `Live.live(ZIO.succeed(fbShutdowns.get()).repeatUntil(_ >= 1).timeout(5.seconds))` + `fbDown.contains(1)` — awaits the async finalizer deterministically, still fails loudly on never-shutdown (None) and double-shutdown (Some(2)). Verified: spec green 5/5 consecutive runs, full core/test 505 pass.

Closes #320