### PR TITLE
Add CI coverage for pinned_ref() in gherkin drift script

### DIFF
--- a/.github/scripts/check-gherkin-drift.sh
+++ b/.github/scripts/check-gherkin-drift.sh
@@ -9,8 +9,12 @@
 #   mirror    the two in-repo copies (conformance/ and conformance-zio-bdd/) are byte-identical to
 #             each other. Breaking that IS a PR author's doing, so CI runs this one per PR.
 #
+# `print-pin` is a third mode but not a third invariant: it just resolves and prints the pin. It
+# exists so the README parse below is exercised by CI at all — see its case arm in `main` (#338).
+#
 # Usage:
 #   check-gherkin-drift.sh mirror
+#   check-gherkin-drift.sh print-pin
 #   check-gherkin-drift.sh upstream [<ref>] [--report <file>]
 #
 # `<ref>` defaults to the pin read from the conformance README (see `pinned_ref`). Pass `main` to
@@ -226,6 +230,12 @@ main() {
     mirror)
       check_mirror
       ;;
+    print-pin)
+      # Parse-only: resolve and print the pin from the conformance README. Exit 0 with the pin on
+      # stdout, exit 2 if the line is missing, duplicated, or unparseable — the same contract
+      # `pinned_ref` already enforces. No network and no gh, so it is safe as a per-PR gate (#338).
+      pinned_ref
+      ;;
     upstream)
       shift
       local ref="" report=""
@@ -248,7 +258,7 @@ main() {
       check_upstream "$ref" "$report"
       ;;
     *)
-      die "usage: $(basename "$0") mirror | upstream [<ref>] [--report <file>]"
+      die "usage: $(basename "$0") mirror | print-pin | upstream [<ref>] [--report <file>]"
       ;;
   esac
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,13 @@ jobs:
       # behind a multi-minute scalafmt run — which would mask it entirely whenever scalafmt fails.
       - name: Check vendored gherkin copies are in sync
         run: .github/scripts/check-gherkin-drift.sh mirror
+      # The pin is machine-read from the conformance README (#336). Nothing else in CI executes that
+      # parse: the scheduled drift job always passes an explicit ref (deliberately — it compares
+      # against upstream main), so without this step a README edit that breaks the parse would
+      # surface only on a developer's machine (#338). Parse-only — no JDK, no sbt, no network — so
+      # it belongs up here beside the mirror check rather than behind the multi-minute sbt setup.
+      - name: Check the gherkin pin parses from the README
+        run: .github/scripts/check-gherkin-drift.sh print-pin
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:

--- a/conformance/src/test/resources/zio/openfeature/conformance/README.md
+++ b/conformance/src/test/resources/zio/openfeature/conformance/README.md
@@ -29,14 +29,21 @@ different owners:
 |------|-----------|------|
 | `upstream` | vendored files match `open-feature/spec` at a ref | `.github/workflows/gherkin-drift.yml` — weekly + on dispatch |
 | `mirror` | the two in-repo copies are identical | the `format` job in `ci.yml` — every PR |
+| `print-pin` | the "Pinned tag" line above still parses | the `format` job in `ci.yml` — every PR |
 
 Upstream drift is not a PR author's doing, so it is scheduled and files a deduped issue rather than
 blocking PRs. Breaking the in-repo mirror **is** a PR author's doing, so that one blocks.
 
-Run either locally:
+`print-pin` is a parse-only mode (no network, no `gh`) that exists so the pin line's format is
+CI-checked per PR: the scheduled `upstream` job always passes an explicit ref, so nothing else in CI
+ever exercises the parse. Reformatting the pin line therefore fails the PR that makes it, rather
+than surfacing later as a confusing exit 2 on somebody's machine (#338).
+
+Run any of them locally:
 
 ```sh
 .github/scripts/check-gherkin-drift.sh mirror
+.github/scripts/check-gherkin-drift.sh print-pin           # what ref does the README pin to?
 .github/scripts/check-gherkin-drift.sh upstream            # against the pinned tag
 .github/scripts/check-gherkin-drift.sh upstream main       # has upstream moved since the pin?
 ```


### PR DESCRIPTION
## Summary

- Adds a parse-only `print-pin` mode to `.github/scripts/check-gherkin-drift.sh` that resolves and prints the gherkin pin from the conformance README
- Runs this mode in the `format` job of `.github/workflows/ci.yml` on every PR to exercise the README pin parse by CI
- Previously no CI path executed the pin parsing; reformatting the pin line would only surface as a confusing exit 2 on developers' machines
- Documents the new mode in the conformance README alongside the existing `mirror` and `upstream` checks
- Scheduled drift workflow (`gherkin-drift.yml`) remains unchanged — it explicitly passes a ref and never uses the pin parse

Closes #338