### PR TITLE
Prepare 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-07-12
+
+First stable release. **Upgrading from 0.9.x:** two behavior changes may require action —
+**`FlagType` decoders no longer coerce silently** (strict type decoding, #187) and a **1-second default
+per-evaluation timeout** (bounds hung providers; opt out with `evaluationTimeout = None`). Note also the
+**BREAKING** entries below — the `EvaluationTimeout` ADT (#251) and the `FeatureHook.before` signature
+change (#247) — and the **Removed** `OpenFeatureAPIFactory` shim (#316). Details in the entries below.
+
 ### Added
 
 - **`FeatureFlagsConfig` and the config-driven `FeatureFlags.fromProvider(provider, config)` factory** (#253). The 17
@@ -360,17 +368,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clients the caller never touched. `shutdown` now only shuts the API when the instance solely owns it; a shared-API
   (registry/domain) client leaves the shared API and its provider untouched — both are owned by whatever owns the API
   (e.g. the registry, which tears every provider down once on its own scope close) — and releases only its own state.
-
-## [1.0.0] — unreleased
-
-> **Not yet published.** The latest artifact on Maven Central is `1.0.0-RC2`; the `v1.0.0` tag has not been
-> cut. The changes below shipped in the `1.0.0-RC1`/`1.0.0-RC2` pre-releases and are staged for the first
-> stable release. This heading is dated when `v1.0.0` is tagged (see [`RELEASING.md`](RELEASING.md)).
-
-Planned first stable release. **Upgrading from 0.9.x:** two behavior changes may require action —
-**`FlagType` decoders no longer coerce silently** (strict type decoding, #187) and a **1-second default
-per-evaluation timeout** (bounds hung providers; opt out with `evaluationTimeout = None`). Details in the
-entries below.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ ZIO OpenFeature provides a type-safe, functional interface for feature flag eval
 
 | ZIO OpenFeature | OpenFeature Spec | OpenFeature Java SDK |
 |:----------------|:-----------------|:---------------------|
-| 1.0.0-RC2 (latest published) | [v0.8.0](https://github.com/open-feature/spec/releases/tag/v0.8.0) | 1.20.2 |
-| 1.0.0 (upcoming) | [v0.8.0](https://github.com/open-feature/spec/releases/tag/v0.8.0) | 1.21.0 |
+| 1.0.0 (latest published) | [v0.8.0](https://github.com/open-feature/spec/releases/tag/v0.8.0) | 1.21.0 |
+| 1.0.0-RC2 | [v0.8.0](https://github.com/open-feature/spec/releases/tag/v0.8.0) | 1.20.2 |
 
 This library implements the **dynamic-context paradigm** (server-side) of the OpenFeature specification. See [Spec Compliance](https://etacassiopeia.github.io/zio-openfeature/spec-compliance) for details.
 
@@ -62,8 +62,8 @@ resolvers += "Sonatype Central Snapshots" at "https://central.sonatype.com/repos
 libraryDependencies += "io.github.etacassiopeia" %% "zio-openfeature-core" % "<snapshot-version>"
 ```
 
-Snapshots share a single moving coordinate — the next version with a `-SNAPSHOT` suffix (e.g. `1.0.0-RC3-SNAPSHOT`
-while `v1.0.0-RC2` is the latest release tag). Every `main` commit republishes to that same version, so you can pin
+Snapshots share a single moving coordinate — the next version with a `-SNAPSHOT` suffix (e.g. `1.0.1-SNAPSHOT`
+while `v1.0.0` is the latest release tag). Every `main` commit republishes to that same version, so you can pin
 it and pull the newest build via a normal `-SNAPSHOT` refresh. The current coordinate is the latest tag with its
 final segment bumped; find it in the
 [snapshots repository](https://central.sonatype.com/repository/maven-snapshots/io/github/etacassiopeia/) or the


### PR DESCRIPTION
Release-prep docs for the first stable `1.0.0` (docs-only, no code changes).

- **CHANGELOG**: fold the pending `[Unreleased]` and `[1.0.0] — unreleased` sections into a single dated `## [1.0.0] — 2026-07-12`; drop the "not yet published" note; keep the "Upgrading from 0.9.x" guidance as the section intro and extend it to flag the BREAKING (#251, #247) and Removed (#316) entries.
- **README**: compatibility table now lists `1.0.0` (Java SDK 1.21.0) as latest published, RC2 demoted to a history row; snapshot-coordinate example updated to `1.0.1-SNAPSHOT` / `v1.0.0`.

MiMa baseline is intentionally left for a post-publish follow-up (can't baseline against an artifact not yet on Maven Central). The `v1.0.0` tag is the publish trigger and is cut separately after this merges.