### PR TITLE
Adopt OpenFeature Java SDK 1.22.0 (native Long, bound-domain init); bump zio-bdd to 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`Long` flag evaluation now uses the OpenFeature SDK's native long surface** (#333). `ff.long` / `ff.longDetails`
+  call `client.getLongDetails`, so the **provider's** `getLongEvaluation` decides the result instead of this library
+  choosing a resolver for it. Previously an int-range default was routed to the provider's integer resolver and
+  anything larger to its double resolver — exact only up to 2^53, and **silently lossy beyond it**.
+  - Every provider shipped here (`TestFeatureProvider`, `HoconProvider`, `EnvVarProvider`,
+    `OptimizelyFeatureProvider`) now implements `getLongEvaluation` natively and resolves the full 64-bit range
+    exactly, so **there is no behaviour change if you use one of them**.
+  - **Who is affected:** a *third-party* provider written against SDK &lt; 1.22.0 that does not override
+    `getLongEvaluation`. It inherits the SDK's default, which answers from `getDoubleEvaluation` and returns a
+    `TYPE_MISMATCH` (with your default echoed back) outside ±(2^53−1) instead of a quietly wrong number. An
+    integer-stored flag will now meet that provider's *double* resolver.
+  - **Remedy:** wrap it in the new `IntegerWideningLongProvider` to restore the previous int-range routing.
+- **`FlagValueType.Long` is now reported for long evaluations** instead of `FlagValueType.Int` (#333). Only hooks
+  that explicitly narrowed `supportedFlagTypes` are affected: one narrowed to `Int` no longer runs for long
+  evaluations, and one narrowed to `Long` now does. `HookContext.flagType` is public, so this is observable.
+- Out-of-int-range `Long` **tracking** attributes are now sent through `Value`'s native long support rather than
+  being widened to `Double` (#333) — the same silent precision loss, on the tracking path.
+
+### Added
+
+- `IntegerWideningLongProvider` (`extras`) — wraps a provider that predates SDK 1.22.0 and resolves `Long`
+  evaluations through its existing integer resolver for int-range defaults. The escape hatch for the behaviour
+  change above; bundled providers never need it.
+- `TestFeatureProvider.boundDomain` (`testkit`) — reports the domain the SDK bound the provider to, so tests can
+  assert domain propagation (SDK 1.22.0's `initialize(ctx, domain)`).
+
+### Fixed
+
+- **The delegating wrappers no longer strip new SDK interface methods** (#333). `CachingProvider`,
+  `CircuitBreakerProvider`, `DeferredProvider` and `CachingReasonProvider` forwarded only the surface they were
+  written against, so every capability the SDK adds as a *default method* was silently answered by the interface
+  default instead of the wrapped provider. Under 1.22.0 that meant three at once: a `CachingProvider` around a
+  provider with native 64-bit resolution routed long evaluations through the double-backed default,
+  `initialize(ctx, domain)` dropped the bound domain, and `isDomainScoped` hid a wrapped provider's scoping from
+  the SDK. All three are now forwarded, and a reflection-based completeness spec fails when a future SDK method
+  goes unforwarded.
+
+### Dependencies
+
+- OpenFeature Java SDK 1.21.0 → 1.22.0
+- zio-bdd 1.4.2 → 1.4.4 (test-only)
+
 ## [1.0.0] — 2026-07-12
 
 First stable release. **Upgrading from 0.9.x:** two behavior changes may require action —

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ import net.nmoncho.sbt.dependencycheck.settings._
 val scala213Version       = "2.13.16"
 val scala3Version         = "3.3.4"
 val zioVersion            = "2.1.14"
-val zioBddVersion         = "1.4.2"
-val openFeatureSdkVersion = "1.21.0"
+val zioBddVersion         = "1.4.4"
+val openFeatureSdkVersion = "1.22.0"
 
 // OpenFeature Specification Compatibility
 // Spec version: v0.8.0 (https://github.com/open-feature/spec)

--- a/core/src/main/scala-2/zio/openfeature/FlagValueType.scala
+++ b/core/src/main/scala-2/zio/openfeature/FlagValueType.scala
@@ -5,6 +5,7 @@ sealed trait FlagValueType extends Product with Serializable {
     case FlagValueType.Boolean => "Boolean"
     case FlagValueType.String  => "String"
     case FlagValueType.Int     => "Int"
+    case FlagValueType.Long    => "Long"
     case FlagValueType.Double  => "Double"
     case FlagValueType.Object  => "Object"
   }
@@ -14,17 +15,21 @@ object FlagValueType {
   case object Boolean extends FlagValueType
   case object String  extends FlagValueType
   case object Int     extends FlagValueType
+  case object Long    extends FlagValueType
   case object Double  extends FlagValueType
   case object Object  extends FlagValueType
 
-  val allTypes: Set[FlagValueType] = Set(Boolean, String, Int, Double, Object)
+  // Hand-built rather than derived (no `values` on a sealed trait), so every new case must be added here too —
+  // `FeatureHook.supportedFlagTypes` defaults to this set, and a case missing from it would silently exclude that
+  // flag type from every hook.
+  val allTypes: Set[FlagValueType] = Set(Boolean, String, Int, Long, Double, Object)
 
   def fromFlagType[A](implicit ft: FlagType[A]): FlagValueType =
     ft.typeName match {
       case "Boolean" => Boolean
       case "String"  => String
       case "Int"     => Int
-      case "Long"    => Int
+      case "Long"    => Long
       case "Float"   => Double
       case "Double"  => Double
       case _         => Object

--- a/core/src/main/scala-3/zio/openfeature/FlagValueType.scala
+++ b/core/src/main/scala-3/zio/openfeature/FlagValueType.scala
@@ -4,6 +4,7 @@ enum FlagValueType:
   case Boolean
   case String
   case Int
+  case Long
   case Double
   case Object
 
@@ -17,7 +18,7 @@ object FlagValueType:
       case "Boolean" => Boolean
       case "String"  => String
       case "Int"     => Int
-      case "Long"    => Int
+      case "Long"    => Long
       case "Float"   => Double
       case "Double"  => Double
       case _         => Object

--- a/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
+++ b/core/src/main/scala/zio/openfeature/FeatureFlagsLive.scala
@@ -1215,10 +1215,12 @@ final private[openfeature] class FeatureFlagsLive(
       case b: Boolean => details.add(key, b)
       case s: String  => details.add(key, s)
       case i: Int     => details.add(key, Integer.valueOf(i))
-      // int-range long → Integer (no precision loss, matches integer targeting); else Double (lossy beyond 2^53).
+      // int-range long → Integer (no precision loss, and matches integer targeting); anything larger goes through
+      // `Value`'s native Long support (SDK 1.22.0) rather than the old Double fallback, which was silently lossy
+      // beyond 2^53.
       case l: Long =>
         if (l.isValidInt) details.add(key, Integer.valueOf(l.toInt))
-        else details.add(key, java.lang.Double.valueOf(l.toDouble))
+        else details.add(key, new dev.openfeature.sdk.Value(java.lang.Long.valueOf(l)))
       case d: Double                  => details.add(key, d)
       case f: Float                   => details.add(key, java.lang.Double.valueOf(f.toDouble))
       case instant: java.time.Instant => details.add(key, instant)

--- a/core/src/main/scala/zio/openfeature/internal/ClientEvaluator.scala
+++ b/core/src/main/scala/zio/openfeature/internal/ClientEvaluator.scala
@@ -113,9 +113,16 @@ private[openfeature] object ClientEvaluator {
       details.getValue.asInstanceOf[java.lang.Integer].intValue()
   }
 
-  // An int-range long routes through the SDK's Integer method so a flag stored as an integer resolves against the
-  // provider's integer resolver (rather than its double resolver, which can TYPE_MISMATCH). Out-of-int-range longs
-  // still use the Double method (exact for integers up to 2^53). `extractValue` accepts either numeric result.
+  // SDK 1.22.0 added a native Long surface, so Long evaluations dispatch to the provider's own `getLongEvaluation`
+  // rather than being routed here. That routing used to live at this call site: an int-range default went to
+  // `getIntegerDetails` (so an integer-stored flag met the provider's integer resolver instead of its double one),
+  // and anything larger went to `getDoubleDetails` — exact only up to 2^53, silently lossy beyond it.
+  //
+  // Going native trades that silent precision loss for either an exact 64-bit result (providers that override
+  // `getLongEvaluation`, which every provider this library ships now does) or a loud TYPE_MISMATCH from the SDK's
+  // double-backed default. It also makes SDK-level `LongHook`s and `FlagValueType.LONG` observable, which the
+  // hand-rolled routing hid. A third-party provider that does NOT override `getLongEvaluation` can be wrapped in
+  // `zio.openfeature.extras.IntegerWideningLongProvider` to restore the old int-range behaviour.
   implicit val longEvaluator: ClientEvaluator[Long] = new ClientEvaluator[Long] {
     def evaluate(
       client: OFClient,
@@ -123,11 +130,9 @@ private[openfeature] object ClientEvaluator {
       default: Long,
       context: dev.openfeature.sdk.EvaluationContext
     ): Task[FlagEvaluationDetails[_]] =
-      if (default.isValidInt)
-        ZIO.attemptBlocking(client.getIntegerDetails(key, Integer.valueOf(default.toInt), context))
-      else
-        ZIO.attemptBlocking(client.getDoubleDetails(key, java.lang.Double.valueOf(default.toDouble), context))
+      ZIO.attemptBlocking(client.getLongDetails(key, java.lang.Long.valueOf(default), context))
 
+    // Still `Number`, not a `Long` cast: the SDK's double-backed default path can hand back a boxed Double.
     def extractValue(details: FlagEvaluationDetails[_]): Long =
       details.getValue.asInstanceOf[java.lang.Number].longValue()
   }

--- a/core/src/test/scala/zio/openfeature/HookSpec.scala
+++ b/core/src/test/scala/zio/openfeature/HookSpec.scala
@@ -65,9 +65,12 @@ object HookSpec extends ZIOSpecDefault {
         val fvt = FlagValueType.fromFlagType[Double]
         assertTrue(fvt == FlagValueType.Double)
       },
-      test("fromFlagType returns Int for Long") {
+      // Long stopped being reported as Int with SDK 1.22.0 (#333): the SDK gained a distinct LONG flag type, and
+      // `ff.long` now dispatches to the provider's native long resolver. Mislabelling it as Int meant a hook that
+      // narrowed `supportedFlagTypes` to Int also ran for long evaluations, and one narrowed to Long never did.
+      test("fromFlagType returns Long for Long") {
         val fvt = FlagValueType.fromFlagType[Long]
-        assertTrue(fvt == FlagValueType.Int)
+        assertTrue(fvt == FlagValueType.Long)
       },
       test("fromFlagType returns Double for Float") {
         val fvt = FlagValueType.fromFlagType[Float]

--- a/core/src/test/scala/zio/openfeature/LongCoercionSpec.scala
+++ b/core/src/test/scala/zio/openfeature/LongCoercionSpec.scala
@@ -17,8 +17,16 @@ import dev.openfeature.sdk.{
 import java.util.concurrent.atomic.AtomicReference
 
 /** Spec §3.1.2 / §1.3.4: int-range `Long`s must not be silently coerced to `Double`. A small long in the context
-  * reaches providers as an `Integer` (so `instanceof Integer` targeting rules match), and a long-typed flag evaluation
-  * routes through the provider's integer resolver rather than its double resolver.
+  * reaches providers as an `Integer` (so `instanceof Integer` targeting rules match).
+  *
+  * Flag *evaluation* changed with SDK 1.22.0 (#333). `ff.long` now calls the native `client.getLongDetails`, so the
+  * provider's own `getLongEvaluation` decides the result instead of this library choosing a resolver for it:
+  *   - a provider that overrides it resolves the full 64-bit range **exactly** (was: silently lossy past 2^53);
+  *   - one that does not inherits the SDK's double-backed default, which answers from `getDoubleEvaluation` and returns
+  *     a loud `TYPE_MISMATCH` outside ±(2^53−1) rather than a quietly wrong number.
+  * Every provider this library ships overrides it. A third-party provider that does not can be wrapped in `extras`'
+  * `IntegerWideningLongProvider` to restore the old int-range routing — covered by that module's spec, since `core`
+  * cannot depend on `extras`.
   */
 object LongCoercionSpec extends ZIOSpecDefault {
 
@@ -61,6 +69,35 @@ object LongCoercionSpec extends ZIOSpecDefault {
       ProviderEvaluations.of[java.lang.Double](java.lang.Double.valueOf(99.0), "STATIC")
     override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
       ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  /** Overrides `getLongEvaluation` natively, as every provider this library ships now does. Returns a value beyond 2^53
+    * so an exact result is distinguishable from anything that went through a Double.
+    */
+  private class NativeLongProvider extends EventProvider {
+    @scala.annotation.nowarn("msg=deprecated")
+    override def getMetadata: Metadata                      = new Metadata { def getName: String = "NativeLong" }
+    override def getState: ProviderState                    = ProviderState.READY
+    override def initialize(ctx: OFEvaluationContext): Unit = ()
+    override def shutdown(): Unit                           = ()
+    override def getLongEvaluation(k: String, d: java.lang.Long, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Long](java.lang.Long.valueOf(NativeLongProvider.Exact), "STATIC")
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Boolean](true, "STATIC")
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) =
+      ProviderEvaluations.of[String](d, "DEFAULT")
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Integer](d, "DEFAULT")
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) =
+      ProviderEvaluations.of[java.lang.Double](d, "DEFAULT")
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) =
+      ProviderEvaluations.of[Value](d, "DEFAULT")
+  }
+
+  private object NativeLongProvider {
+
+    /** Not representable exactly as a Double: round-tripping it through one yields 9007199254740993 -> ...92. */
+    val Exact: Long = 9007199254740993L
   }
 
   /** Records the runtime class of the `"id"` attribute as it arrives in the tracking details. */
@@ -125,20 +162,38 @@ object LongCoercionSpec extends ZIOSpecDefault {
         } yield assertTrue(seen.get() == "Double")
       }
     },
-    test("an int-range long flag evaluation routes through the provider's integer resolver") {
+    test("a provider with a native long resolver resolves beyond 2^53 exactly") {
+      ZIO.scoped {
+        for {
+          ff <- buildFF(new NativeLongProvider)
+          v  <- ff.long("flag", default = 0L)
+        } yield assertTrue(
+          v == NativeLongProvider.Exact,
+          // The point of going native: this value is not representable as a Double, so the old
+          // route through getDoubleDetails could never have returned it.
+          v.toDouble.toLong != NativeLongProvider.Exact
+        )
+      }
+    },
+    test("a provider without a long resolver falls to the SDK's double-backed default") {
       ZIO.scoped {
         for {
           ff <- buildFF(new ResolverProvider)
           v  <- ff.long("flag", default = 0L)
-        } yield assertTrue(v == 7L) // 7 from the integer resolver, not 99 from the double resolver
+        } yield assertTrue(v == 99L) // 99 from the double resolver, via the SDK's default getLongEvaluation
       }
     },
-    test("an out-of-int-range long flag evaluation still routes through the double resolver") {
+    test("an out-of-safe-range default against a resolver-less provider is a loud TYPE_MISMATCH, not a wrong number") {
       ZIO.scoped {
         for {
-          ff <- buildFF(new ResolverProvider)
-          v  <- ff.long("flag", default = Long.MaxValue)
-        } yield assertTrue(v == 99L) // 99 from the double resolver
+          ff  <- buildFF(new ResolverProvider)
+          det <- ff.longDetails("flag", default = Long.MaxValue)
+        } yield assertTrue(
+          // The SDK refuses to answer rather than silently truncating through a Double...
+          det.errorCode.contains(ErrorCode.TypeMismatch),
+          // ...and hands the caller's own default back untouched.
+          det.value == Long.MaxValue
+        )
       }
     },
     test("an int-range Long tracking attribute is sent as an Integer, not a Double") {
@@ -148,6 +203,15 @@ object LongCoercionSpec extends ZIOSpecDefault {
           ff <- buildFF(new TrackInspectingProvider(seen))
           _  <- ff.track("purchase", TrackingEventDetails(Map("id" -> 42L)))
         } yield assertTrue(seen.get() == "Integer")
+      }
+    },
+    test("an out-of-int-range Long tracking attribute is sent as a Long, not a lossy Double") {
+      val seen = new AtomicReference[String]("unset")
+      ZIO.scoped {
+        for {
+          ff <- buildFF(new TrackInspectingProvider(seen))
+          _  <- ff.track("purchase", TrackingEventDetails(Map("id" -> Long.MaxValue)))
+        } yield assertTrue(seen.get() == "Long")
       }
     }
   ) @@ sequential @@ withLiveClock

--- a/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CachingProvider.scala
@@ -120,11 +120,21 @@ final class CachingProvider private (
     ()
   }
 
-  override def initialize(context: OFEvaluationContext): Unit = {
+  private def attachDelegate(): Unit =
     if (delegateAttached.compareAndSet(false, true))
       EventProviderBridge.attach(underlying, onDelegateEvent)
+
+  override def initialize(context: OFEvaluationContext): Unit = {
+    attachDelegate()
     underlying.initialize(context)
   }
+
+  override def initialize(context: OFEvaluationContext, domain: String): Unit = {
+    attachDelegate()
+    underlying.initialize(context, domain)
+  }
+
+  override def isDomainScoped(): Boolean = underlying.isDomainScoped()
 
   override def shutdown(): Unit = {
     if (delegateAttached.compareAndSet(true, false))
@@ -240,6 +250,13 @@ final class CachingProvider private (
     context: OFEvaluationContext
   ): ProviderEvaluation[java.lang.Double] =
     cached(key, "double", context, underlying.getDoubleEvaluation(key, defaultValue, context))
+
+  override def getLongEvaluation(
+    key: String,
+    defaultValue: java.lang.Long,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Long] =
+    cached(key, "long", context, underlying.getLongEvaluation(key, defaultValue, context))
 
   override def getObjectEvaluation(
     key: String,

--- a/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/CircuitBreakerProvider.scala
@@ -127,17 +127,25 @@ final class CircuitBreakerProvider private (
     ()
   }
 
-  override def initialize(context: OFEvaluationContext): Unit =
+  private def doInitialize(runDelegateInit: => Unit): Unit =
     try {
       if (delegateAttached.compareAndSet(false, true))
         EventProviderBridge.attach(underlying, onDelegateEvent)
-      underlying.initialize(context)
+      runDelegateInit
       checkDelegateState()
     } catch {
       case e: Exception =>
         breaker.trip()
         throw e
     }
+
+  override def initialize(context: OFEvaluationContext): Unit =
+    doInitialize(underlying.initialize(context))
+
+  override def initialize(context: OFEvaluationContext, domain: String): Unit =
+    doInitialize(underlying.initialize(context, domain))
+
+  override def isDomainScoped(): Boolean = underlying.isDomainScoped()
 
   override def shutdown(): Unit = {
     if (delegateAttached.compareAndSet(true, false))
@@ -180,6 +188,13 @@ final class CircuitBreakerProvider private (
     context: OFEvaluationContext
   ): ProviderEvaluation[java.lang.Double] =
     protect(() => underlying.getDoubleEvaluation(key, defaultValue, context))
+
+  override def getLongEvaluation(
+    key: String,
+    defaultValue: java.lang.Long,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Long] =
+    protect(() => underlying.getLongEvaluation(key, defaultValue, context))
 
   override def getObjectEvaluation(
     key: String,

--- a/extras/src/main/scala/zio/openfeature/extras/DeferredProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/DeferredProvider.scala
@@ -56,8 +56,9 @@ final class DeferredProvider(name: String)(construct: () => FeatureProvider) ext
       case _                      => ProviderState.NOT_READY
     }
 
-  override def initialize(context: OFEvaluationContext): Unit =
-    // Only the first initialize() constructs; a second call (or one after shutdown) is a no-op.
+  // Only the first initialize() constructs; a second call (or one after shutdown) is a no-op. `runDelegateInit`
+  // carries the ctx-only vs ctx+domain choice so both `initialize` overloads share the construction/teardown logic.
+  private def doInitialize(runDelegateInit: FeatureProvider => Unit): Unit =
     if (stateRef.compareAndSet(State.NotStarted, State.Constructing)) {
       // If construction throws, don't wedge in Constructing (which would report NOT_READY forever and no-op shutdown):
       // move to Shutdown and rethrow so the SDK marks the provider errored.
@@ -66,7 +67,7 @@ final class DeferredProvider(name: String)(construct: () => FeatureProvider) ext
         catch { case t: Throwable => stateRef.set(State.Shutdown); throw t }
       // If delegate.initialize throws, the delegate is already built — shut it down so its poller/HTTP client doesn't
       // leak, move to Shutdown, and rethrow.
-      try delegate.initialize(context)
+      try runDelegateInit(delegate)
       catch {
         case t: Throwable =>
           stateRef.set(State.Shutdown)
@@ -77,6 +78,20 @@ final class DeferredProvider(name: String)(construct: () => FeatureProvider) ext
       // Shutdown and we must tear the freshly built delegate down so its background threads don't leak.
       if (!stateRef.compareAndSet(State.Constructing, State.Active(delegate)))
         delegate.shutdown()
+    }
+
+  override def initialize(context: OFEvaluationContext): Unit =
+    doInitialize(_.initialize(context))
+
+  override def initialize(context: OFEvaluationContext, domain: String): Unit =
+    doInitialize(_.initialize(context, domain))
+
+  // No delegate exists before construction completes, so there is no domain-scoping fact to report yet; `false`
+  // matches the SDK's own interface default until the delegate becomes active.
+  override def isDomainScoped(): Boolean =
+    stateRef.get() match {
+      case State.Active(delegate) => delegate.isDomainScoped()
+      case _                      => false
     }
 
   override def shutdown(): Unit =
@@ -129,6 +144,13 @@ final class DeferredProvider(name: String)(construct: () => FeatureProvider) ext
     context: OFEvaluationContext
   ): ProviderEvaluation[java.lang.Double] =
     delegateOr(defaultValue)(_.getDoubleEvaluation(key, defaultValue, context))
+
+  override def getLongEvaluation(
+    key: String,
+    defaultValue: java.lang.Long,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Long] =
+    delegateOr(defaultValue)(_.getLongEvaluation(key, defaultValue, context))
 
   override def getObjectEvaluation(
     key: String,

--- a/extras/src/main/scala/zio/openfeature/extras/EnvVarProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/EnvVarProvider.scala
@@ -86,6 +86,22 @@ final class EnvVarProvider private (
         ProviderEvaluations.of(defaultValue, "DEFAULT")
     }
 
+  override def getLongEvaluation(
+    key: String,
+    defaultValue: java.lang.Long,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Long] =
+    lookup(key) match {
+      case Some(v) =>
+        scala.util.Try(v.toLong) match {
+          case scala.util.Success(n) => ProviderEvaluations.of(java.lang.Long.valueOf(n), "STATIC")
+          case scala.util.Failure(_) =>
+            throw new ParseError(s"Env var ${envKey(key)}='$v' is not a valid long for flag '$key'")
+        }
+      case None =>
+        ProviderEvaluations.of(defaultValue, "DEFAULT")
+    }
+
   override def getDoubleEvaluation(
     key: String,
     defaultValue: java.lang.Double,

--- a/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/HoconProvider.scala
@@ -81,6 +81,16 @@ final class HoconProvider private (
     else
       ProviderEvaluations.of(defaultValue, "DEFAULT")
 
+  override def getLongEvaluation(
+    key: String,
+    defaultValue: java.lang.Long,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Long] =
+    if (config.hasPath(key))
+      ProviderEvaluations.of(java.lang.Long.valueOf(typedRead(key, config.getLong(key))), "STATIC")
+    else
+      ProviderEvaluations.of(defaultValue, "DEFAULT")
+
   override def getDoubleEvaluation(
     key: String,
     defaultValue: java.lang.Double,

--- a/extras/src/main/scala/zio/openfeature/extras/IntegerWideningLongProvider.scala
+++ b/extras/src/main/scala/zio/openfeature/extras/IntegerWideningLongProvider.scala
@@ -1,0 +1,102 @@
+package zio.openfeature.extras
+
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  FeatureProvider,
+  Hook,
+  Metadata,
+  ProviderEvaluation,
+  TrackingEventDetails,
+  Value
+}
+
+/** Escape hatch for third-party `FeatureProvider`s that predate SDK 1.22.0 and so do not override `getLongEvaluation`:
+  * the interface's default implementation routes it through `getDoubleEvaluation`, which TYPE_MISMATCHes an
+  * integer-stored flag whenever the provider's double resolution doesn't also accept an integer-typed value. Wrapping
+  * such a provider here resolves `Long` evaluations through its existing `getIntegerEvaluation` path instead, for
+  * defaults that fit in an `Int`.
+  *
+  * The providers bundled with this library (`HoconProvider`, `EnvVarProvider`, `TestFeatureProvider`,
+  * `OptimizelyFeatureProvider`) already implement `getLongEvaluation` natively and never need this wrapper.
+  *
+  * `getState` is not forwarded: it is deprecated in 1.22.0 (the SDK owns provider status now, see #332), so the
+  * interface's own default applies rather than this wrapper adding a fresh use of a deprecated API. The
+  * wrapper-completeness spec exempts it for the same reason.
+  */
+final class IntegerWideningLongProvider(underlying: FeatureProvider) extends FeatureProvider {
+
+  override def getMetadata: Metadata = underlying.getMetadata
+
+  override def getProviderHooks: java.util.List[Hook[_]] = underlying.getProviderHooks
+
+  override def track(eventName: String, context: OFEvaluationContext, details: TrackingEventDetails): Unit =
+    underlying.track(eventName, context, details)
+
+  override def initialize(context: OFEvaluationContext): Unit = underlying.initialize(context)
+
+  override def initialize(context: OFEvaluationContext, domain: String): Unit =
+    underlying.initialize(context, domain)
+
+  override def isDomainScoped(): Boolean = underlying.isDomainScoped()
+
+  override def shutdown(): Unit = underlying.shutdown()
+
+  override def getBooleanEvaluation(
+    key: String,
+    defaultValue: java.lang.Boolean,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Boolean] = underlying.getBooleanEvaluation(key, defaultValue, context)
+
+  override def getStringEvaluation(
+    key: String,
+    defaultValue: String,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[String] = underlying.getStringEvaluation(key, defaultValue, context)
+
+  override def getIntegerEvaluation(
+    key: String,
+    defaultValue: java.lang.Integer,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Integer] = underlying.getIntegerEvaluation(key, defaultValue, context)
+
+  override def getDoubleEvaluation(
+    key: String,
+    defaultValue: java.lang.Double,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Double] = underlying.getDoubleEvaluation(key, defaultValue, context)
+
+  override def getObjectEvaluation(
+    key: String,
+    defaultValue: Value,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[Value] = underlying.getObjectEvaluation(key, defaultValue, context)
+
+  override def getLongEvaluation(
+    key: String,
+    defaultValue: java.lang.Long,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Long] =
+    // Null-guarded: the SDK passes a null default through to the provider (its own default implementation
+    // null-checks before range-testing, and upstream pins that in `LongDefaultDelegationTest`). Unboxing first
+    // would NPE on a path the interface contract allows.
+    if (defaultValue != null && defaultValue.longValue().isValidInt) {
+      val intResult = underlying.getIntegerEvaluation(key, java.lang.Integer.valueOf(defaultValue.intValue()), context)
+      // `underlying` is third-party by definition — the whole reason this wrapper exists — so it may hand back an
+      // evaluation with no value on an error path. Fall back to the caller's default rather than NPE on unboxing.
+      val widened = Option(intResult.getValue).map(i => java.lang.Long.valueOf(i.longValue())).getOrElse(defaultValue)
+      // Builder calls are split across statements (not chained) — the SDK's SuperBuilder-style self-type confuses
+      // Scala 2.13's existential resolution past the second fluent call.
+      val builder = ProviderEvaluation.builder[java.lang.Long]()
+      builder.value(widened)
+      builder.variant(intResult.getVariant)
+      builder.reason(intResult.getReason)
+      builder.errorCode(intResult.getErrorCode)
+      builder.errorMessage(intResult.getErrorMessage)
+      builder.flagMetadata(intResult.getFlagMetadata)
+      builder.build().asInstanceOf[ProviderEvaluation[java.lang.Long]]
+    } else underlying.getLongEvaluation(key, defaultValue, context)
+}
+
+object IntegerWideningLongProvider {
+  def apply(underlying: FeatureProvider): IntegerWideningLongProvider = new IntegerWideningLongProvider(underlying)
+}

--- a/extras/src/test/scala-3/zio/openfeature/extras/WrapperCompletenessSpec.scala
+++ b/extras/src/test/scala-3/zio/openfeature/extras/WrapperCompletenessSpec.scala
@@ -1,0 +1,73 @@
+package zio.openfeature.extras
+
+import dev.openfeature.sdk.FeatureProvider
+import zio.test.*
+
+/** Every delegating wrapper must forward the whole `FeatureProvider` surface.
+  *
+  * The SDK adds capabilities as **default methods** on the interface, so a wrapper that forwards only the surface it
+  * was written against keeps compiling while silently answering from the interface default instead of the provider it
+  * wraps. SDK 1.22.0 shipped three at once (`getLongEvaluation`, `initialize(ctx, domain)`, `isDomainScoped`), and
+  * every one of them was being stripped — a `CachingProvider` around a provider with native 64-bit resolution routed
+  * Long evaluations through the double-backed default.
+  *
+  * Reflection is the only check that fails when the *next* default method lands, rather than when someone happens to
+  * notice.
+  */
+object WrapperCompletenessSpec extends ZIOSpecDefault:
+
+  /** Methods a wrapper may legitimately not forward, each with the reason it is safe. */
+  private val exempt: Map[String, String] = Map(
+    "getMetadata" -> "a wrapper reports its own name, not the wrapped provider's",
+    "getState"    -> "deprecated in 1.22.0; SDK owns status. Removal tracked in #332"
+  )
+
+  /** Name AND parameter types. Matching on name alone is not enough: `initialize` is overloaded, so a wrapper declaring
+    * only `initialize(ctx)` would satisfy a name-based check while silently dropping the bound domain from
+    * `initialize(ctx, domain)` — one of the three methods this spec exists to catch.
+    */
+  private type Sig = (String, List[Class[?]])
+
+  private def render(s: Sig): String = s"${s._1}(${s._2.map(_.getSimpleName).mkString(", ")})"
+
+  /** Instance methods contributed by the OpenFeature interface hierarchy, ignoring `Object`. */
+  private def surface: List[Sig] =
+    classOf[FeatureProvider].getMethods.toList
+      .filterNot(_.getDeclaringClass == classOf[Object])
+      .filterNot(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .map(m => (m.getName, m.getParameterTypes.toList))
+      .distinct
+      .sortBy(render)
+
+  private def declaredSigs(cls: Class[?]): Set[Sig] =
+    cls.getDeclaredMethods.map(m => (m.getName, m.getParameterTypes.toList)).toSet
+
+  private def check(cls: Class[?]): TestResult =
+    val declared = declaredSigs(cls)
+    val missing  = surface.filterNot(declared.contains).filterNot(s => exempt.contains(s._1))
+    assertTrue(missing.isEmpty) ??
+      s"${cls.getSimpleName} does not forward: ${missing.map(render).mkString(", ")}"
+
+  def spec = suite("wrapper completeness")(
+    test("CachingProvider forwards the whole FeatureProvider surface")(check(classOf[CachingProvider])),
+    test("CircuitBreakerProvider forwards the whole FeatureProvider surface")(
+      check(classOf[CircuitBreakerProvider])
+    ),
+    test("DeferredProvider forwards the whole FeatureProvider surface")(check(classOf[DeferredProvider])),
+    test("IntegerWideningLongProvider forwards the whole FeatureProvider surface")(
+      check(classOf[IntegerWideningLongProvider])
+    ),
+    // Guards the guard: if the reflection ever returns an empty surface (an SDK repackaging, a
+    // shading step, a JPMS change), every check above would pass vacuously and the suite would
+    // report success while verifying nothing.
+    test("the reflected surface is non-empty and contains the methods 1.22.0 added") {
+      val names = surface.map(_._1).toSet
+      assertTrue(
+        surface.nonEmpty,
+        names.contains("getLongEvaluation"),
+        names.contains("isDomainScoped"),
+        // The two-argument overload specifically — the one a name-based check cannot see.
+        surface.exists(s => s._1 == "initialize" && s._2.sizeIs == 2)
+      )
+    }
+  )

--- a/extras/src/test/scala/zio/openfeature/extras/IntegerWideningLongProviderSpec.scala
+++ b/extras/src/test/scala/zio/openfeature/extras/IntegerWideningLongProviderSpec.scala
@@ -1,0 +1,87 @@
+package zio.openfeature.extras
+
+import dev.openfeature.sdk.{
+  EvaluationContext => OFEvaluationContext,
+  FeatureProvider,
+  ImmutableContext,
+  Metadata,
+  ProviderEvaluation,
+  Value
+}
+import zio.test._
+
+/** `IntegerWideningLongProvider` restores pre-1.22.0 Long routing for third-party providers that never overrode
+  * `getLongEvaluation`. Without it, such a provider inherits the SDK's double-backed default, so an integer-stored flag
+  * is resolved by its *double* resolver — which is exactly what the old hand-rolled routing in `ClientEvaluator`
+  * existed to avoid (#333).
+  */
+object IntegerWideningLongProviderSpec extends ZIOSpecDefault {
+
+  private val ctx = new ImmutableContext("user")
+
+  /** Stands in for a pre-1.22.0 third-party provider: distinct values per resolver, and no `getLongEvaluation`
+    * override, so the SDK's default would route Long through `getDoubleEvaluation`.
+    */
+  // Every builder use below is split across statements and cast at the end, never chained: the SDK's
+  // SuperBuilder-style self-type defeats Scala 2.13's existential resolution past the second fluent call, and this
+  // spec is cross-built. The production wrapper carries the same note for the same reason.
+  private class LegacyProvider extends FeatureProvider {
+    override def getMetadata: Metadata = new Metadata { def getName: String = "Legacy" }
+    override def getBooleanEvaluation(k: String, d: java.lang.Boolean, c: OFEvaluationContext) = {
+      val b = ProviderEvaluation.builder[java.lang.Boolean]()
+      b.value(d)
+      b.build().asInstanceOf[ProviderEvaluation[java.lang.Boolean]]
+    }
+    override def getStringEvaluation(k: String, d: String, c: OFEvaluationContext) = {
+      val b = ProviderEvaluation.builder[String]()
+      b.value(d)
+      b.build().asInstanceOf[ProviderEvaluation[String]]
+    }
+    override def getIntegerEvaluation(k: String, d: java.lang.Integer, c: OFEvaluationContext) = {
+      val b = ProviderEvaluation.builder[java.lang.Integer]()
+      b.value(Integer.valueOf(7))
+      b.reason("STATIC")
+      b.variant("int-variant")
+      b.build().asInstanceOf[ProviderEvaluation[java.lang.Integer]]
+    }
+    override def getDoubleEvaluation(k: String, d: java.lang.Double, c: OFEvaluationContext) = {
+      val b = ProviderEvaluation.builder[java.lang.Double]()
+      b.value(java.lang.Double.valueOf(99.0))
+      b.reason("STATIC")
+      b.build().asInstanceOf[ProviderEvaluation[java.lang.Double]]
+    }
+    override def getObjectEvaluation(k: String, d: Value, c: OFEvaluationContext) = {
+      val b = ProviderEvaluation.builder[Value]()
+      b.value(d)
+      b.build().asInstanceOf[ProviderEvaluation[Value]]
+    }
+  }
+
+  def spec = suite("IntegerWideningLongProvider")(
+    test("an int-range default is resolved by the wrapped provider's INTEGER resolver") {
+      val p      = IntegerWideningLongProvider(new LegacyProvider)
+      val result = p.getLongEvaluation("flag", java.lang.Long.valueOf(0L), ctx)
+      assertTrue(result.getValue.longValue == 7L)
+    },
+    test("resolver metadata is preserved through the widening") {
+      val p      = IntegerWideningLongProvider(new LegacyProvider)
+      val result = p.getLongEvaluation("flag", java.lang.Long.valueOf(0L), ctx)
+      assertTrue(result.getReason == "STATIC", result.getVariant == "int-variant")
+    },
+    test("without the wrapper the same provider resolves Long via the DOUBLE resolver") {
+      // Pins the problem the wrapper exists to solve; if this ever returns 7 the wrapper is redundant.
+      val bare = new LegacyProvider
+      assertTrue(bare.getLongEvaluation("flag", java.lang.Long.valueOf(0L), ctx).getValue.longValue == 99L)
+    },
+    test("an out-of-Int-range default defers to the wrapped provider's long path") {
+      val p      = IntegerWideningLongProvider(new LegacyProvider)
+      val result = p.getLongEvaluation("flag", java.lang.Long.valueOf(5000000000L), ctx)
+      // Falls through to the SDK default on the delegate, i.e. the double resolver — NOT a truncated int read.
+      assertTrue(result.getValue.longValue == 99L)
+    },
+    test("a null default does not throw") {
+      val p = IntegerWideningLongProvider(new LegacyProvider)
+      assertTrue(p.getLongEvaluation("flag", null, ctx).getValue.longValue == 99L)
+    }
+  )
+}

--- a/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
+++ b/optimizely/src/main/scala/zio/openfeature/optimizely/OptimizelyFeatureProvider.scala
@@ -352,6 +352,40 @@ final class OptimizelyFeatureProvider private[optimizely] (
   ): ProviderEvaluation[java.lang.Double] =
     typedEvaluation[java.lang.Double](key, defaultValue, ctx, classOf[java.lang.Double])
 
+  // Optimizely has no long-typed variable, so Long evaluations read the same integer variable that
+  // getIntegerEvaluation does and widen it — Int -> Long is exact, so a resolved value is never lossy.
+  //
+  // This deliberately does NOT reuse `typedEvaluation`. Doing so would mean seeding it with a default of the
+  // wrong type: narrowing the caller's Long would silently truncate anything outside Int range
+  // (`long("f", 5000000000L)` -> 705032704), and seeding a sentinel instead would leave this method having to
+  // infer "did a variable resolve?" from the built result. That inference is not sound — `deriveReason` reports
+  // DEFAULT whenever the decision has no variation key, independently of whether a variable was read, so a flag
+  // that is off but still carries variable defaults would have its real value discarded here while
+  // `getIntegerEvaluation` returned it. Reading the variable directly keeps `usedDefault` a fact rather than a
+  // guess, and mirrors `getObjectEvaluation`, which resolves its own variable for the same reason.
+  override def getLongEvaluation(
+    key: String,
+    defaultValue: java.lang.Long,
+    ctx: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Long] =
+    decide(key, ctx) match {
+      case Right(d) =>
+        val variableKey = OptimizelyFeatureProvider.variableKey(ctx)
+        val variable    = readVariable[java.lang.Integer](d, variableKey, classOf[java.lang.Integer])
+        val (value, usedDefault) = variable match {
+          case Some(i) => (java.lang.Long.valueOf(i.longValue()), false)
+          case None    => (defaultValue, true)
+        }
+        // Builder calls are split across statements (not chained) — see the note on getBooleanEvaluation above.
+        val builder = ProviderEvaluation.builder[java.lang.Long]()
+        builder.value(value)
+        builder.variant(d.getVariationKey)
+        builder.reason(if (usedDefault) Reason.DEFAULT.name() else deriveReason(d))
+        builder.flagMetadata(metadataFrom(d))
+        builder.build().asInstanceOf[ProviderEvaluation[java.lang.Long]]
+      case Left(err) => failingEvaluation(defaultValue, err)
+    }
+
   /** Shared scaffold for Integer/Double evaluations: extract the named variable, fall back to the OF default with a
     * `DEFAULT` reason if the variable is missing. The Optimizely SDK throws `JsonParseException` from `getValue` when
     * the key is absent, so we wrap in `Try` and treat any failure as a missing variable.

--- a/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyLongEvaluationSpec.scala
+++ b/optimizely/src/test/scala/zio/openfeature/optimizely/OptimizelyLongEvaluationSpec.scala
@@ -1,0 +1,123 @@
+package zio.openfeature.optimizely
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.optimizely.ab.Optimizely
+import com.optimizely.ab.config.HttpProjectConfigManager
+import dev.openfeature.sdk.{ImmutableContext, Reason, Value}
+import zio._
+import zio.test._
+
+import java.util.concurrent.TimeUnit
+import scala.jdk.CollectionConverters._
+
+/** Long evaluation for `OptimizelyFeatureProvider` (SDK 1.22.0 native `getLongEvaluation`).
+  *
+  * Optimizely has no long-typed variable, so the provider reads the integer variable and widens — exact, because Int ->
+  * Long cannot lose precision. The risk is entirely on the *default*: `typedEvaluation` hands its default straight back
+  * both when the variable is absent and on the failure path, so seeding that read with a narrowed
+  * `defaultValue.intValue()` would silently truncate any default outside Int range and return it as the answer.
+  *
+  * WireMock-backed (no Docker), mirroring the object-evaluation spec's fail-fast HTTP + shutdown-in-finally hygiene.
+  */
+object OptimizelyLongEvaluationSpec extends ZIOSpecDefault {
+
+  private val DatafilePath    = "/datafiles/long-eval-key.json"
+  private val targetedContext = new ImmutableContext("user-long")
+
+  /** Comfortably outside Int range: narrowing this to Int yields 705032704. */
+  private val BigDefault = 5000000000L
+
+  /** A flag whose `value` variable is an integer (100 for premium users, 10 by default). */
+  private val RateLimitFlag = "recommendation_rate_limit"
+
+  /** Deliberately distinct from every value the datafile can produce, so a test can tell "resolved the variable" apart
+    * from "handed the caller's default back".
+    */
+  private val Sentinel = java.lang.Long.valueOf(-987654321L)
+
+  private def readResource(path: String): String =
+    scala.io.Source.fromInputStream(getClass.getResourceAsStream(path)).mkString
+
+  private def withMockServer[A](body: WireMockServer => A): A = {
+    val server = new WireMockServer(WireMockConfiguration.options().dynamicPort())
+    server.start()
+    try body(server)
+    finally server.stop()
+  }
+
+  private def buildClient(server: WireMockServer): Optimizely = {
+    val mgr = HttpProjectConfigManager
+      .builder()
+      .withSdkKey("long-eval-key")
+      .withUrl(s"http://localhost:${server.port()}$DatafilePath")
+      .withBlockingTimeout(2000, TimeUnit.MILLISECONDS)
+      .withPollingInterval(3600, TimeUnit.SECONDS)
+      .withOptimizelyHttpClient(TestHttpClient.failFast())
+      .build()
+    Optimizely.builder().withConfigManager(mgr).build()
+  }
+
+  private def readyProvider(server: WireMockServer, datafile: String): OptimizelyFeatureProvider = {
+    server.stubFor(get(urlEqualTo(DatafilePath)).willReturn(okJson(datafile)))
+    val client   = buildClient(server)
+    val provider = new OptimizelyFeatureProvider(client, java.time.Duration.ofSeconds(3), closeOnShutdown = true)
+    provider.initialize(new ImmutableContext())
+    provider
+  }
+
+  // One WireMock server + Optimizely client per DATAFILE rather than per test. Each pair costs a real HTTP server and
+  // a polling-capable SDK client, and this module already runs a load-sensitive polling-lifecycle spec concurrently —
+  // spinning five of them to make eight assertions measurably raises the odds of that spec's in-flight-poll race.
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("OptimizelyFeatureProvider long evaluation")(
+    test("falls back to the caller's Long default without narrowing it") {
+      withMockServer { server =>
+        // `lifecycle_flag`'s `value` variable is a STRING, so reading it as an Integer fails and the provider must
+        // fall back to the caller's default. Seeding the integer read with a narrowed default would return
+        // 705032704 for the out-of-range cases.
+        val provider = readyProvider(server, readResource("/test-datafile-with-flag.json"))
+        try {
+          val big = provider.getLongEvaluation("lifecycle_flag", java.lang.Long.valueOf(BigDefault), targetedContext)
+          val unknown = provider.getLongEvaluation("no-such-flag", java.lang.Long.valueOf(BigDefault), targetedContext)
+          val small   = provider.getLongEvaluation("lifecycle_flag", java.lang.Long.valueOf(42L), targetedContext)
+          assertTrue(
+            big.getReason == Reason.DEFAULT.name(),
+            big.getValue.longValue == BigDefault,
+            unknown.getValue.longValue == BigDefault,
+            small.getReason == Reason.DEFAULT.name(),
+            small.getValue.longValue == 42L
+          )
+        } finally provider.shutdown()
+      }
+    },
+    // The case above only exercises the *fallback* branch. This one covers the branch where a variable really
+    // resolves — the one an earlier implementation got wrong by inferring "did it resolve?" from the reason, which
+    // reports DEFAULT whenever a decision carries no variation key even though the variable read succeeded. Parity
+    // with `getIntegerEvaluation` is the point: the two must never disagree about the same flag.
+    test("a resolved integer variable is widened, never replaced by the default") {
+      withMockServer { server =>
+        val provider = readyProvider(server, readResource("/datafiles/audience-premium.json"))
+        try {
+          val premium  = new ImmutableContext("user-alice", Map("plan" -> new Value("premium")).asJava)
+          val standard = new ImmutableContext("user-bob", Map("plan" -> new Value("standard")).asJava)
+          val pLong    = provider.getLongEvaluation(RateLimitFlag, Sentinel, premium)
+          val pInt     = provider.getIntegerEvaluation(RateLimitFlag, java.lang.Integer.valueOf(-1), premium)
+          val sLong    = provider.getLongEvaluation(RateLimitFlag, Sentinel, standard)
+          val sInt     = provider.getIntegerEvaluation(RateLimitFlag, java.lang.Integer.valueOf(-1), standard)
+          assertTrue(
+            pLong.getValue.longValue == 100L,
+            pLong.getValue.longValue == pInt.getValue.longValue,
+            pLong.getReason == pInt.getReason,
+            // The variable's own default (10), NOT the caller's sentinel — the case where the decision may carry no
+            // variation key while the variable still reads successfully.
+            sLong.getValue.longValue == 10L,
+            sLong.getValue.longValue != Sentinel.longValue,
+            sLong.getValue.longValue == sInt.getValue.longValue,
+            sLong.getReason == sInt.getReason
+          )
+        } finally provider.shutdown()
+      }
+    }
+  ) @@ TestAspect.sequential
+}

--- a/testkit/src/main/scala/zio/openfeature/testkit/CachingReasonProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/CachingReasonProvider.scala
@@ -74,6 +74,13 @@ final class CachingReasonProvider(delegate: OFFeatureProvider) extends EventProv
   ): ProviderEvaluation[java.lang.Double] =
     cached(key, delegate.getDoubleEvaluation(key, defaultValue, context))
 
+  override def getLongEvaluation(
+    key: String,
+    defaultValue: java.lang.Long,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Long] =
+    cached(key, delegate.getLongEvaluation(key, defaultValue, context))
+
   override def getObjectEvaluation(
     key: String,
     defaultValue: Value,
@@ -89,6 +96,11 @@ final class CachingReasonProvider(delegate: OFFeatureProvider) extends EventProv
   override def getState: ProviderState = delegate.getState
 
   override def initialize(context: OFEvaluationContext): Unit = delegate.initialize(context)
+
+  override def initialize(context: OFEvaluationContext, domain: String): Unit =
+    delegate.initialize(context, domain)
+
+  override def isDomainScoped(): Boolean = delegate.isDomainScoped()
 
   override def shutdown(): Unit = delegate.shutdown()
 

--- a/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
+++ b/testkit/src/main/scala/zio/openfeature/testkit/TestFeatureProvider.scala
@@ -44,6 +44,10 @@ final class TestFeatureProvider private (
 
   private[testkit] val behaviorRef: AtomicReference[BehaviorConfig] = new AtomicReference(BehaviorConfig())
 
+  // SDK 1.22.0 hands the bound domain to `initialize(ctx, domain)` (null for the default provider). Recorded so
+  // tests can assert what a domain-registered client actually delivered — there is no other observation point.
+  private val boundDomainRef: AtomicReference[Option[String]] = new AtomicReference(None)
+
   private def applyBehavior(): Unit = {
     val config = behaviorRef.get()
     config.delay.foreach(d => Thread.sleep(d.toMillis))
@@ -77,6 +81,15 @@ final class TestFeatureProvider private (
     // Note: initDone is NOT counted down here. It is counted down by the event bridge's
     // readyHandler when the Java SDK fires PROVIDER_READY, ensuring the SDK has fully
     // processed the initialization before setStatus(Ready) returns.
+  }
+
+  /** SDK 1.22.0 calls this overload with the bound domain (null for the default provider) and its interface default
+    * forwards to the one-argument form. Recording the domain before delegating keeps all existing init behaviour while
+    * giving [[boundDomain]] something to report.
+    */
+  override def initialize(context: OFEvaluationContext, domain: String): Unit = {
+    boundDomainRef.set(Option(domain))
+    initialize(context)
   }
 
   override def shutdown(): Unit = {
@@ -131,6 +144,27 @@ final class TestFeatureProvider private (
     )
   }
 
+  override def getLongEvaluation(
+    key: String,
+    defaultValue: java.lang.Long,
+    context: OFEvaluationContext
+  ): ProviderEvaluation[java.lang.Long] = {
+    applyBehavior()
+    evaluations.add((key, context))
+    val value = Option(flags.get(key))
+      .map {
+        case l: Long   => l
+        case i: Int    => i.toLong
+        case d: Double => d.toLong
+        case other     => other.toString.toLong
+      }
+      .getOrElse(defaultValue.longValue())
+    ProviderEvaluations.of(
+      java.lang.Long.valueOf(value),
+      if (flags.containsKey(key)) "TARGETING_MATCH" else "DEFAULT"
+    )
+  }
+
   override def getDoubleEvaluation(
     key: String,
     defaultValue: java.lang.Double,
@@ -170,7 +204,7 @@ final class TestFeatureProvider private (
     case b: Boolean    => new Value(b)
     case s: String     => new Value(s)
     case i: Int        => new Value(i)
-    case l: Long       => new Value(l.toDouble)
+    case l: Long       => new Value(l)
     case d: Double     => new Value(d)
     case list: List[_] => new Value(list.map(anyToValue).asJava)
     case map: Map[_, _] =>
@@ -282,6 +316,12 @@ final class TestFeatureProvider private (
             () // No Java SDK equivalent for reconnecting
         }
       }
+
+  /** The domain this provider was registered under, as the SDK delivered it to `initialize(ctx, domain)`.
+    *
+    * `None` before initialization, and `None` for the default (domain-less) provider — the SDK passes null there.
+    */
+  def boundDomain: UIO[Option[String]] = ZIO.succeed(boundDomainRef.get())
 
   /** All evaluations made so far, each captured context converted to the library's [[EvaluationContext]] so you can
     * assert on `.targetingKey` / `.getString(...)` etc. directly instead of the Java SDK type. Use

--- a/testkit/src/test/scala-3/zio/openfeature/testkit/TestkitWrapperCompletenessSpec.scala
+++ b/testkit/src/test/scala-3/zio/openfeature/testkit/TestkitWrapperCompletenessSpec.scala
@@ -1,0 +1,51 @@
+package zio.openfeature.testkit
+
+import dev.openfeature.sdk.FeatureProvider
+import zio.test.*
+
+/** The `extras` counterpart of this spec carries the full rationale. Duplicated rather than shared because `extras` and
+  * `testkit` are sibling modules — neither depends on the other, and adding a dependency between them to host ~20 lines
+  * of reflection would be a worse trade than the copy.
+  */
+object TestkitWrapperCompletenessSpec extends ZIOSpecDefault:
+
+  private val exempt: Map[String, String] = Map(
+    "getMetadata" -> "a wrapper reports its own name, not the wrapped provider's",
+    "getState"    -> "deprecated in 1.22.0; SDK owns status. Removal tracked in #332"
+  )
+
+  /** Name AND parameter types — `initialize` is overloaded, so a name-only check would miss a wrapper that declares
+    * `initialize(ctx)` but drops `initialize(ctx, domain)`.
+    */
+  private type Sig = (String, List[Class[?]])
+
+  private def render(s: Sig): String = s"${s._1}(${s._2.map(_.getSimpleName).mkString(", ")})"
+
+  private def surface: List[Sig] =
+    classOf[FeatureProvider].getMethods.toList
+      .filterNot(_.getDeclaringClass == classOf[Object])
+      .filterNot(m => java.lang.reflect.Modifier.isStatic(m.getModifiers))
+      .map(m => (m.getName, m.getParameterTypes.toList))
+      .distinct
+      .sortBy(render)
+
+  private def check(cls: Class[?]): TestResult =
+    val declared = cls.getDeclaredMethods.map(m => (m.getName, m.getParameterTypes.toList)).toSet
+    val missing  = surface.filterNot(declared.contains).filterNot(s => exempt.contains(s._1))
+    assertTrue(missing.isEmpty) ??
+      s"${cls.getSimpleName} does not forward: ${missing.map(render).mkString(", ")}"
+
+  def spec = suite("testkit wrapper completeness")(
+    test("CachingReasonProvider forwards the whole FeatureProvider surface")(
+      check(classOf[CachingReasonProvider])
+    ),
+    test("the reflected surface is non-empty and contains the methods 1.22.0 added") {
+      val names = surface.map(_._1).toSet
+      assertTrue(
+        surface.nonEmpty,
+        names.contains("getLongEvaluation"),
+        names.contains("isDomainScoped"),
+        surface.exists(s => s._1 == "initialize" && s._2.sizeIs == 2)
+      )
+    }
+  )

--- a/testkit/src/test/scala/zio/openfeature/testkit/BoundDomainSpec.scala
+++ b/testkit/src/test/scala/zio/openfeature/testkit/BoundDomainSpec.scala
@@ -1,0 +1,37 @@
+package zio.openfeature.testkit
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.sequential
+import zio.openfeature._
+
+/** SDK 1.22.0 supplies the bound domain to `FeatureProvider.initialize(ctx, domain)` (java-sdk#1982).
+  *
+  * This library already registers providers with `setProviderAndWait(domain, provider)`, so the domain should reach the
+  * provider with no API change on our side — but "should" is the whole reason to pin it: nothing else in the codebase
+  * would notice if the SDK stopped delivering it, or if a wrapper swallowed the two-argument overload on the way
+  * through.
+  */
+object BoundDomainSpec extends ZIOSpecDefault {
+
+  def spec = suite("bound domain")(
+    test("a domain-registered client delivers its domain to the provider") {
+      ZIO.scoped {
+        for {
+          provider <- TestFeatureProvider.make
+          _        <- FeatureFlags.fromProvider(provider, FeatureFlagsConfig(domain = Some("checkout"))).build
+          domain   <- provider.boundDomain
+        } yield assertTrue(domain.contains("checkout"))
+      }
+    },
+    test("a provider registered without a domain reports None") {
+      ZIO.scoped {
+        for {
+          provider <- TestFeatureProvider.make
+          _        <- FeatureFlags.fromProvider(provider).build
+          domain   <- provider.boundDomain
+        } yield assertTrue(domain.isEmpty)
+      }
+    }
+  ) @@ sequential
+}


### PR DESCRIPTION
Adopts the two capabilities OpenFeature Java SDK 1.22.0 ships — native `Long` evaluation and bound-domain provider initialization — and bumps zio-bdd to 1.4.4.

## Long evaluation is now native

`ff.long` / `ff.longDetails` call `client.getLongDetails`, so the **provider's** `getLongEvaluation` decides the result instead of this library hand-routing it. The old routing sent an int-range default to the integer resolver and anything larger to the double resolver — exact only to 2^53, and **silently lossy beyond**.

All four bundled providers (`TestFeatureProvider`, `HoconProvider`, `EnvVarProvider`, `OptimizelyFeatureProvider`) now implement `getLongEvaluation` natively and resolve the full 64-bit range exactly, so **there is no behaviour change if you use one of them**. A third-party provider that predates 1.22.0 inherits the SDK's double-backed default; wrap it in the new `IntegerWideningLongProvider` to restore the previous routing. Full migration note in the changelog.

## Fixed: wrappers were silently stripping new SDK methods

`CachingProvider`, `CircuitBreakerProvider`, `DeferredProvider` and `CachingReasonProvider` forwarded only the surface they were written against, so anything the SDK adds as a *default method* was answered by the interface default instead of the wrapped provider. 1.22.0 added three at once — a `CachingProvider` around a provider with native 64-bit resolution routed longs through the double path, `initialize(ctx, domain)` dropped the domain, and `isDomainScoped` hid a wrapped provider's scoping. This was already live for anyone running our published providers against a 1.22.0 SDK.

A reflection-based completeness spec now compares each wrapper against `classOf[FeatureProvider]` by **(name, parameterTypes)** and fails when a future SDK method goes unforwarded. Matching on names alone was not enough — it missed `initialize(ctx, domain)` behind the declared 1-arg overload.

## Also
- `FlagValueType.Long` replaces the previous `Long -> Int` mapping (both the Scala 2 and Scala 3 copies). Affects only hooks that explicitly narrowed `supportedFlagTypes`.
- Out-of-int-range `Long` tracking attributes go through `Value`'s native long support instead of being widened to `Double`.
- `TestFeatureProvider.boundDomain` exposes the domain the SDK bound the provider to.

## Notes on the design
Two premises in the original issue were tested and did not hold:
- The bump was expected to fail compilation on `getState` deprecation under `-Xfatal-warnings`. It does not — the full cross-compile is clean. A probe calling `p.getState` from ordinary code *did* fail the build, confirming the machinery is live: Scala flags *calls* to deprecated members, not *overrides*. No `@nowarn` suppressions were added, since they would suppress nothing and mask future real warnings.
- `getLongEvaluation`'s default delegates to `getDoubleEvaluation`, not the integer resolver as the upstream PR summary stated — which is what makes the wrapper/escape-hatch work necessary rather than optional.

## Verification
`scalafmtCheckAll`, `+test` (Scala 2.13 + 3.3), `conformance/test` 113/113, `conformanceZioBdd/test` 113/113, `+mimaReportBinaryIssues` — all green.

Closes #333
