### PR TITLE
Read the gherkin pin from the conformance README

### DIFF
--- a/.github/scripts/check-gherkin-drift.sh
+++ b/.github/scripts/check-gherkin-drift.sh
@@ -13,7 +13,8 @@
 #   check-gherkin-drift.sh mirror
 #   check-gherkin-drift.sh upstream [<ref>] [--report <file>]
 #
-# `<ref>` defaults to the pinned tag below. Pass `main` to ask "has upstream moved since the pin?".
+# `<ref>` defaults to the pin read from the conformance README (see `pinned_ref`). Pass `main` to
+# ask "has upstream moved since the pin?".
 # Exit 0 = no drift, 1 = drift found (report written), 2 = usage/fetch error.
 #
 # Exit 2 is deliberately distinct from 1: a GitHub API failure or an empty upstream listing means
@@ -22,14 +23,14 @@
 
 set -euo pipefail
 
-# The spec ref these assets are vendored from. Keep in sync with the conformance README.
-PINNED_REF="v0.9.0"
-
 UPSTREAM_REPO="open-feature/spec"
 UPSTREAM_DIR="specification/assets/gherkin"
 
 CUCUMBER_DIR="conformance/src/test/resources/zio/openfeature/conformance"
 ZIOBDD_DIR="conformance-zio-bdd/src/test/resources/features/openfeature"
+
+# Authoritative record of the vendored spec ref; parsed by `pinned_ref`.
+README_PATH="$CUCUMBER_DIR/README.md"
 
 # The vendoring contract is the gherkin *suites* — `*.feature` and nothing else. Upstream's
 # gherkin directory also ships `README.md` (documentation of their assets; ours in the same
@@ -56,6 +57,36 @@ is_excluded() {
     [[ "$candidate" == "$excluded" ]] && return 0
   done
   return 1
+}
+
+# Single source of truth for the pin: the conformance README's "Pinned tag" line. The script parses
+# it rather than keeping a second copy — two copies of the pin is how #336 happened, in a tool whose
+# whole purpose is ending silent pin rot. Called lazily (only by `upstream` with no explicit ref) so
+# `mirror` mode never depends on README formatting.
+#
+# Ambiguity dies as exit 2 ("could not check"), never as a guess: answering "does the pin still
+# hold?" against a pin we failed to read is the silent fallback this script exists to prevent.
+pinned_ref() {
+  local claims matches
+  # Count lines that *claim* to be the pin — however malformed — before parsing one. Counting only
+  # well-formed matches would let a broken current pin sitting above a stale well-formed one resolve
+  # silently to the stale ref: a wrong pin reported as fine, which is the failure this file exists
+  # to prevent.
+  #
+  # The `|| die` is load-bearing, not belt-and-braces: BSD sed exits 1 on an unreadable file while
+  # GNU sed exits 2, so leaving it to `set -e` would abort with 1 on macOS — and the scheduled
+  # workflow reads 1 as "drift found" and files a bogus issue. This normalises both to 2.
+  claims="$(sed -n '/^- Pinned tag:/p' "$README_PATH")" \
+    || die "cannot read $README_PATH"
+  [[ -n "$claims" ]] || die "no '- Pinned tag: **vX.Y.Z**' line found in $README_PATH"
+  [[ "$(printf '%s\n' "$claims" | wc -l | tr -d ' ')" == "1" ]] \
+    || die "multiple 'Pinned tag' lines in $README_PATH — cannot determine the pin"
+
+  matches="$(printf '%s\n' "$claims" | sed -n 's/^- Pinned tag: \*\*\(v[0-9][0-9.]*\)\*\*.*/\1/p')" \
+    || die "cannot parse the 'Pinned tag' line in $README_PATH"
+  [[ -n "$matches" ]] \
+    || die "unparseable '- Pinned tag' line in $README_PATH — expected '- Pinned tag: **vX.Y.Z**'"
+  printf '%s\n' "$matches"
 }
 
 # --- mirror -----------------------------------------------------------------------------------
@@ -197,7 +228,7 @@ main() {
       ;;
     upstream)
       shift
-      local ref="$PINNED_REF" report=""
+      local ref="" report=""
       while [[ $# -gt 0 ]]; do
         case "$1" in
           --report)
@@ -211,6 +242,9 @@ main() {
             ;;
         esac
       done
+      # Resolved after parsing so an explicit ref never pays the README read — and so a malformed
+      # README cannot fail a run that did not need the pin at all.
+      [[ -n "$ref" ]] || ref="$(pinned_ref)"
       check_upstream "$ref" "$report"
       ;;
     *)

--- a/conformance/src/test/resources/zio/openfeature/conformance/README.md
+++ b/conformance/src/test/resources/zio/openfeature/conformance/README.md
@@ -6,9 +6,15 @@ conformance suite, executed against the ZIO `FeatureFlags` API by Cucumber (see 
 - Source: https://github.com/open-feature/spec — `specification/assets/gherkin/`
 - Pinned tag: **v0.9.0** (commit `d5b0a734d8cb9b42bf89be2a97c627f58208e811`)
 
+That "Pinned tag" line is **authoritative and machine-read**: `.github/scripts/check-gherkin-drift.sh`
+parses it for the ref to compare against when run without an explicit one, so this file is the single
+source of truth for the pin (#336 — it used to be duplicated in the script, which could rot silently).
+Preserve the exact shape ``- Pinned tag: **vX.Y.Z** (commit `<sha>`)`` when re-syncing; the script
+exits 2 ("could not check") rather than guessing if the line is missing, malformed, or duplicated.
+
 Keep these byte-identical to upstream so a re-sync is a clean diff. To update: re-copy the files
-from the pinned path at a newer tag and run `sbt conformance/test`; new or changed scenarios
-surface as failing/undefined steps rather than silently going unrun.
+from the pinned path at a newer tag, update the pin line above, and run `sbt conformance/test`; new
+or changed scenarios surface as failing/undefined steps rather than silently going unrun.
 
 The same four files are vendored a second time under
 `conformance-zio-bdd/src/test/resources/features/openfeature/`, where the zio-bdd runner executes


### PR DESCRIPTION
The gherkin pin lived in two places — `PINNED_REF` in `.github/scripts/check-gherkin-drift.sh` and the `Pinned tag` line in the conformance README — with nothing enforcing they agree. A re-sync updating one and not the other was silent, which is a poor property for a tool whose whole purpose is ending silent pin rot.

The README is now the single source of truth; the script parses it.

## Changes

- `PINNED_REF` deleted. `pinned_ref()` parses the README's `- Pinned tag: **vX.Y.Z**` line instead.
- Resolution is **lazy** — only `upstream` with no explicit ref reads the README, so `mirror` mode and explicit-ref runs stay completely decoupled from README formatting.
- Ambiguity (missing / malformed / duplicated pin line) exits **2** ("could not check"), never a guess. Answering "does the pin still hold?" against a pin we failed to read is the exact silent fallback this script exists to prevent, and 2 is the code the scheduled workflow already treats as "fail without filing a drift issue".
- The pin-claim lines are counted *before* one is parsed, so a malformed current pin sitting above a stale well-formed one cannot silently resolve to the stale ref.
- README documents that the line is authoritative and machine-read, with the exact shape to preserve.

## Verification

Reproduced before fixing: with a garbage pin line in the README, no-arg `upstream` exited **0** — silently comparing against the hardcoded value. It now exits 2.

| Case | Result |
|---|---|
| no-arg `upstream` | 0, resolves `v0.9.0` from the README |
| explicit `v0.9.0` / `main` / bogus ref | 0 / 0 / 2 (unchanged) |
| missing pin line | 2 — "no ... line found" |
| duplicated pin line | 2 — "multiple" |
| malformed pin line | 2 — "unparseable" |
| malformed pin above a stale well-formed one | 2 (would otherwise have silently resolved the stale ref) |
| broken README + `mirror` / + explicit ref | 0 / 0 — decoupling holds |

`sbt conformance/test` 113/113 and `conformanceZioBdd/test` 113/113.

One note carried forward: `pinned_ref()` is exercised only by local no-arg runs — the scheduled workflow always passes an explicit ref — so the mechanism itself has no CI coverage. Left for a follow-up rather than widened here, since this issue scoped the workflows as untouched.

Closes #336
