### PR TITLE
Re-sync vendored gherkin to spec v0.9.0 and add drift detection

### DIFF
--- a/.github/scripts/check-gherkin-drift.sh
+++ b/.github/scripts/check-gherkin-drift.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Detect drift between the vendored OpenFeature gherkin conformance assets and upstream.
+#
+# Two independent invariants, because they fail for different reasons and want different gates:
+#
+#   upstream  the vendored files match `specification/assets/gherkin/` in open-feature/spec at a
+#             given ref. Drift here is upstream moving, not a PR author's doing, so the workflow
+#             that runs this is scheduled, never a PR gate.
+#   mirror    the two in-repo copies (conformance/ and conformance-zio-bdd/) are byte-identical to
+#             each other. Breaking that IS a PR author's doing, so CI runs this one per PR.
+#
+# Usage:
+#   check-gherkin-drift.sh mirror
+#   check-gherkin-drift.sh upstream [<ref>] [--report <file>]
+#
+# `<ref>` defaults to the pinned tag below. Pass `main` to ask "has upstream moved since the pin?".
+# Exit 0 = no drift, 1 = drift found (report written), 2 = usage/fetch error.
+#
+# Exit 2 is deliberately distinct from 1: a GitHub API failure or an empty upstream listing means
+# the check could not run, and reporting "no drift" for it would be the silent-fallback this whole
+# job exists to prevent. The workflow treats 2 as a failure without filing a drift issue.
+
+set -euo pipefail
+
+# The spec ref these assets are vendored from. Keep in sync with the conformance README.
+PINNED_REF="v0.9.0"
+
+UPSTREAM_REPO="open-feature/spec"
+UPSTREAM_DIR="specification/assets/gherkin"
+
+CUCUMBER_DIR="conformance/src/test/resources/zio/openfeature/conformance"
+ZIOBDD_DIR="conformance-zio-bdd/src/test/resources/features/openfeature"
+
+# The vendoring contract is the gherkin *suites* — `*.feature` and nothing else. Upstream's
+# gherkin directory also ships `README.md` (documentation of their assets; ours in the same
+# directory documents our vendoring and is a local artifact that merely shares the name) and
+# `test-flags.json` (fixture data our step definitions supply from `Fixtures.scala` instead).
+# Both predate the current pin, so neither is new drift. Restricting the comparison to
+# `*.feature` states that contract directly, and still catches a brand-new upstream suite —
+# which is the case the file-set comparison exists for.
+FEATURE_GLOB="*.feature"
+
+# Feature files upstream ships that we deliberately do NOT vendor. `evaluation.feature` is
+# entirely @deprecated and both runners exclude that tag, so vendoring it would add only dead
+# scenarios. Without this list the upstream check would report it missing on every run.
+EXCLUDED_FILES=("evaluation.feature")
+
+die() {
+  echo "error: $*" >&2
+  exit 2
+}
+
+is_excluded() {
+  local candidate="$1" excluded
+  for excluded in "${EXCLUDED_FILES[@]}"; do
+    [[ "$candidate" == "$excluded" ]] && return 0
+  done
+  return 1
+}
+
+# --- mirror -----------------------------------------------------------------------------------
+# Compares the two vendored copies against each other. The zio-bdd module holds exactly the
+# OpenFeature files; its Optimizely-specific features live in sibling directories and are not
+# part of this invariant.
+check_mirror() {
+  local drift=0 compared=0 name counterpart
+
+  [[ -d "$CUCUMBER_DIR" ]] || die "missing directory: $CUCUMBER_DIR"
+  [[ -d "$ZIOBDD_DIR" ]] || die "missing directory: $ZIOBDD_DIR"
+
+  for path in "$CUCUMBER_DIR"/*.feature; do
+    [[ -e "$path" ]] || continue
+    compared=$((compared + 1))
+    name="$(basename "$path")"
+    counterpart="$ZIOBDD_DIR/$name"
+    if [[ ! -f "$counterpart" ]]; then
+      echo "MIRROR DRIFT: $name exists in $CUCUMBER_DIR but not in $ZIOBDD_DIR" >&2
+      drift=1
+    elif ! diff -q "$path" "$counterpart" >/dev/null; then
+      echo "MIRROR DRIFT: $name differs between the two vendored copies" >&2
+      diff -u "$path" "$counterpart" >&2 || true
+      drift=1
+    fi
+  done
+
+  for path in "$ZIOBDD_DIR"/*.feature; do
+    [[ -e "$path" ]] || continue
+    name="$(basename "$path")"
+    if [[ ! -f "$CUCUMBER_DIR/$name" ]]; then
+      echo "MIRROR DRIFT: $name exists in $ZIOBDD_DIR but not in $CUCUMBER_DIR" >&2
+      drift=1
+    fi
+  done
+
+  # A checker that passes because it found nothing to check is indistinguishable from a checker
+  # that verified everything — the same vacuous-green shape this job exists to prevent.
+  [[ $compared -gt 0 ]] || die "no .feature files in $CUCUMBER_DIR; refusing to report 'identical' vacuously"
+
+  if [[ $drift -eq 0 ]]; then
+    echo "mirror: $compared vendored copies are identical"
+  fi
+  return $drift
+}
+
+# --- upstream ---------------------------------------------------------------------------------
+check_upstream() {
+  local ref="$1" report="${2:-}"
+  local tmp drift=0 name
+  tmp="$(mktemp -d)" || die "mktemp failed"
+  # EXIT, not RETURN: `die` ends in `exit`, and a RETURN trap does not fire on exit — so every
+  # `die` path below would leak the temp dir. This is the only trap the script installs, so there
+  # is nothing to clobber.
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp'" EXIT
+
+  command -v gh >/dev/null || die "gh CLI is required"
+  [[ -d "$CUCUMBER_DIR" ]] || die "missing directory: $CUCUMBER_DIR"
+
+  # Compare the file SET as well as contents: a brand-new upstream suite is drift we must notice,
+  # and a contents-only loop would never see it.
+  if ! gh api "repos/$UPSTREAM_REPO/contents/$UPSTREAM_DIR?ref=$ref" \
+    --jq '.[] | select(.type == "file") | .name' >"$tmp/all-names" 2>"$tmp/gh-err"; then
+    die "failed to list $UPSTREAM_DIR at $ref: $(cat "$tmp/gh-err")"
+  fi
+  [[ -s "$tmp/all-names" ]] || die "upstream listing at $ref was empty"
+  grep -E '\.feature$' "$tmp/all-names" >"$tmp/upstream-names" || true
+  [[ -s "$tmp/upstream-names" ]] || die "no .feature files found upstream at $ref"
+
+  # Guarded so an infrastructure failure (disk full, permissions) dies as exit 2 "could not check"
+  # rather than falling out of `set -e` as exit 1, which the workflow reads as "drift found".
+  : >"$tmp/report" || die "cannot write report scratch file"
+
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    if is_excluded "$name"; then
+      echo "skip (excluded): $name"
+      continue
+    fi
+    # Raw media type rather than the base64 `.content` field: `base64 --decode` is GNU-only
+    # spelling (BSD/macOS wants -D), and this check must run identically on a dev machine and on
+    # the ubuntu runner.
+    if ! gh api "repos/$UPSTREAM_REPO/contents/$UPSTREAM_DIR/$name?ref=$ref" \
+      -H "Accept: application/vnd.github.raw" >"$tmp/$name" 2>"$tmp/gh-err"; then
+      die "failed to download $name at $ref: $(cat "$tmp/gh-err")"
+    fi
+    if [[ ! -f "$CUCUMBER_DIR/$name" ]]; then
+      {
+        echo "### $name — present upstream, not vendored"
+        echo "A new upstream suite, or one dropped locally. Vendor it or add it to EXCLUDED_FILES."
+      } >>"$tmp/report"
+      drift=1
+    elif ! diff -q "$tmp/$name" "$CUCUMBER_DIR/$name" >/dev/null; then
+      {
+        echo "### $name"
+        echo '```diff'
+        diff -u "$CUCUMBER_DIR/$name" "$tmp/$name" \
+          --label "vendored/$name" --label "upstream@$ref/$name" || true
+        echo '```'
+      } >>"$tmp/report"
+      drift=1
+    else
+      echo "ok: $name"
+    fi
+  done <"$tmp/upstream-names"
+
+  # A vendored file that upstream no longer ships is drift too — it is dead weight the suites
+  # still execute.
+  for path in "$CUCUMBER_DIR"/*.feature; do
+    [[ -e "$path" ]] || continue
+    name="$(basename "$path")"
+    if ! grep -qxF "$name" "$tmp/upstream-names"; then
+      {
+        echo "### $name — vendored, gone upstream"
+        echo "Upstream no longer ships this file at $ref; the suites still run it."
+      } >>"$tmp/report"
+      drift=1
+    fi
+  done
+
+  if [[ $drift -ne 0 ]]; then
+    echo "UPSTREAM DRIFT against $UPSTREAM_REPO@$ref" >&2
+    cat "$tmp/report" >&2
+    if [[ -n "$report" ]]; then
+      cp "$tmp/report" "$report" || die "cannot write report to $report"
+    fi
+  else
+    echo "upstream: vendored assets match $UPSTREAM_REPO@$ref"
+  fi
+  return $drift
+}
+
+main() {
+  local mode="${1:-}"
+  case "$mode" in
+    mirror)
+      check_mirror
+      ;;
+    upstream)
+      shift
+      local ref="$PINNED_REF" report=""
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --report)
+            [[ $# -ge 2 ]] || die "--report needs a file argument"
+            report="$2"
+            shift 2
+            ;;
+          *)
+            ref="$1"
+            shift
+            ;;
+        esac
+      done
+      check_upstream "$ref" "$report"
+      ;;
+    *)
+      die "usage: $(basename "$0") mirror | upstream [<ref>] [--report <file>]"
+      ;;
+  esac
+}
+
+main "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
+      # The four vendored gherkin files exist twice — once per conformance runner — and must stay
+      # byte-identical. Unlike upstream drift (scheduled, see gherkin-drift.yml), breaking the
+      # in-repo mirror is the PR author's doing, so it blocks here. Runs first: it needs no JDK, no
+      # sbt and no network, so failing it early gives the signal in seconds rather than burying it
+      # behind a multi-minute scalafmt run — which would mask it entirely whenever scalafmt fails.
+      - name: Check vendored gherkin copies are in sync
+        run: .github/scripts/check-gherkin-drift.sh mirror
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/gherkin-drift.yml
+++ b/.github/workflows/gherkin-drift.yml
@@ -1,0 +1,111 @@
+name: Gherkin drift
+
+# Detects the vendored OpenFeature gherkin conformance assets falling behind upstream. Scheduled,
+# never a PR gate: upstream moving is not a PR author's doing, so blocking unrelated PRs on it would
+# punish the wrong person. The in-repo mirror invariant IS a PR author's doing and is checked in
+# ci.yml's `format` job instead.
+#
+# The pin drifted for ~2 months before anyone noticed (#331) — that silence is what this job exists
+# to end.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC. Upstream moves on the order of months, so weekly is ample.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'open-feature/spec ref to compare against (default: main)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      # `main` on a schedule: the point is "has upstream moved since the pin?", which comparing
+      # against the pin itself could never answer. A manual dispatch may override the ref.
+      - name: Check for upstream drift
+        id: drift
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ inputs.ref || 'main' }}
+        run: |
+          set +e
+          .github/scripts/check-gherkin-drift.sh upstream "$REF" --report drift-report.md
+          status=$?
+          set -e
+          # Only `status` is published, and it is `$?` — always a bare integer, so it cannot inject
+          # extra lines into $GITHUB_OUTPUT. `ref` is deliberately NOT published: it derives from a
+          # free-text dispatch input, and a value containing a newline plus `status=0` would append
+          # a second status line that masks a real drift as clean. Downstream steps re-derive the
+          # ref from the same expression instead.
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          # An exhaustive partition on success, NOT a whitelist of known-bad codes. 0 is the only
+          # value meaning "checked, no drift"; 1 means drift and is handled by the next step.
+          # Everything else — 2 from `die`, or 126/127/137 from a lost mode bit, a missing `gh`, or
+          # an OOM kill — means the check did not run. Letting an unrecognised code fall through as
+          # success is exactly the "silently reports no drift" failure this job exists to end.
+          # Fail without filing: "could not tell" is not "there is drift", and filing on it would
+          # train the maintainer to ignore the issue.
+          if [ "$status" -eq 0 ]; then
+            echo "no drift against $REF"
+          elif [ "$status" -ne 1 ]; then
+            echo "::error::drift check could not run against $REF (exit $status)"
+            exit 1
+          fi
+
+      - name: File or update the drift issue
+        if: steps.drift.outputs.status == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ inputs.ref || 'main' }}
+          RUN_ID: ${{ github.run_id }}
+          TITLE: Gherkin conformance assets drifted from upstream spec
+        run: |
+          # pipefail: without it a failing `gh issue list` is masked by jq's exit 0, leaving
+          # `existing` empty — which files a duplicate issue instead of commenting on the open one.
+          set -o pipefail
+          # Dedup on the exact title among OPEN issues. Without this the weekly schedule would
+          # file a duplicate every Monday until someone re-syncs. `--arg` rather than escaping
+          # the title into the jq program, so the query survives the title ever changing.
+          existing=$(gh issue list --state open --search "\"$TITLE\" in:title" --json number,title \
+            | jq -r --arg title "$TITLE" '[.[] | select(.title == $title)] | .[0].number // empty')
+
+          {
+            echo "The vendored gherkin conformance assets no longer match \`open-feature/spec@$REF\`."
+            echo
+            echo "Re-sync per \`conformance/src/test/resources/zio/openfeature/conformance/README.md\`:"
+            echo "re-copy the changed files into **both** vendored copies, update the pinned tag, and"
+            echo "run \`sbt conformance/test\` + \`sbt conformanceZioBdd/test\`."
+            echo
+            echo "Reproduce locally: \`.github/scripts/check-gherkin-drift.sh upstream $REF\`"
+            echo
+            cat drift-report.md
+            echo
+            echo "_Filed by the \`Gherkin drift\` workflow (run $RUN_ID)._"
+          } > issue-body.md
+
+          if [ -n "$existing" ]; then
+            echo "drift issue #$existing already open — commenting instead of filing a duplicate"
+            gh issue comment "$existing" --body-file issue-body.md
+          else
+            gh issue create --title "$TITLE" --body-file issue-body.md \
+              --label spec-compliance --label needs-triage
+          fi
+
+      # Runs after the issue step so the drift is recorded before the job goes red.
+      - name: Fail if drift was found
+        if: steps.drift.outputs.status == '1'
+        env:
+          REF: ${{ inputs.ref || 'main' }}
+        run: |
+          echo "::error::vendored gherkin assets drifted from open-feature/spec@$REF"
+          exit 1

--- a/conformance-zio-bdd/src/test/resources/features/openfeature/evaluation_v2.feature
+++ b/conformance-zio-bdd/src/test/resources/features/openfeature/evaluation_v2.feature
@@ -189,10 +189,10 @@ Feature: Flag Evaluations - Complete OpenFeature Specification Coverage
             | key          | type   | default    |
             | boolean-flag | Object | {\"a\": 1} |
 
-  # Spec 1.7.6: Testing PROVIDER_NOT_READY error when provider isn't initialized
-  # Testing: client must short-circuit and return error when provider not ready
+  # Spec 2.2.7: Testing PROVIDER_NOT_READY error when provider isn't initialized
+  # Testing: provider indicates error abnormally; client returns default per 1.4.10
   # Implicitly tests: 1.4.10 (client never throws exceptions - returns default instead)
-    @provider-status @spec-1.7.6 @spec-1.4.10
+    @provider-status @spec-2.2.7 @spec-1.4.10
     Scenario Outline: Provider not ready error
         Given a not ready provider
         And a <type>-flag with key "<key>" and a fallback value "<default>"
@@ -222,10 +222,10 @@ Feature: Flag Evaluations - Complete OpenFeature Specification Coverage
             | key         | type   | default    |
             | object-flag | Object | {\"a\": 1} |
 
-  # Spec 1.7.7: Testing PROVIDER_FATAL error when provider is in fatal state
-  # Testing: client must short-circuit and return error when provider is fatal
+  # Spec 2.2.7: Testing PROVIDER_FATAL error when provider is in fatal state
+  # Testing: provider indicates error abnormally; client returns default per 1.4.10
   # Implicitly tests: 1.4.10 (client never throws exceptions - returns default instead), 1.7.5 (FATAL status)
-    @provider-status @provider-status-fatal @spec-1.7.7 @spec-1.4.10 @spec-1.7.5
+    @provider-status @provider-status-fatal @spec-2.2.7 @spec-1.4.10 @spec-1.7.5
     Scenario Outline: Provider in fatal state error
         Given a fatal provider
         And a <type>-flag with key "<key>" and a fallback value "<default>"

--- a/conformance/src/test/resources/zio/openfeature/conformance/README.md
+++ b/conformance/src/test/resources/zio/openfeature/conformance/README.md
@@ -4,18 +4,51 @@ The `.feature` files in this directory are **verbatim copies** of the OpenFeatur
 conformance suite, executed against the ZIO `FeatureFlags` API by Cucumber (see `RunConformance`).
 
 - Source: https://github.com/open-feature/spec — `specification/assets/gherkin/`
-- Pinned commit: **203c25f93495**
+- Pinned tag: **v0.9.0** (commit `d5b0a734d8cb9b42bf89be2a97c627f58208e811`)
 
 Keep these byte-identical to upstream so a re-sync is a clean diff. To update: re-copy the files
-from the pinned path at a newer commit and run `sbt conformance/test`; new or changed scenarios
+from the pinned path at a newer tag and run `sbt conformance/test`; new or changed scenarios
 surface as failing/undefined steps rather than silently going unrun.
+
+The same four files are vendored a second time under
+`conformance-zio-bdd/src/test/resources/features/openfeature/`, where the zio-bdd runner executes
+them. The two copies must stay byte-identical to each other.
+
+## Drift detection
+
+Both invariants are checked by `.github/scripts/check-gherkin-drift.sh`, split because they have
+different owners:
+
+| Mode | Invariant | Runs |
+|------|-----------|------|
+| `upstream` | vendored files match `open-feature/spec` at a ref | `.github/workflows/gherkin-drift.yml` — weekly + on dispatch |
+| `mirror` | the two in-repo copies are identical | the `format` job in `ci.yml` — every PR |
+
+Upstream drift is not a PR author's doing, so it is scheduled and files a deduped issue rather than
+blocking PRs. Breaking the in-repo mirror **is** a PR author's doing, so that one blocks.
+
+Run either locally:
+
+```sh
+.github/scripts/check-gherkin-drift.sh mirror
+.github/scripts/check-gherkin-drift.sh upstream            # against the pinned tag
+.github/scripts/check-gherkin-drift.sh upstream main       # has upstream moved since the pin?
+```
+
+## What is and isn't vendored
+
+The vendoring contract is the gherkin **suites** — `*.feature`, nothing else. Upstream's directory
+also ships `README.md` (documentation of their assets; this file happens to share its name and
+location but is ours) and `test-flags.json` (fixture data — our step definitions build the
+equivalent fixtures in `Fixtures.scala`). Neither is vendored, and the drift checker compares only
+`*.feature`, so neither is reported. A brand-new upstream *suite* is still caught.
 
 ## Excluded tags
 
 `RunConformance` filters out exactly `@deprecated`, `@async`, and `@immutability`, matching the
 zio-bdd runner's `excludeTags`. The canonical rationale for each exclusion lives in `ConformanceSpec`
 in the `conformance-zio-bdd` module. The `evaluation.feature` file is not vendored (it is entirely
-`@deprecated`).
+`@deprecated`) and is listed in the drift checker's `EXCLUDED_FILES`.
 
 `@reason-codes-cached` (spec 1.4.7) and `@evaluation-options` (spec 1.5.1) are executed: the CACHED
 reason is exercised by wrapping the in-memory provider with the testkit `CachingReasonProvider`, and
@@ -27,3 +60,8 @@ the evaluation-options step definitions live in `ConformanceSteps`.
 NOT_READY/FATAL. This wrapper surfaces those states as a typed failure rather than a returned
 resolution; the step definitions bridge that failure back into the resolution shape the gherkin
 asserts (same value/reason/error-code, different channel).
+
+Spec v0.9.0 renumbered these scenarios from `@spec-1.7.6`/`@spec-1.7.7` to `@spec-2.2.7`: provider
+status is now derived from provider-emitted events, and the client short-circuit those requirements
+mandated is no longer required. Neither runner filters on `@spec-*` tags, so the rename is inert
+here. Adapting the library's own behaviour to that change is tracked separately in #332.

--- a/conformance/src/test/resources/zio/openfeature/conformance/evaluation_v2.feature
+++ b/conformance/src/test/resources/zio/openfeature/conformance/evaluation_v2.feature
@@ -189,10 +189,10 @@ Feature: Flag Evaluations - Complete OpenFeature Specification Coverage
             | key          | type   | default    |
             | boolean-flag | Object | {\"a\": 1} |
 
-  # Spec 1.7.6: Testing PROVIDER_NOT_READY error when provider isn't initialized
-  # Testing: client must short-circuit and return error when provider not ready
+  # Spec 2.2.7: Testing PROVIDER_NOT_READY error when provider isn't initialized
+  # Testing: provider indicates error abnormally; client returns default per 1.4.10
   # Implicitly tests: 1.4.10 (client never throws exceptions - returns default instead)
-    @provider-status @spec-1.7.6 @spec-1.4.10
+    @provider-status @spec-2.2.7 @spec-1.4.10
     Scenario Outline: Provider not ready error
         Given a not ready provider
         And a <type>-flag with key "<key>" and a fallback value "<default>"
@@ -222,10 +222,10 @@ Feature: Flag Evaluations - Complete OpenFeature Specification Coverage
             | key         | type   | default    |
             | object-flag | Object | {\"a\": 1} |
 
-  # Spec 1.7.7: Testing PROVIDER_FATAL error when provider is in fatal state
-  # Testing: client must short-circuit and return error when provider is fatal
+  # Spec 2.2.7: Testing PROVIDER_FATAL error when provider is in fatal state
+  # Testing: provider indicates error abnormally; client returns default per 1.4.10
   # Implicitly tests: 1.4.10 (client never throws exceptions - returns default instead), 1.7.5 (FATAL status)
-    @provider-status @provider-status-fatal @spec-1.7.7 @spec-1.4.10 @spec-1.7.5
+    @provider-status @provider-status-fatal @spec-2.2.7 @spec-1.4.10 @spec-1.7.5
     Scenario Outline: Provider in fatal state error
         Given a fatal provider
         And a <type>-flag with key "<key>" and a fallback value "<default>"


### PR DESCRIPTION
Re-syncs the vendored OpenFeature gherkin conformance assets to spec tag `v0.9.0` (commit `d5b0a734d8cb`) and adds drift detection so the pin cannot rot silently again — it had been stale for ~2 months.

## Changes
- `evaluation_v2.feature` re-copied at `v0.9.0` in both conformance modules (tag-only change: `@spec-1.7.6`/`@spec-1.7.7` → `@spec-2.2.7`). The other three vendored files were already byte-identical.
- New `.github/scripts/check-gherkin-drift.sh` with two modes: `upstream` (vendored files vs `open-feature/spec` at a ref) and `mirror` (the two in-repo copies vs each other).
- New `.github/workflows/gherkin-drift.yml` — weekly + dispatch, files a deduped issue on drift. Scheduled rather than a PR gate: upstream moving is not a PR author's doing.
- `ci.yml` `format` job gains the `mirror` check, which runs first (no JDK/sbt/network needed). Breaking the in-repo mirror IS a PR author's doing, so that one blocks.
- Conformance README rewritten: new pin, drift-detection table, and the vendoring contract (`*.feature` only — upstream's `README.md` and `test-flags.json` are deliberately not vendored).

## Verification
- `conformance/test` 113/113, `conformanceZioBdd/test` 113/113 (+6 ignored) — both non-zero, so neither ran an empty corpus.
- Checker proven against real drift: red on the pre-sync corpus, green after. Mirror tamper-test detects a broken copy. Bogus ref and missing args both exit 2.
- Exit contract is an exhaustive partition on success: 0 = clean, 1 = drift, anything else = could-not-run (fails without filing, so "could not tell" is never reported as "no drift").

Closes #331